### PR TITLE
fix: automatic disposal of reactive observers to prevent memory leaks

### DIFF
--- a/src/Xote__Component.res
+++ b/src/Xote__Component.res
@@ -72,22 +72,14 @@ let span = (~attrs=?, ~events=?, ~children=?, ()) =>
   element("span", ~attrs?, ~events?, ~children?, ())
 let button = (~attrs=?, ~events=?, ~children=?, ()) =>
   element("button", ~attrs?, ~events?, ~children?, ())
-let input = (~attrs=?, ~events=?, ()) =>
-  element("input", ~attrs?, ~events?, ())
-let h1 = (~attrs=?, ~events=?, ~children=?, ()) =>
-  element("h1", ~attrs?, ~events?, ~children?, ())
-let h2 = (~attrs=?, ~events=?, ~children=?, ()) =>
-  element("h2", ~attrs?, ~events?, ~children?, ())
-let h3 = (~attrs=?, ~events=?, ~children=?, ()) =>
-  element("h3", ~attrs?, ~events?, ~children?, ())
-let p = (~attrs=?, ~events=?, ~children=?, ()) =>
-  element("p", ~attrs?, ~events?, ~children?, ())
-let ul = (~attrs=?, ~events=?, ~children=?, ()) =>
-  element("ul", ~attrs?, ~events?, ~children?, ())
-let li = (~attrs=?, ~events=?, ~children=?, ()) =>
-  element("li", ~attrs?, ~events?, ~children?, ())
-let a = (~attrs=?, ~events=?, ~children=?, ()) =>
-  element("a", ~attrs?, ~events?, ~children?, ())
+let input = (~attrs=?, ~events=?, ()) => element("input", ~attrs?, ~events?, ())
+let h1 = (~attrs=?, ~events=?, ~children=?, ()) => element("h1", ~attrs?, ~events?, ~children?, ())
+let h2 = (~attrs=?, ~events=?, ~children=?, ()) => element("h2", ~attrs?, ~events?, ~children?, ())
+let h3 = (~attrs=?, ~events=?, ~children=?, ()) => element("h3", ~attrs?, ~events?, ~children?, ())
+let p = (~attrs=?, ~events=?, ~children=?, ()) => element("p", ~attrs?, ~events?, ~children?, ())
+let ul = (~attrs=?, ~events=?, ~children=?, ()) => element("ul", ~attrs?, ~events?, ~children?, ())
+let li = (~attrs=?, ~events=?, ~children=?, ()) => element("li", ~attrs?, ~events?, ~children?, ())
+let a = (~attrs=?, ~events=?, ~children=?, ()) => element("a", ~attrs?, ~events?, ~children?, ())
 
 /* External bindings for DOM manipulation */
 @val @scope("document") external createElement: string => Dom.element = "createElement"


### PR DESCRIPTION
Reactive DOM nodes were creating effects and computeds that persisted in Core.observers indefinitely, even after DOM removal. Each list re-render or fragment update would accumulate new observers while old ones continued updating detached DOM nodes.

Relates to #7