### PR TITLE
Topological ordering

### DIFF
--- a/src/Xote__Core.res
+++ b/src/Xote__Core.res
@@ -16,6 +16,7 @@ let currentObserverId: ref<option<int>> = ref(None)
 /* Simple scheduler */
 let pending: ref<IntSet.t> = ref(IntSet.empty)
 let batching = ref(false)
+let flushing = ref(false) /* Prevent nested flushes */
 
 let ensureSignalBucket = (sid: int) => {
   switch IntMap.get(signalObservers.contents, sid) {
@@ -50,13 +51,77 @@ let clearDeps = (obs: Observer.t) => {
   obs.deps = IntSet.empty
 }
 
-let schedule = (obsId: int) => {
-  pending := pending.contents->IntSet.add(obsId)
-  if batching.contents == false {
-    /* flush immediately (sync microtask-ish) */
+/* Compute observer level based on dependency depth (topological ordering) */
+let computeLevel = (obs: Observer.t): int => {
+  /* Effects are always at a higher level than computeds they depend on */
+  switch obs.kind {
+  | #Effect => {
+      /* Find the maximum level among all dependent signals' observers + 1 */
+      let maxDepLevel = ref(0)
+      obs.deps->IntSet.forEach(sid => {
+        switch IntMap.get(signalObservers.contents, sid) {
+        | None => ()
+        | Some(obsSet) =>
+          obsSet->IntSet.forEach(depObsId => {
+            switch IntMap.get(observers.contents, depObsId) {
+            | None => ()
+            | Some(depObs) =>
+              if depObs.level > maxDepLevel.contents {
+                maxDepLevel := depObs.level
+              }
+            }
+          })
+        }
+      })
+      maxDepLevel.contents + 1000 /* Effects always after computeds */
+    }
+  | #Computed(_) => {
+      /* Find the maximum level among all signals we depend on */
+      let maxDepLevel = ref(0)
+      obs.deps->IntSet.forEach(sid => {
+        switch IntMap.get(signalObservers.contents, sid) {
+        | None => ()
+        | Some(obsSet) =>
+          obsSet->IntSet.forEach(depObsId => {
+            if depObsId != obs.id {
+              /* Don't include self */
+              switch IntMap.get(observers.contents, depObsId) {
+              | None => ()
+              | Some(depObs) =>
+                /* Only look at other computeds (not effects) */
+                switch depObs.kind {
+                | #Computed(_) =>
+                  if depObs.level > maxDepLevel.contents {
+                    maxDepLevel := depObs.level
+                  }
+                | #Effect => () /* Ignore effects */
+                }
+              }
+            }
+          })
+        }
+      })
+      maxDepLevel.contents + 1
+    }
+  }
+}
+
+let rec flush = () => {
+  if pending.contents != IntSet.empty {
     let toRun = pending.contents
     pending := IntSet.empty
-    toRun->IntSet.forEach(id => {
+
+    /* Convert to array and sort by level (lower levels first) */
+    let sorted = toRun->IntSet.toArray->Array.toSorted((a, b) => {
+      switch (IntMap.get(observers.contents, a), IntMap.get(observers.contents, b)) {
+      | (Some(obsA), Some(obsB)) => Float.fromInt(obsA.level - obsB.level)
+      | (Some(_), None) => -1.0
+      | (None, Some(_)) => 1.0
+      | (None, None) => 0.0
+      }
+    })
+
+    sorted->Array.forEach(id => {
       switch IntMap.get(observers.contents, id) {
       | None => ()
       | Some(o) => {
@@ -66,9 +131,24 @@ let schedule = (obsId: int) => {
           currentObserverId := Some(id)
           o.run()
           currentObserverId := prev
+          /* Recompute level after re-tracking (dependencies may have changed) */
+          o.level = computeLevel(o)
         }
       }
     })
+
+    /* Recursively flush any new pending observers that were scheduled during execution */
+    flush()
+  }
+}
+
+let schedule = (obsId: int) => {
+  pending := pending.contents->IntSet.add(obsId)
+  if batching.contents == false && flushing.contents == false {
+    /* flush with topological ordering, preventing nested flushes */
+    flushing := true
+    flush()
+    flushing := false
   }
 }
 
@@ -76,7 +156,18 @@ let notify = (sid: int) => {
   ensureSignalBucket(sid)
   switch IntMap.get(signalObservers.contents, sid) {
   | None => ()
-  | Some(sset) => sset->IntSet.forEach(schedule)
+  | Some(sset) => {
+      // Add all dependent observers to pending before flushing
+      sset->IntSet.forEach(obsId => {
+        pending := pending.contents->IntSet.add(obsId)
+      })
+      // Only flush if we're not already batching or flushing
+      if batching.contents == false && flushing.contents == false {
+        flushing := true
+        flush()
+        flushing := false
+      }
+    }
   }
 }
 

--- a/src/Xote__Effect.res
+++ b/src/Xote__Effect.res
@@ -15,6 +15,7 @@ let run = (fn: unit => unit): disposer => {
     kind: #Effect,
     run: () => fn(),
     deps: IntSet.empty,
+    level: 1000, /* Effects start at high level, will be recomputed after tracking */
   }
   Core.observers := IntMap.set(Core.observers.contents, id, observer)
   /* initial run */
@@ -23,6 +24,8 @@ let run = (fn: unit => unit): disposer => {
   Core.currentObserverId := Some(id)
   observer.run()
   Core.currentObserverId := prev
+  /* Compute proper level after tracking dependencies */
+  observer.level = Core.computeLevel(observer)
 
   let dispose = () => {
     switch IntMap.get(Core.observers.contents, id) {

--- a/src/Xote__Observer.res
+++ b/src/Xote__Observer.res
@@ -9,4 +9,6 @@ type t = {
   run: unit => unit,
   /* current dependency set (signal ids) */
   mutable deps: IntSet.t,
+  /* topological level for scheduling order */
+  mutable level: int,
 }


### PR DESCRIPTION
## Problem

The Xote reactivity system had a critical scheduling glitch where effects could run before all dependent computeds had settled, causing effects to observe inconsistent intermediate state.

Relates to #9 

### Example

```rescript
let s = Signal.make(1)
let a = Computed.make(() => Signal.get(s) * 2)  // a = 2
let b = Computed.make(() => Signal.get(s) * 3)  // b = 3
Effect.run(() => {
  Console.log(`A=${Signal.get(a)}, B=${Signal.get(b)}`)
})

Signal.set(s, 2)
// Before fix: Effect saw A=4, B=3 (inconsistent!)
// After fix: Effect sees A=4, B=6 (consistent)
```

## Root Cause

The original `notify()` function called `schedule()` for each dependent observer separately:

```rescript
let notify = (sid: int) => {
  switch IntMap.get(signalObservers.contents, sid) {
  | Some(sset) => sset->IntSet.forEach(schedule)  // ← Each triggers immediate flush!
  }
}
```

This caused:
1. `schedule(computedA)` → immediate flush → runs A → A calls Signal.set → schedules effect → effect runs
2. `schedule(computedB)` → immediate flush → runs B → ...

The effect ran after A but before B, observing inconsistent state.

## Topological Ordering

Implemented level-based topological ordering inspired by Solid.js:

### 1. Added level to Observers

**File: `src/Xote__Observer.res`**
```rescript
type t = {
  id: int,
  kind: kind,
  run: unit => unit,
  mutable deps: IntSet.t,
  mutable level: int,  // ← NEW
}
```

### 2. Level computation algorithm

```rescript
let computeLevel = (obs: Observer.t): int => {
  switch obs.kind {
  | #Effect => {
      // Effects: max(all dependencies) + 1000
      // The +1000 ensures effects always run after all computeds
      let maxDepLevel = ref(0)
      obs.deps->IntSet.forEach(sid => {
        // Find max level of all observers of this signal
      })
      maxDepLevel.contents + 1000
    }
  | #Computed(_) => {
      // Computeds: max(dependent computeds only) + 1
      // Ignores effects to create proper topological ordering
      let maxDepLevel = ref(0)
      obs.deps->IntSet.forEach(sid => {
        // Find max level of computed observers only
      })
      maxDepLevel.contents + 1
    }
  }
}
```

**Level Assignment:**
- Source signal observers (computeds depending directly on signals): level 1
- Computeds depending on other computeds: level = max(deps) + 1
- Effects: level = max(deps) + 1000 (always higher than computeds)

### 3. Topological sorting

```rescript
let rec flush = () => {
  if pending.contents != IntSet.empty {
    let toRun = pending.contents
    pending := IntSet.empty

    // Sort observers by level (lower first)
    let sorted = toRun->IntSet.toArray->Array.toSorted((a, b) => {
      switch (IntMap.get(observers.contents, a), IntMap.get(observers.contents, b)) {
      | (Some(obsA), Some(obsB)) => Float.fromInt(obsA.level - obsB.level)
      | _ => 0.0
      }
    })

    // Run observers in topological order
    sorted->Array.forEach(id => {
      switch IntMap.get(observers.contents, id) {
      | Some(o) => {
          clearDeps(o)
          currentObserverId := Some(id)
          o.run()
          currentObserverId := None
          o.level = computeLevel(o)  // Recompute for dynamic deps
        }
      }
    })

    flush()  // Recursively flush new pending observers
  }
}
```

### 4. Atomic notify()

```rescript
let notify = (sid: int) => {
  switch IntMap.get(signalObservers.contents, sid) {
  | Some(sset) => {
      // Add ALL observers to pending FIRST
      sset->IntSet.forEach(obsId => {
        pending := pending.contents->IntSet.add(obsId)
      })
      // Then flush ONCE with topological ordering
      if batching.contents == false && flushing.contents == false {
        flushing := true
        flush()
        flushing := false
      }
    }
  }
}
```

**Key change:** All observers are added to `pending` before any flushing occurs, ensuring they're all sorted together by level.

### 5. Prevent Nested Flushes

```rescript
let flushing = ref(false)  // Prevent nested flushes
```

When a computed calls `Signal.set()` during execution:
- The new observers get added to `pending`
- But flushing is blocked (`flushing = true`)
- They're processed in the recursive `flush()` call after the current batch completes

## Code analysis

### Performance characteristics

- **Time Complexity**: O(n log n) for sorting observers by level, where n = number of pending observers
- **Space Complexity**: O(n) for the sorted array
- **Typical Case**: Most updates involve few observers, so overhead is minimal
- **Trade-off**: Slightly more work per update, but prevents expensive re-runs and glitches

### Comparison to other frameworks

### Solid.js
- Uses observer levels/ranks
- Xote's implementation is similar but simplified
- Both ensure topological execution order

### Preact Signals
- Uses two-phase queues (computeds then effects)
- Xote's level-based approach is more general
- Handles deeper dependency chains better

### Vue 3
- Uses a scheduler queue with priority
- Similar goals, different implementation
- Xote's approach is more explicit about ordering

## Future Improvements

Potential optimizations (not currently needed):

1. **Lazy Level Computation**: Only recompute levels when dependency structure changes
2. **Level Caching**: Cache max levels per signal to speed up computation
3. **Batched Level Updates**: Update levels in bulk after large graph changes
4. **Incremental Sorting**: Use insertion sort for small batches

## References

- Solid.js scheduling: https://github.com/solidjs/solid
- TC39 Signals: https://github.com/tc39/proposal-signals
