### PR TITLE
Update library to ReScript v12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "xote",
       "version": "0.0.0",
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@rescript/core": "^1.6.1",
         "@semantic-release/changelog": "^6.0.3",
@@ -17,7 +17,7 @@
         "@semantic-release/npm": "^13.1.1",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "glob": "^11.0.3",
-        "rescript": "^11.1.4",
+        "rescript": "^12.0.0",
         "semantic-release": "^25.0.1",
         "vite": "^7.1.12"
       }
@@ -665,7 +665,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -858,6 +857,92 @@
       "dev": true,
       "peerDependencies": {
         "rescript": ">=11.1.0"
+      }
+    },
+    "node_modules/@rescript/darwin-arm64": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@rescript/darwin-arm64/-/darwin-arm64-12.0.0.tgz",
+      "integrity": "sha512-N2zNj/Uh0zrg8BJGWxdQjYTDf0d2ZV8D+Vmct8xORaUcEZvAkvZb+xA66UxP2QGhWmATcHmBth7oJ48xpWz/Vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@rescript/darwin-x64": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@rescript/darwin-x64/-/darwin-x64-12.0.0.tgz",
+      "integrity": "sha512-Qx/ao3Fl2lx3rF8mbRsyRK5HGAx8pmzyCdpSIAaUun5wLBnsJbNqgvqUH7VeI2TwaczHvcIljrYmnB7T5LJdFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@rescript/linux-arm64": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@rescript/linux-arm64/-/linux-arm64-12.0.0.tgz",
+      "integrity": "sha512-H65csj/0uqqjYy235m0h5CFxbrsas6RoVfjy5Xjf91Vyg/r5R/QIGQvhMtFvl4QojYsa1wXzXGcujwXh+S15xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@rescript/linux-x64": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@rescript/linux-x64/-/linux-x64-12.0.0.tgz",
+      "integrity": "sha512-WizQwyfMadxF096foZYU3I4zxcnNIc9XP7TP4fqdfe0v6OvQ5yHMI/uIfOsJ1GfNALce2UxvgS0pn67uxc55uA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@rescript/runtime": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@rescript/runtime/-/runtime-12.0.0.tgz",
+      "integrity": "sha512-STRbYHT5rnW61vWn2+Bdtj620XaprnoBSbPbkvOYZ+Zs8nfqtpBjhNw+JNpGQLXf73crk6MhxFGPxL2o5vb8TQ==",
+      "dev": true
+    },
+    "node_modules/@rescript/win32-x64": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@rescript/win32-x64/-/win32-x64-12.0.0.tgz",
+      "integrity": "sha512-kkqj4kQGbni5YglWoPm76M6hUuzKJHDEiLce5EZxW2Q4FrkS9dNRgm02c2Ck1cz/uKCS3m+ZoKQGIMMXTvo5Jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.11.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3254,7 +3339,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5919,7 +6003,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6415,7 +6498,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6631,19 +6713,40 @@
       }
     },
     "node_modules/rescript": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.1.4.tgz",
-      "integrity": "sha512-0bGU0bocihjSC6MsE3TMjHjY0EUpchyrREquLS8VsZ3ohSMD+VHUEwimEfB3kpBI1vYkw3UFZ3WD8R28guz/Vw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-12.0.0.tgz",
+      "integrity": "sha512-DGcZI2L5W0c6FuEnspLE0MIe1UtTt1VsW/vQfzBFCEBxSsQtoA6YRHUB8Puwnb30PHqZiFK1ADhn6UgA8LWK0A==",
       "dev": true,
-      "hasInstallScript": true,
-      "peer": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "workspaces": [
+        "packages/playground",
+        "packages/@rescript/*",
+        "tests/dependencies/**",
+        "tests/analysis_tests/**",
+        "tests/docstring_tests",
+        "tests/gentype_tests/**",
+        "tests/tools_tests",
+        "scripts/res"
+      ],
+      "dependencies": {
+        "@rescript/runtime": "12.0.0"
+      },
       "bin": {
-        "bsc": "bsc",
-        "bstracing": "lib/bstracing",
-        "rescript": "rescript"
+        "bsc": "cli/bsc.js",
+        "bstracing": "cli/bstracing.js",
+        "rescript": "cli/rescript.js",
+        "rescript-legacy": "cli/rescript-legacy.js",
+        "rescript-tools": "cli/rescript-tools.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20.11.0"
+      },
+      "optionalDependencies": {
+        "@rescript/darwin-arm64": "12.0.0",
+        "@rescript/darwin-x64": "12.0.0",
+        "@rescript/linux-arm64": "12.0.0",
+        "@rescript/linux-x64": "12.0.0",
+        "@rescript/win32-x64": "12.0.0"
       }
     },
     "node_modules/resolve-from": {
@@ -6711,7 +6814,6 @@
       "integrity": "sha512-0OCYLm0AfVilNGukM+w0C4aptITfuW1Mhvmz8LQliLeYbPOTFRCIJzoltWWx/F5zVFe6np9eNatBUHdAvMFeZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -7488,7 +7590,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@semantic-release/npm": "^13.1.1",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "glob": "^11.0.3",
-    "rescript": "^11.1.4",
+    "rescript": "^12.0.0",
     "semantic-release": "^25.0.1",
     "vite": "^7.1.12"
   }

--- a/rescript.json
+++ b/rescript.json
@@ -16,10 +16,10 @@
     "in-source": true
   },
   "suffix": ".res.mjs",
-  "bs-dependencies": [
+  "dependencies": [
     "@rescript/core"
   ],
-  "bsc-flags": [
+  "compiler-flags": [
     "-open RescriptCore"
   ],
   "jsx": {

--- a/src/Xote__JSX.res
+++ b/src/Xote__JSX.res
@@ -16,7 +16,7 @@ let jsxKeyed = (
   component: component<'props>,
   props: 'props,
   ~key: option<string>=?,
-  @ignore _: unit,
+  _: unit,
 ): element => {
   let _ = key /* TODO: Implement key support for list reconciliation */
   component(props)
@@ -26,7 +26,7 @@ let jsxsKeyed = (
   component: component<'props>,
   props: 'props,
   ~key: option<string>=?,
-  @ignore _: unit,
+  _: unit,
 ): element => {
   let _ = key
   component(props)
@@ -100,11 +100,11 @@ module Elements = {
   /* Helper to convert any value to Component.attrValue */
   let convertAttrValue = (key: string, value: 'a): (string, Component.attrValue) => {
     // Check if it's a function (computed)
-    if Js.typeof(value) == "function" {
+    if typeof(value) == #function {
       // It's a computed function
       let f: unit => string = Obj.magic(value)
       Component.computedAttr(key, f)
-    } else if Js.typeof(value) == "object" && hasId(value)->Option.isSome {
+    } else if typeof(value) == #object && hasId(value)->Option.isSome {
       // It's a signal (has an id property)
       let sig: Xote__Core.t<string> = Obj.magic(value)
       Component.signalAttr(key, sig)
@@ -283,7 +283,7 @@ module Elements = {
     tag: string,
     props: props<'id, 'class, 'style, 'typ, 'value, 'placeholder, 'href, 'target, 'data>,
     ~key: option<string>=?,
-    @ignore _: unit,
+    _: unit,
   ): element => {
     let _ = key
     createElement(tag, props)
@@ -293,7 +293,7 @@ module Elements = {
     tag: string,
     props: props<'id, 'class, 'style, 'typ, 'value, 'placeholder, 'href, 'target, 'data>,
     ~key: option<string>=?,
-    @ignore _: unit,
+    _: unit,
   ): element => {
     let _ = key
     createElement(tag, props)


### PR DESCRIPTION
- Update ReScript from v11.1.4 to v12.0.0
- Update rescript.json configuration:
  - Rename bs-dependencies to dependencies
  - Rename bsc-flags to compiler-flags
- Fix JSX module for v12 compatibility:
  - Remove `@ignore` attributes (no longer valid for regular parameters)
  - Update typeof usage from Js.typeof to new typeof operator
  - Use polymorphic variants (#function, #object) for type comparison
- All builds pass successfully (ReScript compilation and Vite build)

BREAKING CHANGE: ReScript v12 introduces API changes that affect the typeof operator and configuration fields. Projects upgrading will need to:
- Update rescript.json to use 'dependencies' and 'compiler-flags' instead of 'bs-dependencies' and 'bsc-flags'
- Replace Js.typeof string comparisons with polymorphic variant comparisons (e.g., typeof(x) == #function instead of Js.typeof(x) == "function")
- Remove @ignore attributes from regular function parameters