### PR TITLE
Use @jsx.component and JSX.array

### DIFF
--- a/demos/BookstoreApp.res
+++ b/demos/BookstoreApp.res
@@ -521,7 +521,7 @@ let catalogView = () => {
       {Component.text("Available Books")}
     </h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      {Component.fragment(products->Array.map(product => <ProductCard product />))}
+      {products->Array.map(product => <ProductCard product />)->JSX.array}
     </div>
   </div>
 }


### PR DESCRIPTION
This is a draft change to an example to make component definitions more idiomatic / aligned to how we have been doing it in rescript-react. I.e. define a submodule with a `make` function with labeled arguments as props and a `@react.component` or `@jsx.component` annotation.

I only did it for the `ProductCard` component for testing, seemed to work fine.

There are more changes in the file because it was not formatted for ReScript 12, and my editor has format-on-save on. 🙂