### PR TITLE
style(docs): polish homepage hero and tutorial layout

### DIFF
--- a/docs-website/src/HomePage.res
+++ b/docs-website/src/HomePage.res
@@ -157,18 +157,20 @@ module HeroBackground = {
               if (!nearest) return;
               var vb = svg.viewBox && svg.viewBox.baseVal;
               if (!vb) return;
-              function activate(el, delay, ttl) {
+              function activate(el, delay, ttl, accent) {
                 clearTimeout(el.__xoteTimer);
                 clearTimeout(el.__xoteDelay);
                 el.__xoteDelay = setTimeout(function() {
+                  el.classList.toggle('active-accent', !!accent);
                   el.classList.add('active');
                   el.__xoteTimer = setTimeout(function() {
                     el.classList.remove('active');
+                    el.classList.remove('active-accent');
                   }, ttl);
                 }, delay);
               }
               if (throttle && svg.__xoteLastRipple && performance.now() - svg.__xoteLastRipple < 140) {
-                activate(nearest, 0, 600);
+                activate(nearest, 0, 600, Math.random() < 0.18);
                 return;
               }
               svg.__xoteLastRipple = performance.now();
@@ -211,7 +213,9 @@ module HeroBackground = {
                 if (Math.random() > prob) continue;
                 var jitter = (Math.random() - 0.5) * (idle ? 120 : 60);
                 var ttl = ringDuration + ring * (idle ? 110 : 50) + Math.random() * (idle ? 320 : 160);
-                activate(q, ring * ringDelay + jitter, ttl);
+                var accentProb = idle ? 0.12 : 0.18;
+                var accent = ring > 0 && Math.random() < accentProb;
+                activate(q, ring * ringDelay + jitter, ttl, accent);
               }
             };
             (function tick() {
@@ -430,12 +434,12 @@ Effect.run(() => {
         {stepHeader(
           ~n="03",
           ~title="Fetch live data in an effect",
-          ~blurb="An effect tracks the selected capital and fetches the current temperature from the free Open-Meteo API. When the capital changes, the effect re-runs and the dashboard re-renders.",
+          ~blurb="An effect tracks the selected capital and fetches the current temperature from the Open-Meteo API. When the capital changes, the effect re-runs and the dashboard re-renders.",
         )}
         <div class="tutorial-step-body">
           {codeBlock(~filename="CapitalWeather.res", ~code=step3Code)}
           {stage(
-            ~caption="Preview — real weather from a random world capital (Open-Meteo, no API key)",
+            ~caption="Preview — real weather from a random world capital (Open-Meteo)",
             ~children=<TutorialDemos.Step3 />,
           )}
         </div>

--- a/docs-website/src/styles.css
+++ b/docs-website/src/styles.css
@@ -946,8 +946,8 @@ td strong {
   .features-section,
   .code-example-section,
   .tutorial-section {
-    padding-left: var(--s-4);
-    padding-right: var(--s-4);
+    padding-left: var(--s-5);
+    padding-right: var(--s-5);
   }
   .hero {
     padding-top: var(--s-8);
@@ -2044,6 +2044,25 @@ td strong {
 
 .docs-main > * {
   max-width: var(--prose-width);
+}
+
+@media (max-width: 768px) {
+  .docs-layout {
+    padding-left: var(--s-5);
+    padding-right: var(--s-5);
+  }
+  .docs-main {
+    max-width: none;
+    margin: 0;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .docs-main > *,
+  .docs-page-lead,
+  .docs-content,
+  .docs-prev-next {
+    max-width: none;
+  }
 }
 
 .docs-breadcrumb {

--- a/docs-website/src/styles.css
+++ b/docs-website/src/styles.css
@@ -552,8 +552,8 @@ td strong {
   position: relative;
   max-width: var(--content-max);
   margin: 0 auto;
-  padding: var(--s-12) var(--s-5);
-  overflow: clip;
+  padding: var(--s-12) var(--s-5) var(--s-6);
+  overflow: visible;
 }
 
 .hero > *:not(.hero-bg) {
@@ -567,13 +567,35 @@ td strong {
   bottom: 0;
   left: 50%;
   transform: translateX(-50%);
-  width: 100%;
+  width: 100vw;
   z-index: 0;
   pointer-events: none;
   overflow: hidden;
   opacity: 0.55;
-  mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.9), transparent 75%);
-  -webkit-mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.9), transparent 75%);
+  mask-image: radial-gradient(
+    ellipse 84% 92% at center,
+    #000 0%,
+    #000 24%,
+    rgba(0, 0, 0, 0.72) 38%,
+    rgba(0, 0, 0, 0.24) 52%,
+    transparent 68%,
+    transparent 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    ellipse 84% 92% at center,
+    #000 0%,
+    #000 24%,
+    rgba(0, 0, 0, 0.72) 38%,
+    rgba(0, 0, 0, 0.24) 52%,
+    transparent 68%,
+    transparent 100%
+  );
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: 100% 100%;
+  -webkit-mask-size: 100% 100%;
+  mask-position: center;
+  -webkit-mask-position: center;
 }
 
 .hero-bg-svg {
@@ -593,6 +615,10 @@ td strong {
 .hero-tri.active {
   fill: var(--text-faint);
   transition: fill 0.08s ease-in;
+}
+
+.hero-tri.active-accent {
+  fill: var(--syntax-warm);
 }
 
 .hero-head {
@@ -729,7 +755,7 @@ td strong {
 .features-section {
   max-width: var(--content-max);
   margin: 0 auto;
-  padding: var(--s-8) var(--s-5) var(--s-12);
+  padding: var(--s-5) var(--s-5) var(--s-8);
 }
 
 .features-heading {
@@ -819,7 +845,7 @@ td strong {
 .code-example-section {
   max-width: var(--content-max);
   margin: 0 auto;
-  padding: var(--s-10) var(--s-5);
+  padding: var(--s-8) var(--s-5);
 }
 
 .code-example-section h2 {
@@ -834,7 +860,7 @@ td strong {
 .tutorial-section {
   max-width: var(--content-max);
   margin: 0 auto;
-  padding: var(--s-10) var(--s-5);
+  padding: var(--s-8) var(--s-5);
 }
 
 .tutorial-heading {
@@ -915,8 +941,32 @@ td strong {
 }
 
 @media (max-width: 640px) {
+  .header-inner,
+  .hero,
+  .features-section,
+  .code-example-section,
   .tutorial-section {
-    padding: var(--s-8) var(--s-4);
+    padding-left: var(--s-4);
+    padding-right: var(--s-4);
+  }
+  .hero {
+    padding-top: var(--s-8);
+    padding-bottom: var(--s-4);
+  }
+  .hero-display {
+    font-size: 42px;
+    margin: var(--s-6) 0 var(--s-5) 0;
+  }
+  .hero-lead {
+    font-size: var(--fs-base);
+    margin-bottom: var(--s-5);
+  }
+  .hero-ctas {
+    gap: var(--s-3);
+    margin-bottom: var(--s-6);
+  }
+  .tutorial-section {
+    padding: var(--s-8) var(--s-5);
   }
   .tutorial-heading {
     margin-bottom: var(--s-6);
@@ -929,6 +979,12 @@ td strong {
   }
   .tutorial-step {
     padding: var(--s-6) 0;
+  }
+  .tutorial-step-number {
+    position: static;
+    top: auto;
+    right: auto;
+    margin-bottom: var(--s-3);
   }
   .tutorial-step-head {
     margin-bottom: var(--s-4);
@@ -1029,12 +1085,19 @@ td strong {
   padding: var(--s-4) 0;
   margin: 0;
   max-height: 420px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   color: var(--text);
 }
 
 .tutorial-code .tutorial-code-pre .syntax-line {
   padding: 0 var(--s-4);
+  min-width: 0;
+}
+
+.tutorial-code .tutorial-code-pre .syntax-line-content {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .tutorial-code .tutorial-code-pre .syntax-keyword {


### PR DESCRIPTION
## Summary
- tighten homepage section spacing and improve mobile gutters/hero spacing
- make the hero animation full-width with a stronger vignette fade and occasional gold pulse accents
- wrap homepage tutorial code examples to avoid horizontal scrolling in their panels

## Testing
- Not run
- `npm run docs:build` is currently blocked in this workspace by an existing ReScript dependency resolution issue in `docs-website` (`xote`, `@rescript/core`, `basefn` not found)