### PR TITLE
Fix initial controlled select value

### DIFF
--- a/src/Node.res
+++ b/src/Node.res
@@ -317,8 +317,10 @@ module Render = {
         setOwner(el, owner)
 
         runWithOwner(owner, () => {
-          /* Set attributes */
-          attrs->Array.forEach(((key, value)) => {
+          let shouldDeferAttrUntilAfterChildren = ((key, _value)) =>
+            tag == "select" && key == "value"
+
+          let applyAttr = ((key, value)) => {
             switch value {
             | Static(v) => DOM.setAttrOrProp(el, key, v)
             | SignalValue(signal) => {
@@ -341,6 +343,13 @@ module Render = {
                 addDisposer(owner, disposer)
               }
             }
+          }
+
+          /* Set attributes that do not depend on mounted children */
+          attrs->Array.forEach(attr => {
+            if !shouldDeferAttrUntilAfterChildren(attr) {
+              applyAttr(attr)
+            }
           })
 
           /* Attach event listeners */
@@ -352,6 +361,13 @@ module Render = {
           children->Array.forEach(child => {
             let childEl = render(child)
             el->DOM.appendChild(childEl)
+          })
+
+          /* Some DOM properties need the child tree to exist before the browser can resolve them */
+          attrs->Array.forEach(attr => {
+            if shouldDeferAttrUntilAfterChildren(attr) {
+              applyAttr(attr)
+            }
           })
         })
 

--- a/tests/JSX_test.res
+++ b/tests/JSX_test.res
@@ -5,6 +5,10 @@ let mountTo = (node, container) => {
   container
 }
 
+@get external valueOf: 'a => string = "value"
+@get external selectedIndexOf: 'a => int = "selectedIndex"
+@send external querySelector: ('a, string) => Nullable.t<'b> = "querySelector"
+
 let suite = Zekr.suite(
   "JSX",
   [
@@ -56,6 +60,27 @@ let suite = Zekr.suite(
       Signal.set(cls, "updated")
       let r2 = Dom.Assert.toHaveClass(el, "updated")
       combineResults([r1, r2])
+    }),
+    test("controlled select honors the initial reactive value", () => {
+      let {container} = Dom.render("")
+      let selected = Signal.make("green")
+
+      let _ = mountTo(
+        <select value={ReactiveProp.reactive(selected)}>
+          <option value="red"> {Node.text("Red")} </option>
+          <option value="green"> {Node.text("Green")} </option>
+        </select>,
+        container,
+      )
+
+      switch querySelector(container, "select")->Nullable.toOption {
+      | Some(select) =>
+          combineResults([
+            assertEqual(valueOf(select), "green"),
+            assertEqual(selectedIndexOf(select), 1),
+          ])
+      | None => assertTrue(false)
+      }
     }),
     test("renders disabled input via JSX boolean attribute", () => {
       let {container} = Dom.render("")


### PR DESCRIPTION
## Summary
- defer applying `select.value` until after option children are mounted
- add a regression test for a controlled select with a non-first initial option
- keep the change scoped to `select` so other elements preserve existing attribute order

## Testing
- npm run test
- npm run build

Closes #90