### PR TITLE
chore(docs): switch to xote.dev custom domain

### DIFF
--- a/docs-website/index.html
+++ b/docs-website/index.html
@@ -11,9 +11,8 @@
         var decoded = redirect[1].split('&').map(function(s) {
           return s.replace(/~and~/g, '&');
         }).join('?');
-        var basePath = '/xote';
         window.history.replaceState(null, '',
-          basePath + '/' + decoded + window.location.hash
+          '/' + decoded + window.location.hash
         );
       }
     })();

--- a/docs-website/public/404.html
+++ b/docs-website/public/404.html
@@ -7,7 +7,7 @@
     // Encodes the current path into a query parameter and redirects to index.html
     // so the client-side router can handle it.
     // Based on https://github.com/rafgraph/spa-github-pages
-    var pathSegmentsToKeep = 1; // Keep '/xote' prefix (1 segment)
+    var pathSegmentsToKeep = 0;
     var l = window.location;
     l.replace(
       l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +

--- a/docs-website/public/CNAME
+++ b/docs-website/public/CNAME
@@ -1,0 +1,1 @@
+xote.dev

--- a/docs-website/server.mjs
+++ b/docs-website/server.mjs
@@ -7,7 +7,7 @@ import http from 'node:http'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const isProduction = process.env.NODE_ENV === 'production'
 const port = process.env.PORT || 4242
-const base = '/xote/'
+const base = '/'
 
 // Handle async errors from SSR-rendered code that defers DOM access
 // (e.g., basefn Icon component uses setTimeout + document.getElementById)

--- a/docs-website/src/EntryClient.res
+++ b/docs-website/src/EntryClient.res
@@ -2,7 +2,7 @@
 module Website = Website
 
 // Initialize client-side router
-Router.init(~basePath="/xote", ())
+Router.init()
 
 // Hydrate the server-rendered HTML
 let _ = Hydration.hydrateById(

--- a/docs-website/src/EntryServer.res
+++ b/docs-website/src/EntryServer.res
@@ -4,7 +4,7 @@ module Website = Website
 // Render function called by the SSR server for each request
 let render = (url: string) => {
   // Initialize router for server-side rendering with the requested URL
-  Router.initSSR(~basePath="/xote", ~pathname=url, ())
+  Router.initSSR(~pathname=url, ())
 
   // Render the app to an HTML string
   SSR.renderToString(() => <Website.App />)

--- a/docs-website/vite.config.js
+++ b/docs-website/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-  base: '/xote/',
+  base: '/',
   server: {
     port: 3000,
   },


### PR DESCRIPTION
## Summary
- Drop the `/xote` base path everywhere it was hardcoded (Vite `base`, client/server router init, SSR dev server, SPA-redirect scripts in `index.html` and `404.html`) so assets and routes resolve from the apex of `xote.dev`.
- Add `docs-website/public/CNAME` containing `xote.dev` so the GitHub Pages custom-domain setting persists across deploys (Vite copies `public/` into the build output, which is what `deploy-docs.yml` uploads as the Pages artifact).

## Test plan
- [ ] After merge, `deploy-docs.yml` succeeds on `main`
- [ ] In repo Settings → Pages: custom domain remains `xote.dev` and "Enforce HTTPS" is enabled
- [ ] Squarespace DNS has the 4 A records for the apex (`185.199.108.153/109.153/110.153/111.153`)
- [ ] `https://xote.dev` loads with CSS/JS assets resolving (no more 404s on `/xote/*` paths)
- [ ] Client-side routing works (e.g., navigating to a docs page and hard-refreshing falls through `404.html` → SPA redirect → correct route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)