### PR TITLE
ci: pass posthog vars to docs build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,6 +40,9 @@ jobs:
           npm ci
 
       - name: Build website
+        env:
+          VITE_POSTHOG_KEY: ${{ vars.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
         run: |
           cd docs-website
           npm run build


### PR DESCRIPTION
## Summary
- Expose `VITE_POSTHOG_KEY` and `VITE_POSTHOG_HOST` to the docs build step in `deploy-docs.yml`, sourced from GitHub Actions repo `vars`
- Without this, the production bundle initializes posthog-js with `undefined`, so no events ship from xote.dev

## Setup
Add the two values under **Settings → Secrets and variables → Actions → Variables** before the next deploy:
- \`VITE_POSTHOG_KEY\` — PostHog project API key (public/write-only; safe as a var)
- \`VITE_POSTHOG_HOST\` — e.g. \`https://eu.i.posthog.com\`

## Test plan
- [ ] Add the two repo variables in GitHub Actions settings
- [ ] Merge and let \`Deploy Documentation to GitHub Pages\` run
- [ ] Visit xote.dev and confirm events appear in PostHog