### PR TITLE
ci: read posthog values from secrets, not vars

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Build website
         env:
-          VITE_POSTHOG_KEY: ${{ vars.VITE_POSTHOG_KEY }}
-          VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
+          VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
         run: |
           cd docs-website
           npm run build


### PR DESCRIPTION
## Summary
- Switch the docs build step from \`vars.VITE_POSTHOG_KEY\` / \`vars.VITE_POSTHOG_HOST\` to \`secrets.*\`, since the values are stored under repo Secrets (not Variables)
- Without this fix, both interpolations expanded to empty strings and posthog-js initialized with \`undefined\`, so no events shipped from xote.dev

## Test plan
- [ ] Trigger \`Deploy Documentation to GitHub Pages\` (push to main or run workflow_dispatch)
- [ ] Visit xote.dev, click around, confirm events arrive in PostHog