### PR TITLE
docs: tighten changelog page spacing

### DIFF
--- a/docs-website/src/RepoData.res
+++ b/docs-website/src/RepoData.res
@@ -21,10 +21,43 @@ type release = {
 }
 
 let sourceUrl = "https://github.com/brnrdog/xote/blob/main/docs/CHANGELOG.md"
-let latestVersion = "6.1.2"
-let latestReleaseDate = "2026-04-25"
+let latestVersion = "6.2.0"
+let latestReleaseDate = "2026-04-26"
 
 let releases: array<release> = [
+  {
+    version: "6.2.0",
+    url: "https://github.com/brnrdog/xote/compare/v6.1.2...v6.2.0",
+    date: "2026-04-26",
+    id: "release-6-2-0-2026-04-26",
+    sections: [
+      {
+        title: "Bug Fixes",
+        items: [
+          [
+            Node.text("connect keyed JSX to reconciliation ("),
+            <a href="https://github.com/brnrdog/xote/commit/6839f90c8ff0838ce65427715ba65af57a76cce3" target="_blank"> {Node.text("6839f90")} </a>,
+            Node.text(")")
+          ]
+        ],
+      },
+      {
+        title: "Features",
+        items: [
+          [
+            Node.text("add clearer api aliases ("),
+            <a href="https://github.com/brnrdog/xote/commit/1bc01da9f3a871b38fae7f243fa2b99a2ce37690" target="_blank"> {Node.text("1bc01da")} </a>,
+            Node.text(")")
+          ],
+          [
+            Node.text("promote View and Prop as primary modules ("),
+            <a href="https://github.com/brnrdog/xote/commit/5a1566fd13d1bd4af09dbce0b8e40bdf2a4cc948" target="_blank"> {Node.text("5a1566f")} </a>,
+            Node.text(")")
+          ]
+        ],
+      }
+    ],
+  },
   {
     version: "6.1.2",
     url: "https://github.com/brnrdog/xote/compare/v6.1.1...v6.1.2",

--- a/docs-website/src/Website.res
+++ b/docs-website/src/Website.res
@@ -424,7 +424,6 @@ module App = {
             <DocsPage
               currentPath="/docs/changelog"
               pageTitle="Changelog"
-              pageLead="Release history generated from the repository changelog."
               content={ChangelogDoc.content()}
               tocItems=changelogTocItems
             />,

--- a/docs-website/src/docs/ChangelogDoc.res
+++ b/docs-website/src/docs/ChangelogDoc.res
@@ -9,7 +9,7 @@ let content = () => {
 
   <div class="changelog-doc">
     <p class="changelog-meta">
-      {Node.text("Version " ++ RepoData.latestVersion ++ " is the latest entry in the repository changelog. Source: ")}
+      {Node.text("See the full history on GitHub: ")}
       <a href={RepoData.sourceUrl} target="_blank"> {Node.text("docs/CHANGELOG.md")} </a>
     </p>
     {Node.fragment(

--- a/docs-website/src/styles.css
+++ b/docs-website/src/styles.css
@@ -2185,7 +2185,7 @@ td strong {
 
 .changelog-doc {
   display: grid;
-  gap: var(--s-8);
+  gap: var(--s-5);
 }
 
 .changelog-meta {
@@ -2214,18 +2214,8 @@ td strong {
   text-decoration-thickness: 1px;
 }
 
-.changelog-release {
-  padding-top: var(--s-6);
-  border-top: 1px solid var(--border);
-}
-
-.changelog-release:first-of-type {
-  padding-top: 0;
-  border-top: 0;
-}
-
 .changelog-release-head {
-  margin-bottom: var(--s-5);
+  margin-bottom: var(--s-3);
 }
 
 .changelog-release-title {
@@ -2251,11 +2241,11 @@ td strong {
 }
 
 .changelog-section + .changelog-section {
-  margin-top: var(--s-5);
+  margin-top: var(--s-3);
 }
 
 .changelog-section-title {
-  margin-bottom: var(--s-3);
+  margin-bottom: var(--s-2);
 }
 
 .changelog-list {


### PR DESCRIPTION
## Summary
- Reduce gap between releases on the changelog page and remove the separator borders so versions sit closer together.
- Simplify the meta paragraph and drop the page lead that mentioned generation; both top and bottom still link to the GitHub source.
- Refresh `RepoData.res` so the page surfaces the v6.2.0 entry from `docs/CHANGELOG.md`.

## Test plan
- [ ] `npm run docs:build` and visually confirm the changelog page renders with tighter spacing and no separators.
- [ ] Verify the GitHub source link (top and bottom) still points to `docs/CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)