### PR TITLE
[codex] fix empty view keyed children

### DIFF
--- a/src/View.res
+++ b/src/View.res
@@ -117,21 +117,25 @@ module Render = {
   }
 
   let getKeyedChildren = (children: array<node>): option<array<keyedChild>> => {
-    let keyedChildren = []
-    let allKeyed = ref(true)
-
-    children->Array.forEach(child => {
-      switch child {
-      | Keyed({key, identity, child}) =>
-        keyedChildren->Array.push({key, identity, child})->ignore
-      | _ => allKeyed := false
-      }
-    })
-
-    if allKeyed.contents {
-      Some(keyedChildren)
-    } else {
+    if Array.length(children) == 0 {
       None
+    } else {
+      let keyedChildren = []
+      let allKeyed = ref(true)
+
+      children->Array.forEach(child => {
+        switch child {
+        | Keyed({key, identity, child}) =>
+          keyedChildren->Array.push({key, identity, child})->ignore
+        | _ => allKeyed := false
+        }
+      })
+
+      if allKeyed.contents {
+        Some(keyedChildren)
+      } else {
+        None
+      }
     }
   }
 


### PR DESCRIPTION
## What changed

This updates `View.Render.getKeyedChildren` so an empty child array returns `None` instead of being treated as an all-keyed collection.

## Why

The previous `allKeyed` default meant empty children were classified as keyed children because no non-keyed child was encountered. That can route empty child sets through keyed reconciliation behavior even when there is nothing to reconcile.

## Impact

Empty view child arrays now follow the normal non-keyed path, while non-empty arrays still use keyed reconciliation only when every child is keyed.

## Validation

- `npm run res:build`
- `npm run test` (75 passed)
- `npm run build`