### PR TITLE
[codex] add pointer event JSX props

### DIFF
--- a/src/XoteJSX.res
+++ b/src/XoteJSX.res
@@ -158,6 +158,17 @@ module Elements = {
     onMouseMove?: Dom.event => unit,
     onMouseUp?: Dom.event => unit,
     onContextMenu?: Dom.event => unit,
+    /* Pointer event handlers */
+    onPointerDown?: Dom.event => unit,
+    onPointerMove?: Dom.event => unit,
+    onPointerUp?: Dom.event => unit,
+    onPointerCancel?: Dom.event => unit,
+    onPointerEnter?: Dom.event => unit,
+    onPointerLeave?: Dom.event => unit,
+    onPointerOver?: Dom.event => unit,
+    onPointerOut?: Dom.event => unit,
+    onGotPointerCapture?: Dom.event => unit,
+    onLostPointerCapture?: Dom.event => unit,
     /* Drag-and-drop event handlers */
     onDrag?: Dom.event => unit,
     onDragStart?: Dom.event => unit,
@@ -288,6 +299,16 @@ module Elements = {
     addEvent(events, props.onMouseMove, "mousemove")
     addEvent(events, props.onMouseUp, "mouseup")
     addEvent(events, props.onContextMenu, "contextmenu")
+    addEvent(events, props.onPointerDown, "pointerdown")
+    addEvent(events, props.onPointerMove, "pointermove")
+    addEvent(events, props.onPointerUp, "pointerup")
+    addEvent(events, props.onPointerCancel, "pointercancel")
+    addEvent(events, props.onPointerEnter, "pointerenter")
+    addEvent(events, props.onPointerLeave, "pointerleave")
+    addEvent(events, props.onPointerOver, "pointerover")
+    addEvent(events, props.onPointerOut, "pointerout")
+    addEvent(events, props.onGotPointerCapture, "gotpointercapture")
+    addEvent(events, props.onLostPointerCapture, "lostpointercapture")
     addEvent(events, props.onDrag, "drag")
     addEvent(events, props.onDragStart, "dragstart")
     addEvent(events, props.onDragEnd, "dragend")

--- a/tests/JSX_test.res
+++ b/tests/JSX_test.res
@@ -1,5 +1,11 @@
 open! Zekr
 
+%%raw(`
+function __xoteTestDispatchEventByName(node, eventName) {
+  node.dispatchEvent(new Event(eventName, {bubbles: true}));
+}
+`)
+
 let mountTo = (node, container) => {
   View.mount(node, container)
   container
@@ -9,6 +15,7 @@ let mountTo = (node, container) => {
 @get external selectedIndexOf: 'a => int = "selectedIndex"
 @send external querySelector: ('a, string) => Nullable.t<'b> = "querySelector"
 @val external objectIs: ('a, 'a) => bool = "Object.is"
+@val external dispatchEventByName: ('a, string) => unit = "__xoteTestDispatchEventByName"
 
 let suite = Zekr.suite(
   "JSX",
@@ -29,6 +36,28 @@ let suite = Zekr.suite(
       let btn = Dom.Query.getByRole(container, "button")
       Dom.Event.click(btn)
       assertTrue(clicked.contents)
+    }),
+    test("handles pointer events in JSX", () => {
+      let {container} = Dom.render("")
+      let pointerDown = ref(false)
+      let pointerUp = ref(false)
+      let _ = mountTo(
+        <button
+          onPointerDown={_evt => pointerDown := true}
+          onPointerUp={_evt => pointerUp := true}>
+          {View.text("Drag handle")}
+        </button>,
+        container,
+      )
+      let btn = Dom.Query.getByRole(container, "button")
+
+      dispatchEventByName(btn, "pointerdown")
+      dispatchEventByName(btn, "pointerup")
+
+      combineResults([
+        assertTrue(pointerDown.contents),
+        assertTrue(pointerUp.contents),
+      ])
     }),
     test("renders input with type and placeholder", () => {
       let {container} = Dom.render("")


### PR DESCRIPTION
## Summary

Adds typed JSX props for standard pointer events in `XoteJSX.Elements` and maps them to their corresponding DOM event names.

Supported props now include:

- `onPointerDown`
- `onPointerMove`
- `onPointerUp`
- `onPointerCancel`
- `onPointerEnter`
- `onPointerLeave`
- `onPointerOver`
- `onPointerOut`
- `onGotPointerCapture`
- `onLostPointerCapture`

## Why

Consumers currently have to fall back to `View.element(..., ~events=[("pointerdown", handler)])` for pointer interactions such as drag handles. Typed JSX props let those controls stay in JSX while preserving Xote's existing event-handler model.

## Validation

- `npm run res:build`
- `npm test`
- `npm run build`