### PR TITLE
ci: trigger release workflow manually only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Removes the push-to-main trigger so releases run on demand via workflow_dispatch. 