### PR TITLE
[codex] Improve changelog content layout

### DIFF
--- a/docs-website/src/RepoData.res
+++ b/docs-website/src/RepoData.res
@@ -21,10 +21,56 @@ type release = {
 }
 
 let sourceUrl = "https://github.com/brnrdog/xote/blob/main/docs/CHANGELOG.md"
-let latestVersion = "6.2.0"
-let latestReleaseDate = "2026-04-26"
+let latestVersion = "6.4.0"
+let latestReleaseDate = "2026-05-20"
 
 let releases: array<release> = [
+  {
+    version: "6.4.0",
+    url: "https://github.com/brnrdog/xote/compare/v6.3.0...v6.4.0",
+    date: "2026-05-20",
+    id: "release-6-4-0-2026-05-20",
+    sections: [
+      {
+        title: "Bug Fixes",
+        items: [
+          [
+            Node.text("empty view keyed children ("),
+            <a href="https://github.com/brnrdog/xote/commit/5fbe71bfa2dd15818c5f1c58c7bc76759adbcd0e" target="_blank"> {Node.text("5fbe71b")} </a>,
+            Node.text(")")
+          ]
+        ],
+      },
+      {
+        title: "Features",
+        items: [
+          [
+            Node.text("add SVG attribute props to JSX Elements ("),
+            <a href="https://github.com/brnrdog/xote/commit/63592e5d58bc581515b0bb707033f8d3246e1665" target="_blank"> {Node.text("63592e5")} </a>,
+            Node.text(")")
+          ]
+        ],
+      }
+    ],
+  },
+  {
+    version: "6.3.0",
+    url: "https://github.com/brnrdog/xote/compare/v6.2.0...v6.3.0",
+    date: "2026-05-12",
+    id: "release-6-3-0-2026-05-12",
+    sections: [
+      {
+        title: "Features",
+        items: [
+          [
+            Node.text("add missing pointer event props ("),
+            <a href="https://github.com/brnrdog/xote/commit/3a8f596c2a516b0258e007e7080f07ac1d06ba47" target="_blank"> {Node.text("3a8f596")} </a>,
+            Node.text(")")
+          ]
+        ],
+      }
+    ],
+  },
   {
     version: "6.2.0",
     url: "https://github.com/brnrdog/xote/compare/v6.1.2...v6.2.0",

--- a/docs-website/src/docs/ChangelogDoc.res
+++ b/docs-website/src/docs/ChangelogDoc.res
@@ -1,5 +1,16 @@
 let maxVisibleReleases = 10
 
+let changeLabel = count => {
+  if count == 1 {
+    "1 change"
+  } else {
+    `${count->Int.toString} changes`
+  }
+}
+
+let releaseChangeCount = (release: RepoData.release) =>
+  Array.reduce(release.sections, 0, (total, section) => total + Array.length(section.items))
+
 let content = () => {
   let visibleReleases =
     RepoData.releases->Array.slice(
@@ -8,49 +19,73 @@ let content = () => {
     )
 
   <div class="changelog-doc">
-    <p class="changelog-meta">
-      {Node.text("See the full history on GitHub: ")}
-      <a href={RepoData.sourceUrl} target="_blank"> {Node.text("docs/CHANGELOG.md")} </a>
-    </p>
-    {Node.fragment(
-      visibleReleases->Array.map(release => {
-        <section class="changelog-release" id={release.id}>
-          <div class="changelog-release-head">
-            <div>
-              <h2 class="changelog-release-title">
-                <a
-                  href={release.url}
-                  target="_blank"
-                  class="changelog-release-link">
-                  {Node.text("v" ++ release.version)}
-                </a>
-              </h2>
-              <p class="changelog-release-date"> {Node.text(release.date)} </p>
-            </div>
-          </div>
-          {Node.fragment(
-            release.sections->Array.map(section => {
-              <div class="changelog-section">
-                {if section.title != "" {
-                  <h3 class="changelog-section-title"> {Node.text(section.title)} </h3>
+    <div class="changelog-summary">
+      <div>
+        <p class="changelog-kicker"> {Node.text("Release history")} </p>
+        <p class="changelog-meta">
+          {Node.text("Recent versions generated from ")}
+          <a href={RepoData.sourceUrl} target="_blank"> {Node.text("docs/CHANGELOG.md")} </a>
+        </p>
+      </div>
+      <a href={RepoData.sourceUrl} target="_blank" class="changelog-source-link">
+        {Node.text("Full history")}
+      </a>
+    </div>
+    <div class="changelog-releases">
+      {Node.fragment(
+        visibleReleases->Array.mapWithIndex((release, index) => {
+          let changeCount = releaseChangeCount(release)
+
+          <section class="changelog-release" id={release.id}>
+            <header class="changelog-release-head">
+              <div class="changelog-version-block">
+                {if index == 0 {
+                  <span class="changelog-latest"> {Node.text("Latest")} </span>
                 } else {
                   Node.fragment([])
                 }}
-                <ul class="changelog-list">
-                  {Node.fragment(
-                    section.items->Array.map(item => {
-                      <li class="changelog-item"> {Node.fragment(item)} </li>
-                    }),
-                  )}
-                </ul>
+                <h2 class="changelog-release-title">
+                  <a href={release.url} target="_blank" class="changelog-release-link">
+                    {Node.text("v" ++ release.version)}
+                  </a>
+                </h2>
               </div>
-            }),
-          )}
-        </section>
-      }),
-    )}
-    <p class="changelog-more">
-      <a href={RepoData.sourceUrl} target="_blank"> {Node.text("View the full changelog on GitHub")} </a>
-    </p>
+              <div class="changelog-release-meta">
+                <time class="changelog-release-date"> {Node.text(release.date)} </time>
+                <span class="changelog-release-count"> {Node.text(changeLabel(changeCount))} </span>
+              </div>
+            </header>
+            <div class="changelog-release-body">
+              {Node.fragment(
+                release.sections->Array.map(section => {
+                  <section class="changelog-section">
+                    <div class="changelog-section-head">
+                      {if section.title != "" {
+                        <h3 class="changelog-section-title"> {Node.text(section.title)} </h3>
+                      } else {
+                        <h3 class="changelog-section-title"> {Node.text("Changes")} </h3>
+                      }}
+                      <span class="changelog-section-count">
+                        {Node.text(changeLabel(Array.length(section.items)))}
+                      </span>
+                    </div>
+                    <ul class="changelog-list">
+                      {Node.fragment(
+                        section.items->Array.map(item => {
+                          <li class="changelog-item">
+                            <span class="changelog-item-marker" ariaHidden=true> {Node.text("")} </span>
+                            <span class="changelog-item-copy"> {Node.fragment(item)} </span>
+                          </li>
+                        }),
+                      )}
+                    </ul>
+                  </section>
+                }),
+              )}
+            </div>
+          </section>
+        }),
+      )}
+    </div>
   </div>
 }

--- a/docs-website/src/styles.css
+++ b/docs-website/src/styles.css
@@ -2338,39 +2338,103 @@ td strong {
   margin-top: var(--s-4);
 }
 
+.docs-main:has(.changelog-doc) {
+  max-width: calc(840px + var(--s-12));
+}
+
+.docs-content:has(.changelog-doc) {
+  max-width: 840px;
+}
+
 .changelog-doc {
   display: grid;
+  gap: var(--s-6);
+}
+
+.changelog-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
   gap: var(--s-5);
+  padding-bottom: var(--s-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.changelog-kicker {
+  margin: 0 0 var(--s-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--syntax-warm);
+  text-transform: uppercase;
 }
 
 .changelog-meta {
   margin: 0;
   color: var(--text-muted);
   font-size: var(--fs-sm);
+  line-height: var(--lh-ui);
 }
 
-.changelog-meta a {
+.changelog-meta a,
+.changelog-source-link,
+.changelog-release-link {
   text-decoration: underline;
   text-underline-offset: 4px;
   text-decoration-thickness: 1px;
 }
 
-.changelog-more {
-  margin: 0;
-  padding-top: var(--s-2);
-  border-top: 1px solid var(--border);
-  font-size: var(--fs-sm);
-}
-
-.changelog-more a {
+.changelog-source-link {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
   color: var(--text);
-  text-decoration: underline;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 1px;
+  white-space: nowrap;
+}
+
+.changelog-releases {
+  display: grid;
+  gap: var(--s-4);
+}
+
+.changelog-release {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.36fr) minmax(0, 1fr);
+  gap: var(--s-6);
+  padding: var(--s-5);
+  border: 1px solid var(--border);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--elevated) 62%, transparent),
+      color-mix(in oklch, var(--surface) 86%, transparent)
+    );
 }
 
 .changelog-release-head {
-  margin-bottom: var(--s-3);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--s-5);
+  min-width: 0;
+}
+
+.changelog-version-block {
+  display: grid;
+  justify-items: start;
+  gap: var(--s-2);
+}
+
+.changelog-latest {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 var(--s-2);
+  border: 1px solid color-mix(in oklch, var(--syntax-warm) 38%, var(--border));
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1;
+  color: var(--syntax-warm);
+  background: color-mix(in oklch, var(--syntax-warm) 10%, transparent);
 }
 
 .changelog-release-title {
@@ -2378,37 +2442,82 @@ td strong {
   font-family: var(--font-display);
   font-size: var(--fs-2xl);
   font-style: normal;
+  line-height: var(--lh-tight);
 }
 
-.changelog-release-link:hover {
-  text-decoration: underline;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 1px;
+.changelog-release-meta {
+  display: grid;
+  gap: var(--s-1);
+}
+
+.changelog-release-date,
+.changelog-release-count,
+.changelog-section-count {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-ui);
+  color: var(--text-faint);
 }
 
 .changelog-release-date {
-  margin: var(--s-2) 0 0;
-  font-family: var(--font-mono);
-  font-size: var(--fs-xs);
-  color: var(--text-faint);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.changelog-release-body {
+  min-width: 0;
 }
 
 .changelog-section + .changelog-section {
-  margin-top: var(--s-3);
+  margin-top: var(--s-5);
+  padding-top: var(--s-4);
+  border-top: 1px solid var(--border-soft);
+}
+
+.changelog-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--s-4);
+  margin-bottom: var(--s-3);
 }
 
 .changelog-section-title {
-  margin-bottom: var(--s-2);
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  line-height: var(--lh-ui);
+  color: var(--text);
 }
 
 .changelog-list {
+  display: grid;
+  gap: var(--s-2);
   margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .changelog-item {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  gap: var(--s-3);
+  align-items: start;
   color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+}
+
+.changelog-item-marker {
+  width: 6px;
+  height: 6px;
+  margin-top: 9px;
+  border: 1px solid color-mix(in oklch, var(--syntax-warm) 54%, var(--border));
+  background: color-mix(in oklch, var(--syntax-warm) 24%, var(--surface));
+}
+
+.changelog-item-copy {
+  min-width: 0;
 }
 
 .changelog-item strong,
@@ -2417,10 +2526,55 @@ td strong {
   color: var(--text);
 }
 
-.changelog-item a:hover {
-  text-decoration: underline;
-  text-underline-offset: 4px;
-  text-decoration-thickness: 1px;
+.changelog-item a:hover,
+.changelog-release-link:hover,
+.changelog-source-link:hover {
+  color: var(--syntax-warm);
+}
+
+@media (max-width: 860px) {
+  .docs-main:has(.changelog-doc),
+  .docs-content:has(.changelog-doc) {
+    max-width: none;
+  }
+
+  .changelog-release {
+    grid-template-columns: 1fr;
+    gap: var(--s-4);
+  }
+
+  .changelog-release-head {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: var(--s-4);
+  }
+
+  .changelog-release-meta {
+    justify-items: end;
+    text-align: right;
+  }
+}
+
+@media (max-width: 520px) {
+  .changelog-summary,
+  .changelog-release-head,
+  .changelog-section-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .changelog-source-link {
+    white-space: normal;
+  }
+
+  .changelog-release {
+    padding: var(--s-4);
+  }
+
+  .changelog-release-meta {
+    justify-items: start;
+    text-align: left;
+  }
 }
 
 .docs-prev-next {


### PR DESCRIPTION
## Summary
- Reworked the docs changelog page into a release ledger with a source summary, latest badge, per-release metadata, and grouped change rows.
- Added release and section change counts so each entry is easier to scan by content type.
- Refreshed generated `RepoData.res` from `docs/CHANGELOG.md`, which the docs build updates before compiling.

## Validation
- `npm run res:build` in `docs-website` passed, with existing `ColorMixerDemo.res` unused-variable warnings.
- `npm run build` in `docs-website` passed and prerendered `/docs/changelog`.

## Notes
- Root `npm run res:build` could not run before switching to the docs package because root `node_modules` is not installed (`rescript: command not found`).