### PR TITLE
Refactor changelog release styling and star button appearance

### DIFF
--- a/docs-website/src/styles.css
+++ b/docs-website/src/styles.css
@@ -453,9 +453,9 @@ td strong {
   gap: 6px;
   min-height: 30px;
   padding: 0 var(--s-3);
-  border: 1px solid var(--border);
+  border: none;
   color: var(--text);
-  background: var(--surface);
+  background: transparent;
   font-family: var(--font-body);
   font-size: var(--fs-sm);
   font-weight: 500;
@@ -464,7 +464,6 @@ td strong {
   white-space: nowrap;
 }
 .gh-star-btn:hover {
-  border-color: var(--text-muted);
   color: var(--text);
   background: var(--elevated);
   text-decoration: none;
@@ -2451,14 +2450,11 @@ td strong {
   display: grid;
   grid-template-columns: minmax(150px, 0.36fr) minmax(0, 1fr);
   gap: var(--s-6);
-  padding: var(--s-5);
-  border: 1px solid var(--border);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklch, var(--elevated) 62%, transparent),
-      color-mix(in oklch, var(--surface) 86%, transparent)
-    );
+}
+
+.changelog-release + .changelog-release {
+  padding-top: var(--s-5);
+  border-top: 1px solid var(--border-soft);
 }
 
 .changelog-release-head {
@@ -2616,10 +2612,6 @@ td strong {
 
   .changelog-source-link {
     white-space: normal;
-  }
-
-  .changelog-release {
-    padding: var(--s-4);
   }
 
   .changelog-release-meta {


### PR DESCRIPTION
## Summary
This PR updates the documentation website styles to improve the visual presentation of the changelog and GitHub star button components. The changes simplify the star button styling and restructure the changelog release layout to use a separator-based design instead of bordered containers.

## Key Changes
- **GitHub Star Button**: Removed border and background styling for a cleaner, more minimal appearance
  - Changed `border: 1px solid var(--border)` to `border: none`
  - Changed `background: var(--surface)` to `background: transparent`
  - Removed `border-color` change on hover state
  
- **Changelog Release Layout**: Refactored from bordered containers to a separator-based design
  - Removed padding and gradient background from individual `.changelog-release` elements
  - Introduced new `.changelog-release + .changelog-release` selector to add top padding and border only between consecutive releases
  - Changed border color from `var(--border)` to `var(--border-soft)` for a subtler visual separation
  - Removed responsive padding override for smaller screens

## Implementation Details
The changelog refactoring improves visual hierarchy by using CSS adjacent sibling combinators (`+`) to apply spacing and borders only between release items, rather than styling each container individually. This approach is more maintainable and provides cleaner spacing without redundant borders at the top of the first item or bottom of the last item.

https://claude.ai/code/session_01MjCG2fdZTuZ7LENmbaguB5