### PR TITLE
[codex] Add bundle size PR comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4
@@ -31,3 +38,79 @@ jobs:
 
       - name: Vite Build
         run: npm run build
+
+      - name: Snapshot bundle size
+        run: GITHUB_STEP_SUMMARY= npm run bundle:size -- --json bundle-size-current.json
+
+      - name: Snapshot base bundle size
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          base_dir="$(mktemp -d)"
+
+          cleanup() {
+            git worktree remove "$base_dir" --force || true
+            rm -rf "$base_dir"
+          }
+
+          trap cleanup EXIT
+
+          git worktree add --detach "$base_dir" "$BASE_SHA"
+
+          (
+            cd "$base_dir"
+            npm install
+            npm run res:build
+            npm run build
+          )
+
+          GITHUB_STEP_SUMMARY= node "$GITHUB_WORKSPACE/scripts/bundle-size-report.mjs" \
+            --dist "$base_dir/dist" \
+            --package "$base_dir/package.json" \
+            --json bundle-size-base.json \
+            --markdown /tmp/bundle-size-base-report.md
+
+      - name: Generate bundle size report
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          if [ -f bundle-size-base.json ]; then
+            npm run bundle:size -- \
+              --json bundle-size-current.json \
+              --baseline bundle-size-base.json \
+              --baseline-label "$BASE_REF" \
+              --current-label PR
+          else
+            npm run bundle:size -- --json bundle-size-current.json
+          fi
+
+      - name: Comment bundle size on PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMENT_FILE: bundle-size-report.md
+        run: |
+          marker="<!-- xote-bundle-size-report -->"
+          body_file="$(mktemp)"
+
+          {
+            echo "$marker"
+            cat "$COMMENT_FILE"
+          } > "$body_file"
+
+          comment_id="$(
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq ".[] | select(.body | startswith(\"$marker\")) | .id" \
+              | head -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" \
+              -f body="$(cat "$body_file")"
+          else
+            gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -f body="$(cat "$body_file")"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .merlin
 *.res.mjs
 bundlemeta.json
+bundle-size-report.md
+bundle-size-*.json
 .vite
 
 # Documentation site

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "format": "rescript format",
     "dev": "vite",
     "build": "vite build",
+    "bundle:size": "node scripts/bundle-size-report.mjs",
     "preview": "vite preview",
     "docs:start": "cd docs-website && npm run dev",
     "docs:build": "cd docs-website && npm run build",

--- a/scripts/bundle-size-report.mjs
+++ b/scripts/bundle-size-report.mjs
@@ -1,0 +1,258 @@
+import { appendFile, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { brotliCompressSync, gzipSync } from "node:zlib";
+
+const artifactMetadata = {
+  "xote.mjs": {
+    format: "ESM",
+    consumer: "`import` / `module`",
+  },
+  "xote.cjs": {
+    format: "CommonJS",
+    consumer: "`require` / `main`",
+  },
+  "xote.umd.js": {
+    format: "UMD",
+    consumer: "Browser global",
+  },
+};
+
+function parseArgs(args) {
+  const options = {
+    distDir: "dist",
+    packageJsonPath: "package.json",
+    reportPath: "bundle-size-report.md",
+    jsonPath: null,
+    baselinePath: null,
+    baselineLabel: "main",
+    currentLabel: "PR",
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const [flag, inlineValue] = arg.split("=", 2);
+    const value = inlineValue ?? args[index + 1];
+
+    if (inlineValue === undefined && flag.startsWith("--")) {
+      index += 1;
+    }
+
+    switch (flag) {
+      case "--dist":
+        options.distDir = value;
+        break;
+      case "--package":
+        options.packageJsonPath = value;
+        break;
+      case "--markdown":
+        options.reportPath = value;
+        break;
+      case "--json":
+        options.jsonPath = value;
+        break;
+      case "--baseline":
+        options.baselinePath = value;
+        break;
+      case "--baseline-label":
+        options.baselineLabel = value;
+        break;
+      case "--current-label":
+        options.currentLabel = value;
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+
+  return options;
+}
+
+async function listFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        return listFiles(fullPath);
+      }
+
+      if (entry.isFile()) {
+        return [fullPath];
+      }
+
+      return [];
+    })
+  );
+
+  return files.flat();
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  return `${(bytes / 1024).toFixed(2)} KiB`;
+}
+
+function formatDelta(bytes) {
+  if (bytes === 0) {
+    return "0 B";
+  }
+
+  const sign = bytes > 0 ? "+" : "-";
+  return `${sign}${formatBytes(Math.abs(bytes))}`;
+}
+
+function escapeMarkdownCell(value) {
+  return value.replaceAll("|", "\\|");
+}
+
+function compareArtifacts(left, right) {
+  const order = ["xote.mjs", "xote.cjs", "xote.umd.js"];
+  const leftIndex = order.indexOf(left.name);
+  const rightIndex = order.indexOf(right.name);
+
+  if (leftIndex !== -1 || rightIndex !== -1) {
+    return (
+      (leftIndex === -1 ? order.length : leftIndex) -
+      (rightIndex === -1 ? order.length : rightIndex)
+    );
+  }
+
+  return left.name.localeCompare(right.name);
+}
+
+async function makeSnapshot({ distDir, packageJsonPath }) {
+  const resolvedDistDir = path.resolve(distDir);
+  const resolvedPackageJsonPath = path.resolve(packageJsonPath);
+  const files = (await listFiles(resolvedDistDir)).sort((a, b) => a.localeCompare(b));
+
+  if (files.length === 0) {
+    throw new Error(`No files found in ${resolvedDistDir}`);
+  }
+
+  const packageJson = JSON.parse(await readFile(resolvedPackageJsonPath, "utf-8"));
+  const rows = await Promise.all(
+    files.map(async (filePath) => {
+      const contents = await readFile(filePath);
+      const fileStat = await stat(filePath);
+      const name = path.relative(resolvedDistDir, filePath);
+      const metadata = artifactMetadata[name] ?? {
+        format: path.extname(name).slice(1).toUpperCase() || "File",
+        consumer: "Additional artifact",
+      };
+
+      return {
+        name,
+        ...metadata,
+        raw: fileStat.size,
+        gzip: gzipSync(contents, { level: 9 }).length,
+        brotli: brotliCompressSync(contents).length,
+      };
+    })
+  );
+
+  rows.sort(compareArtifacts);
+
+  return {
+    packageName: packageJson.name,
+    module: packageJson.module ?? null,
+    main: packageJson.main ?? null,
+    files: rows,
+  };
+}
+
+function renderCurrentTable(snapshot) {
+  return [
+    "| Artifact | Format | Consumer | Raw | Gzip | Brotli |",
+    "| --- | --- | --- | ---: | ---: | ---: |",
+    ...snapshot.files.map(
+      (row) =>
+        `| \`${escapeMarkdownCell(row.name)}\` | ${escapeMarkdownCell(row.format)} | ${row.consumer} | ${formatBytes(
+          row.raw
+        )} | ${formatBytes(row.gzip)} | ${formatBytes(row.brotli)} |`
+    ),
+  ];
+}
+
+function renderComparisonTable({ baseline, current, baselineLabel, currentLabel }) {
+  const rowsByName = new Map();
+
+  for (const row of baseline.files) {
+    rowsByName.set(row.name, { baseline: row, current: null });
+  }
+
+  for (const row of current.files) {
+    const existing = rowsByName.get(row.name) ?? { baseline: null, current: null };
+    existing.current = row;
+    rowsByName.set(row.name, existing);
+  }
+
+  const rows = Array.from(rowsByName.entries())
+    .map(([name, values]) => ({
+      name,
+      format: values.current?.format ?? values.baseline?.format ?? "",
+      consumer: values.current?.consumer ?? values.baseline?.consumer ?? "",
+      ...values,
+    }))
+    .sort(compareArtifacts);
+
+  return [
+    `| Artifact | Format | Consumer | Raw (${baselineLabel}) | Raw (${currentLabel}) | Δ Raw | Gzip (${baselineLabel}) | Gzip (${currentLabel}) | Δ Gzip | Brotli (${baselineLabel}) | Brotli (${currentLabel}) | Δ Brotli |`,
+    "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ...rows.map(({ name, format, consumer, baseline: base, current: head }) => {
+      const rawDelta = base && head ? formatDelta(head.raw - base.raw) : head ? "new" : "removed";
+      const gzipDelta = base && head ? formatDelta(head.gzip - base.gzip) : head ? "new" : "removed";
+      const brotliDelta = base && head ? formatDelta(head.brotli - base.brotli) : head ? "new" : "removed";
+
+      return `| \`${escapeMarkdownCell(name)}\` | ${escapeMarkdownCell(format)} | ${consumer} | ${
+        base ? formatBytes(base.raw) : "-"
+      } | ${head ? formatBytes(head.raw) : "-"} | ${rawDelta} | ${
+        base ? formatBytes(base.gzip) : "-"
+      } | ${head ? formatBytes(head.gzip) : "-"} | ${gzipDelta} | ${
+        base ? formatBytes(base.brotli) : "-"
+      } | ${head ? formatBytes(head.brotli) : "-"} | ${brotliDelta} |`;
+    }),
+  ];
+}
+
+function renderReport({ current, baseline, baselineLabel, currentLabel }) {
+  const lines = baseline
+    ? ["## Bundle Size", "", ...renderComparisonTable({ baseline, current, baselineLabel, currentLabel })]
+    : ["## Bundle Size", "", ...renderCurrentTable(current)];
+
+  const commit = process.env.GITHUB_SHA ? process.env.GITHUB_SHA.slice(0, 7) : null;
+
+  if (commit) {
+    lines.push("", `Commit: \`${commit}\``);
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+const options = parseArgs(process.argv.slice(2));
+const current = await makeSnapshot(options);
+const baseline = options.baselinePath
+  ? JSON.parse(await readFile(path.resolve(options.baselinePath), "utf-8"))
+  : null;
+const report = renderReport({
+  current,
+  baseline,
+  baselineLabel: options.baselineLabel,
+  currentLabel: options.currentLabel,
+});
+
+await writeFile(path.resolve(options.reportPath), report);
+
+if (options.jsonPath) {
+  await writeFile(path.resolve(options.jsonPath), `${JSON.stringify(current, null, 2)}\n`);
+}
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, report);
+}
+
+console.log(report);


### PR DESCRIPTION
## Summary

Adds a CI bundle-size report for production builds and posts it as a sticky pull request comment. On PRs, CI also builds the base SHA and includes a size delta against `main`.

## Changes

- Adds `scripts/bundle-size-report.mjs` to measure raw, gzip, and Brotli sizes for every file in `dist/`.
- Adds `npm run bundle:size` for local and CI report generation.
- Updates CI to snapshot the PR build, snapshot the PR base build in a temporary worktree, and render a condensed PR comment with current sizes plus deltas.
- Ignores generated bundle-size Markdown and JSON snapshots locally.

## Validation

- `npm run build`
- `npm run bundle:size -- --json bundle-size-current.json`
- Simulated `origin/main` worktree comparison flow
- `git diff --check`