### PR TITLE
ci: use Node 24 for docs deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: 24.10.0
           cache: "npm"
 
       - name: Install root dependencies


### PR DESCRIPTION
## Summary

- Update the GitHub Pages docs deploy workflow to run on Node 24.10.0.
- Align the docs deploy environment with the main CI and release workflows.

## Root Cause

The docs deployment was failing before the website build started. The `Install root dependencies` step ran `npm ci` under Node 20/npm 10, and npm rejected the current root lockfile as out of sync. The root dependency tree now includes tooling that requires Node `^22.14.0 || >=24.10.0`, so the docs workflow had drifted behind the rest of CI.

## Validation

- `npm ci --dry-run`
- `cd docs-website && npm ci --dry-run`
- `npm run docs:build`