### PR TITLE
Improve TypeScript support, generate types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .bsb.lock
 .merlin
 *.res.mjs
+*.gen.tsx
 bundlemeta.json
 bundle-size-report.md
 bundle-size-*.json

--- a/dist/client.d.ts
+++ b/dist/client.d.ts
@@ -1,0 +1,7 @@
+export * as View from "./types/src/View.js";
+export * as Html from "./types/src/Html.js";
+export * as Prop from "./types/src/Prop.js";
+export * as Signal from "./types/src/Signal.js";
+export * as Computed from "./types/src/Computed.js";
+export * as Effect from "./types/src/Effect.js";
+export const XoteJSX: unknown;

--- a/dist/computed.d.ts
+++ b/dist/computed.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/Computed.js";

--- a/dist/effect.d.ts
+++ b/dist/effect.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/Effect.js";

--- a/dist/html.d.ts
+++ b/dist/html.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/Html.js";

--- a/dist/hydration.d.ts
+++ b/dist/hydration.d.ts
@@ -1,0 +1,2 @@
+export * from "./types/src/Hydration.js";
+export * as Hydration from "./types/src/Hydration.js";

--- a/dist/jsx-dev-runtime.d.ts
+++ b/dist/jsx-dev-runtime.d.ts
@@ -1,0 +1,4 @@
+import { jsx } from "./jsx-runtime.js";
+
+export { Fragment, jsx, jsxs } from "./jsx-runtime.js";
+export const jsxDEV: typeof jsx;

--- a/dist/jsx-runtime.d.ts
+++ b/dist/jsx-runtime.d.ts
@@ -1,0 +1,5 @@
+import type { node as View_node } from "./types/src/View.js";
+
+export const Fragment: symbol;
+export const jsx: (type: unknown, props: Record<string, unknown> | null, key?: unknown) => View_node;
+export const jsxs: typeof jsx;

--- a/dist/jsx.d.ts
+++ b/dist/jsx.d.ts
@@ -1,0 +1,1 @@
+export const XoteJSX: unknown;

--- a/dist/mdx.d.ts
+++ b/dist/mdx.d.ts
@@ -1,0 +1,2 @@
+export * from "./types/src/Mdx.js";
+export * as Mdx from "./types/src/Mdx.js";

--- a/dist/node.d.ts
+++ b/dist/node.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/View.js";

--- a/dist/prop.d.ts
+++ b/dist/prop.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/Prop.js";

--- a/dist/reactive-prop.d.ts
+++ b/dist/reactive-prop.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/Prop.js";

--- a/dist/route.d.ts
+++ b/dist/route.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/Route.js";

--- a/dist/router.d.ts
+++ b/dist/router.d.ts
@@ -1,0 +1,3 @@
+export * from "./types/src/Router.js";
+export * as Router from "./types/src/Router.js";
+export * as Route from "./types/src/Route.js";

--- a/dist/signal.d.ts
+++ b/dist/signal.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/Signal.js";

--- a/dist/ssr-context.d.ts
+++ b/dist/ssr-context.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/SSRContext.js";

--- a/dist/ssr-state.d.ts
+++ b/dist/ssr-state.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/SSRState.js";

--- a/dist/ssr.d.ts
+++ b/dist/ssr.d.ts
@@ -1,0 +1,4 @@
+export * from "./types/src/SSR.js";
+export * as SSR from "./types/src/SSR.js";
+export * as SSRContext from "./types/src/SSRContext.js";
+export * as SSRState from "./types/src/SSRState.js";

--- a/dist/types/src/Computed.d.ts
+++ b/dist/types/src/Computed.d.ts
@@ -1,0 +1,14 @@
+/* TypeScript declarations generated from TypeScriptComputed.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+import type { t as Signal_t } from './Signal.js';
+
+export const makeWithoutEquals: <a>(compute: () => a, name?: string) => Signal_t<a>;
+
+export const makeWithEquals: <a>(compute: () => a, equalsFn: (_1: a, _2: a) => boolean, name?: string) => Signal_t<a>;
+
+export const make: <a>(compute: () => a, name?: string, equals?: (_1: a, _2: a) => boolean) => Signal_t<a>;
+
+export const dispose: <a>(signal:Signal_t<a>) => void;

--- a/dist/types/src/Effect.d.ts
+++ b/dist/types/src/Effect.d.ts
@@ -1,0 +1,10 @@
+/* TypeScript declarations generated from TypeScriptEffect.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+export type disposer = { readonly dispose: () => void };
+
+export const runWithDisposer: (fn: () => undefined | (() => void), name?: string) => disposer;
+
+export const run: (fn: () => undefined | (() => void), name?: string) => void;

--- a/dist/types/src/Html.d.ts
+++ b/dist/types/src/Html.d.ts
@@ -1,0 +1,38 @@
+/* TypeScript declarations generated from TypeScriptHtml.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+type Dom_event = Event;
+
+import type { attrValue as View_attrValue } from './View.js';
+
+import type { node as View_node } from './View.js';
+
+export type attrs = Array<[string, View_attrValue]>;
+
+export type events = Array<[string, (_1:Dom_event) => void]>;
+
+export type children = View_node[];
+
+export const div: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const span: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const button: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const input: (attrs?: attrs, events?: events) => View_node;
+
+export const h1: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const h2: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const h3: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const p: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const ul: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const li: (attrs?: attrs, events?: events, children?: children) => View_node;
+
+export const a: (attrs?: attrs, events?: events, children?: children) => View_node;

--- a/dist/types/src/Hydration.d.ts
+++ b/dist/types/src/Hydration.d.ts
@@ -1,0 +1,14 @@
+/* TypeScript declarations generated from TypeScriptHydration.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+type Dom_element = Element;
+
+import type { node as View_node } from './View.js';
+
+export type hydrateOptions = { readonly renderId?: string; readonly onHydrated?: () => void };
+
+export const hydrate: (component: () => View_node, container: Dom_element, options?: hydrateOptions) => void;
+
+export const hydrateById: (component: () => View_node, containerId: string, options?: hydrateOptions) => void;

--- a/dist/types/src/Mdx.d.ts
+++ b/dist/types/src/Mdx.d.ts
@@ -1,0 +1,24 @@
+/* TypeScript declarations generated from TypeScriptMdx.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+import type { node as View_node } from './View.js';
+
+export type children = unknown;
+
+export type components = {[id: string]: (_1:unknown) => View_node};
+
+export type props = { readonly components?: components };
+
+export type document = (_1:props) => View_node;
+
+export const component: <props>(make:((_1:props) => View_node)) => (_1:unknown) => View_node;
+
+export const components: (entries:Array<[string, ((_1:unknown) => View_node)]>) => components;
+
+export const render: (document: document, components?: components) => View_node;
+
+export const childrenToNodes: (children:children) => View_node[];
+
+export const childrenToText: (children:children) => string;

--- a/dist/types/src/Prop.d.ts
+++ b/dist/types/src/Prop.d.ts
@@ -1,0 +1,16 @@
+/* TypeScript declarations generated from TypeScriptProp.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+import type { t as Signal_t } from './Signal.js';
+
+export abstract class t<a> { protected opaque: a; } /* simulate opaque types */
+
+export const get: <a>(value:t<a>) => a;
+
+export const static: <a>(value:a) => t<a>;
+
+export const reactive: <a>(signal:Signal_t<a>) => t<a>;
+
+export const signal: <T1>(_1:Signal_t<T1>) => t<T1>;

--- a/dist/types/src/Route.d.ts
+++ b/dist/types/src/Route.d.ts
@@ -1,0 +1,22 @@
+/* TypeScript declarations generated from TypeScriptRoute.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+export type params = {[id: string]: string};
+
+export abstract class segment { protected opaque: any; } /* simulate opaque types */
+
+export type matchResult = "NoMatch" | { TAG: "Match"; _0: params };
+
+export const parsePattern: (pattern:string) => segment[];
+
+export const matchPath: (pattern:segment[], pathname:string) => matchResult;
+
+export const match: (pattern:string, pathname:string) => matchResult;
+
+export const compile: (_1:string) => segment[];
+
+export const matchCompiled: (_1:segment[], _2:string) => matchResult;
+
+export const matchPathname: (_1:string, _2:string) => matchResult;

--- a/dist/types/src/Router.d.ts
+++ b/dist/types/src/Router.d.ts
@@ -1,0 +1,42 @@
+/* TypeScript declarations generated from TypeScriptRouter.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+import type { attrValue as View_attrValue } from './View.js';
+
+import type { node as View_node } from './View.js';
+
+import type { params as Route_params } from './Route.js';
+
+import type { t as Signal_t } from './Signal.js';
+
+export type location = {
+  readonly pathname: string; 
+  readonly search: string; 
+  readonly hash: string
+};
+
+export type routeConfig = { readonly pattern: string; readonly render: (_1:Route_params) => View_node };
+
+export const init: (basePath?: string) => void;
+
+export const initSSR: (basePath?: string, pathname?: string, search?: string, hash?: string) => void;
+
+export const location: () => Signal_t<location>;
+
+export const push: (pathname: string, search?: string, hash?: string) => void;
+
+export const replace: (pathname: string, search?: string, hash?: string) => void;
+
+export const route: (pattern:string, render:((_1:Route_params) => View_node)) => View_node;
+
+export const routes: (configs:routeConfig[]) => View_node;
+
+export const link: (to: string, attrs?: Array<[string, View_attrValue]>, children?: View_node[]) => View_node;
+
+export const normalizeBasePath: (_1:string) => string;
+
+export const stripBasePath: (_1:string) => string;
+
+export const addBasePath: (_1:string) => string;

--- a/dist/types/src/SSR.d.ts
+++ b/dist/types/src/SSR.d.ts
@@ -1,0 +1,18 @@
+/* TypeScript declarations generated from TypeScriptSSR.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+import type { node as View_node } from './View.js';
+
+export type renderOptions = { readonly nonce?: string; readonly renderId?: string };
+
+export const renderNodeToString: (node:View_node) => string;
+
+export const renderToString: (component: () => View_node, options?: renderOptions) => string;
+
+export const renderToStringWithRoot: (component: () => View_node, rootId?: string, options?: renderOptions) => string;
+
+export const generateHydrationScript: (nonce?: string) => string;
+
+export const renderDocument: (head: string | undefined, bodyAttrs: string | undefined, scripts: string[] | undefined, styles: string[] | undefined, stateScript: string | undefined, nonce: string | undefined, component: () => View_node) => string;

--- a/dist/types/src/SSRContext.d.ts
+++ b/dist/types/src/SSRContext.d.ts
@@ -1,0 +1,14 @@
+/* TypeScript declarations generated from TypeScriptSSRContext.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+export const isServer: boolean;
+
+export const isClient: boolean;
+
+export const onServer: <T1>(_1:(() => T1)) => (undefined | T1);
+
+export const onClient: <T1>(_1:(() => T1)) => (undefined | T1);
+
+export const match: <a>(server:(() => a), client:(() => a)) => a;

--- a/dist/types/src/SSRState.d.ts
+++ b/dist/types/src/SSRState.d.ts
@@ -1,0 +1,30 @@
+import type { t as Signal_t } from "./Signal.js";
+
+export type Json = unknown;
+export type Codec_t<a> = {
+  readonly encode: (value: a) => Json;
+  readonly decode: (json: Json) => undefined | a;
+};
+
+export const Codec: {
+  readonly int: Codec_t<number>;
+  readonly float: Codec_t<number>;
+  readonly string: Codec_t<string>;
+  readonly bool: Codec_t<boolean>;
+  readonly array: <a>(itemCodec: Codec_t<a>) => Codec_t<a[]>;
+  readonly option: <a>(itemCodec: Codec_t<a>) => Codec_t<a | undefined>;
+  readonly tuple2: <a, b>(codec1: Codec_t<a>, codec2: Codec_t<b>) => Codec_t<[a, b]>;
+  readonly tuple3: <a, b, c>(codec1: Codec_t<a>, codec2: Codec_t<b>, codec3: Codec_t<c>) => Codec_t<[a, b, c]>;
+  readonly dict: <a>(valueCodec: Codec_t<a>) => Codec_t<Record<string, a>>;
+  readonly make: <a>(encode: (value: a) => Json, decode: (json: Json) => undefined | a) => Codec_t<a>;
+};
+
+export const register: <a>(id: string, signal: Signal_t<a>, codec: Codec_t<a>) => void;
+export const clear: () => void;
+export const generateScript: (nonce?: string) => string;
+export const getClientState: () => Record<string, Json>;
+export const restore: <a>(id: string, signal: Signal_t<a>, codec: Codec_t<a>) => void;
+export const sync: <a>(id: string, signal: Signal_t<a>, codec: Codec_t<a>) => void;
+export const make: <a>(id: string, initial: a, codec: Codec_t<a>) => Signal_t<a>;
+export const signal: typeof make;
+export const syncSignal: typeof sync;

--- a/dist/types/src/Signal.d.ts
+++ b/dist/types/src/Signal.d.ts
@@ -1,0 +1,26 @@
+/* TypeScript declarations generated from TypeScriptSignal.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+export abstract class t<a> { protected opaque: a; } /* simulate opaque types */
+
+export const defaultEquals: <T1>(_1:T1, _2:T1) => boolean;
+
+export const neverEquals: <T1>(_1:T1, _2:T1) => boolean;
+
+export const make: <a>(initialValue: a, name?: string, equals?: (_1: a, _2: a) => boolean) => t<a>;
+
+export const makeForComputed: <a>(initialValue: a, name?: string) => t<a>;
+
+export const get: <a>(signal:t<a>) => a;
+
+export const peek: <a>(signal:t<a>) => a;
+
+export const set: <a>(signal:t<a>, newValue:a) => void;
+
+export const update: <a>(signal:t<a>, fn:((_1:a) => a)) => void;
+
+export const batch: <T1>(_1:(() => T1)) => T1;
+
+export const untrack: <T1>(_1:(() => T1)) => T1;

--- a/dist/types/src/View.d.ts
+++ b/dist/types/src/View.d.ts
@@ -1,0 +1,51 @@
+/* TypeScript declarations generated from TypeScriptView.res via genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+type Dom_element = Element;
+type Dom_event = Event;
+
+import type { t as Signal_t } from './Signal.js';
+
+export abstract class attrValue { protected opaque: any; } /* simulate opaque types */
+
+export abstract class node { protected opaque: any; } /* simulate opaque types */
+
+export type eventHandler = (_1:Dom_event) => void;
+
+export const attr: (key:string, value:string) => [string, attrValue];
+
+export const signalAttr: (key:string, signal:Signal_t<string>) => [string, attrValue];
+
+export const computedAttr: (key:string, compute:(() => string)) => [string, attrValue];
+
+export const text: (content:string) => node;
+
+export const signalText: (compute:(() => string)) => node;
+
+export const signalInt: (compute:(() => number)) => node;
+
+export const signalFloat: (compute:(() => number)) => node;
+
+export const int: (value:number) => node;
+
+export const float: (value:number) => node;
+
+export const bool: (value:boolean) => node;
+
+export const fragment: (children:node[]) => node;
+
+export const signalFragment: (signal:Signal_t<node[]>) => node;
+
+export const each: <a>(signal:Signal_t<a[]>, renderItem:((_1:a) => node)) => node;
+
+export const eachWithKey: <a>(signal:Signal_t<a[]>, keyFn:((_1:a) => string), renderItem:((_1:a) => node)) => node;
+
+export const element: (tag: string, attrs?: Array<[string, attrValue]>, events?: Array<[string, eventHandler]>, children?: node[]) => node;
+
+export const $$null: () => node;
+
+export const mount: (node:node, container:Dom_element) => void;
+
+export const mountById: (node:node, containerId:string) => void;

--- a/dist/view.d.ts
+++ b/dist/view.d.ts
@@ -1,0 +1,1 @@
+export * from "./types/src/View.js";

--- a/dist/xote.d.ts
+++ b/dist/xote.d.ts
@@ -1,0 +1,7 @@
+export * as View from "./types/src/View.js";
+export * as Html from "./types/src/Html.js";
+export * as Prop from "./types/src/Prop.js";
+export * as Signal from "./types/src/Signal.js";
+export * as Computed from "./types/src/Computed.js";
+export * as Effect from "./types/src/Effect.js";
+export const XoteJSX: unknown;

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,31 @@
+# Xote TypeScript Example
+
+A Vite TypeScript frontend that consumes Xote through the public `xote/client` entry.
+
+It demonstrates:
+
+- `Signal.make`, `Signal.get`, `Signal.peek`, `Signal.set`, `Signal.update`, and `Signal.batch`
+- `Computed.make` for filtered and derived state
+- `Effect.run` for a DOM side effect
+- `View.signalText`, `View.signalAttr`, and `View.computedAttr`
+- `View.eachWithKey` for keyed list rendering
+- `Router.init`, `Router.routes`, `Router.link`, and `Router.location`
+- `Html` constructors for building UI from TypeScript without ReScript JSX
+
+Routes:
+
+- `/` shows the task list
+- `/tasks/:id` shows a task detail view backed by the same signal state
+
+From the repository root:
+
+```bash
+npm run build
+npm run example:typescript
+```
+
+For a production check:
+
+```bash
+npm run example:typescript:build
+```

--- a/examples/typescript/index.html
+++ b/examples/typescript/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Xote TypeScript Example</title>
+  </head>
+  <body>
+    <main id="app"></main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/typescript/src/main.ts
+++ b/examples/typescript/src/main.ts
@@ -1,0 +1,371 @@
+import { Computed, Effect, Html, Signal, View } from "xote/client";
+import { Router } from "xote/router";
+import "./styles.css";
+
+type Todo = {
+  id: string;
+  title: string;
+  done: boolean;
+};
+
+type Filter = "all" | "active" | "done";
+
+const todos = Signal.make<Todo[]>(
+  [
+    { id: "task-plan", title: "Sketch the UI state", done: true },
+    {
+      id: "task-signals",
+      title: "Wire signals and computed views",
+      done: false,
+    },
+    { id: "task-polish", title: "Add the finishing interactions", done: false },
+  ],
+  "todos",
+);
+const draft = Signal.make("", "draft");
+const filter = Signal.make<Filter>("all", "filter");
+
+Router.init();
+
+const currentPath = Computed.make(
+  () => Signal.get(Router.location()).pathname,
+  "currentPath",
+);
+
+const visibleTodos = Computed.make(() => {
+  const currentFilter = Signal.get(filter);
+  const currentTodos = Signal.get(todos);
+
+  if (currentFilter === "active") {
+    return currentTodos.filter((todo) => !todo.done);
+  }
+
+  if (currentFilter === "done") {
+    return currentTodos.filter((todo) => todo.done);
+  }
+
+  return currentTodos;
+}, "visibleTodos");
+
+const remainingCount = Computed.make(
+  () => Signal.get(todos).filter((todo) => !todo.done).length,
+  "remainingCount",
+);
+
+const completionLabel = Computed.make(() => {
+  const total = Signal.get(todos).length;
+  const remaining = Signal.get(remainingCount);
+  const completed = total - remaining;
+
+  if (total === 0) {
+    return "No tasks yet";
+  }
+
+  return `${completed} of ${total} complete`;
+}, "completionLabel");
+
+Effect.run(() => {
+  const path = Signal.get(currentPath);
+  document.title =
+    path === "/"
+      ? `${Signal.get(remainingCount)} remaining - Xote TypeScript`
+      : "Task detail - Xote TypeScript";
+  return undefined;
+}, "documentTitle");
+
+const addTodo = () => {
+  const title = Signal.peek(draft).trim();
+
+  if (title === "") {
+    return;
+  }
+
+  Signal.batch(() => {
+    Signal.update(todos, (items) => [
+      ...items,
+      {
+        id: `task-${Date.now()}`,
+        title,
+        done: false,
+      },
+    ]);
+    Signal.set(draft, "");
+  });
+};
+
+const toggleTodo = (id: string) => {
+  Signal.update(todos, (items) =>
+    items.map((todo) =>
+      todo.id === id ? { ...todo, done: !todo.done } : todo,
+    ),
+  );
+};
+
+const removeTodo = (id: string) => {
+  Signal.update(todos, (items) => items.filter((todo) => todo.id !== id));
+
+  if (Signal.peek(currentPath) === `/tasks/${id}`) {
+    Router.replace("/");
+  }
+};
+
+const clearCompleted = () => {
+  Signal.update(todos, (items) => items.filter((todo) => !todo.done));
+};
+
+const setDraftFromInput = (event: Event) => {
+  Signal.set(draft, (event.currentTarget as HTMLInputElement).value);
+};
+
+const handleComposerKeydown = (event: Event) => {
+  const keyboardEvent = event as KeyboardEvent;
+
+  if (keyboardEvent.key === "Enter") {
+    addTodo();
+  }
+};
+
+const button = (label: string, onClick: () => void, className = "button") =>
+  Html.button(
+    [View.attr("type", "button"), View.attr("class", className)],
+    [["click", onClick]],
+    [View.text(label)],
+  );
+
+const filterButton = (target: Filter, label: string) =>
+  Html.button(
+    [
+      View.attr("type", "button"),
+      View.computedAttr("class", () =>
+        Signal.get(filter) === target ? "filter is-active" : "filter",
+      ),
+      View.computedAttr("aria-pressed", () =>
+        Signal.get(filter) === target ? "true" : "false",
+      ),
+    ],
+    [["click", () => Signal.set(filter, target)]],
+    [View.text(label)],
+  );
+
+const navLink = (to: string, label: string) =>
+  Router.link(
+    to,
+    [
+      View.computedAttr("class", () =>
+        Signal.get(currentPath) === to ? "nav-link is-active" : "nav-link",
+      ),
+    ],
+    [View.text(label)],
+  );
+
+const todoItem = (todo: Todo) =>
+  Html.li(
+    [
+      View.attr("class", todo.done ? "todo is-done" : "todo"),
+      View.attr("data-id", todo.id),
+    ],
+    [],
+    [
+      Html.button(
+        [
+          View.attr("type", "button"),
+          View.attr("class", "toggle"),
+          View.attr("aria-label", todo.done ? "Mark active" : "Mark complete"),
+        ],
+        [["click", () => toggleTodo(todo.id)]],
+        [View.text(todo.done ? "Done" : "Todo")],
+      ),
+      Html.span(
+        [View.attr("class", "todo-title")],
+        [],
+        [
+          Router.link(
+            `/tasks/${todo.id}`,
+            [View.attr("class", "task-link")],
+            [View.text(todo.title)],
+          ),
+        ],
+      ),
+      Html.button(
+        [
+          View.attr("type", "button"),
+          View.attr("class", "remove"),
+          View.attr("aria-label", `Remove ${todo.title}`),
+        ],
+        [["click", () => removeTodo(todo.id)]],
+        [View.text("Remove")],
+      ),
+    ],
+  );
+
+const tasksPage = () =>
+  View.fragment([
+    Html.div(
+      [View.attr("class", "panel composer")],
+      [],
+      [
+        Html.input(
+          [
+            View.attr("type", "text"),
+            View.attr("placeholder", "Add a task"),
+            View.attr("aria-label", "New task"),
+            View.signalAttr("value", draft),
+          ],
+          [
+            ["input", setDraftFromInput],
+            ["keydown", handleComposerKeydown],
+          ],
+        ),
+        button("Add task", addTodo, "button primary"),
+      ],
+    ),
+    Html.div(
+      [View.attr("class", "toolbar")],
+      [],
+      [
+        Html.div(
+          [View.attr("class", "filters")],
+          [],
+          [
+            filterButton("all", "All"),
+            filterButton("active", "Active"),
+            filterButton("done", "Done"),
+          ],
+        ),
+        Html.div(
+          [View.attr("class", "status")],
+          [],
+          [View.signalText(() => Signal.get(completionLabel))],
+        ),
+      ],
+    ),
+    Html.ul(
+      [View.attr("class", "todo-list")],
+      [],
+      [
+        View.eachWithKey(
+          visibleTodos,
+          (todo) => todo.id,
+          (todo) => todoItem(todo),
+        ),
+      ],
+    ),
+    Html.div(
+      [View.attr("class", "panel footer")],
+      [],
+      [
+        Html.span(
+          [],
+          [],
+          [
+            View.signalText(() => {
+              const count = Signal.get(remainingCount);
+              return `${count} ${count === 1 ? "task" : "tasks"} remaining`;
+            }),
+          ],
+        ),
+        button("Clear completed", clearCompleted),
+      ],
+    ),
+  ]);
+
+const taskDetailPage = (id: string | undefined) =>
+  View.signalFragment(
+    Computed.make(() => {
+      const task = Signal.get(todos).find((todo) => todo.id === id);
+
+      if (!task) {
+        return [
+          Html.div(
+            [View.attr("class", "detail-panel")],
+            [],
+            [
+              Html.h2([], [], [View.text("Task not found")]),
+              Html.p([], [], [
+                View.text("The selected task is no longer in the list."),
+              ]),
+              Router.link("/", [View.attr("class", "button inline-link")], [
+                View.text("Back to tasks"),
+              ]),
+            ],
+          ),
+        ];
+      }
+
+      return [
+        Html.div(
+          [View.attr("class", "detail-panel")],
+          [],
+          [
+            Router.link("/", [View.attr("class", "back-link")], [
+              View.text("Back to tasks"),
+            ]),
+            Html.h2([], [], [View.text(task.title)]),
+            Html.p([], [], [
+              View.text(
+                task.done
+                  ? "This task is complete."
+                  : "This task is still active.",
+              ),
+            ]),
+            Html.div(
+              [View.attr("class", "detail-actions")],
+              [],
+              [
+                button(
+                  task.done ? "Mark active" : "Mark complete",
+                  () => toggleTodo(task.id),
+                  "button primary",
+                ),
+                button("Remove", () => removeTodo(task.id)),
+              ],
+            ),
+          ],
+        ),
+      ];
+    }, `taskDetail:${id ?? "missing"}`),
+  );
+
+const routes = Router.routes([
+  { pattern: "/", render: () => tasksPage() },
+  { pattern: "/tasks/:id", render: (params) => taskDetailPage(params.id) },
+]);
+
+const app = Html.div(
+  [View.attr("class", "app-shell")],
+  [],
+  [
+    Html.div(
+      [View.attr("class", "hero")],
+      [],
+      [
+        Html.h1([], [], [View.text("Tasks")]),
+        Html.p(
+          [],
+          [],
+          [
+            View.text(
+              "A small TypeScript frontend using Xote signals, computeds, effects, reactive attributes, keyed list rendering, and router-driven screens.",
+            ),
+          ],
+        ),
+      ],
+    ),
+    View.element(
+      "nav",
+      [View.attr("class", "app-nav"), View.attr("aria-label", "App")],
+      [],
+      [
+        navLink("/", "Tasks"),
+        Html.span(
+          [View.attr("class", "path-readout")],
+          [],
+          [View.signalText(() => `Current route: ${Signal.get(currentPath)}`)],
+        ),
+      ],
+    ),
+    routes,
+  ],
+);
+
+View.mountById(app, "app");

--- a/examples/typescript/src/styles.css
+++ b/examples/typescript/src/styles.css
@@ -1,0 +1,310 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  color: oklch(25% 0.032 252);
+  background: oklch(93% 0.018 236);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  width: min(920px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.hero {
+  margin-bottom: 24px;
+}
+
+.hero h1 {
+  margin: 0;
+  color: oklch(24% 0.06 239);
+  font-size: clamp(2.25rem, 6vw, 4.75rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.hero p {
+  max-width: 680px;
+  margin: 18px 0 0;
+  color: oklch(43% 0.05 239);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.app-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 24px 0 16px;
+}
+
+.nav-link,
+.back-link,
+.task-link,
+.inline-link {
+  color: oklch(42% 0.105 188);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.nav-link {
+  min-height: 40px;
+  border: 1px solid oklch(70% 0.04 236);
+  border-radius: 6px;
+  padding: 9px 16px;
+  background: oklch(99% 0.004 236);
+}
+
+.nav-link.is-active {
+  border-color: oklch(48% 0.105 188);
+  background: oklch(91% 0.045 188);
+}
+
+.path-readout {
+  color: oklch(43% 0.05 239);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.panel,
+.toolbar,
+.todo-list,
+.detail-panel {
+  border: 1px solid oklch(79% 0.03 236);
+  background: oklch(98% 0.008 82);
+  box-shadow: 0 18px 50px oklch(36% 0.04 239 / 0.12);
+}
+
+.panel {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 8px;
+}
+
+.composer input {
+  min-width: 0;
+  flex: 1;
+  height: 48px;
+  border: 1px solid oklch(73% 0.04 236);
+  border-radius: 6px;
+  padding: 0 14px;
+  background: oklch(99% 0.004 236);
+  color: oklch(25% 0.032 252);
+}
+
+.composer input:focus {
+  border-color: oklch(60% 0.18 246);
+  outline: 3px solid oklch(60% 0.18 246 / 0.18);
+}
+
+.button,
+.filter,
+.toggle,
+.remove {
+  min-height: 40px;
+  border: 1px solid oklch(70% 0.04 236);
+  border-radius: 6px;
+  background: oklch(99% 0.004 236);
+  color: oklch(31% 0.046 239);
+  font-weight: 700;
+}
+
+.button {
+  padding: 0 16px;
+}
+
+.button.primary {
+  border-color: oklch(48% 0.105 188);
+  background: oklch(48% 0.105 188);
+  color: oklch(98% 0.008 188);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 16px;
+  padding: 12px;
+  border-radius: 8px 8px 0 0;
+  border-bottom: 0;
+}
+
+.filters {
+  display: flex;
+  gap: 8px;
+}
+
+.filter {
+  min-width: 78px;
+  padding: 0 14px;
+}
+
+.filter.is-active {
+  border-color: oklch(43% 0.15 12);
+  background: oklch(43% 0.15 12);
+  color: oklch(98% 0.01 12);
+}
+
+.status {
+  min-width: 160px;
+  color: oklch(43% 0.05 239);
+  font-weight: 700;
+  text-align: right;
+}
+
+.todo-list {
+  display: grid;
+  gap: 0;
+  min-height: 76px;
+  margin: 0;
+  padding: 0;
+  border-radius: 0;
+  list-style: none;
+}
+
+.todo {
+  display: grid;
+  grid-template-columns: 74px minmax(0, 1fr) 92px;
+  align-items: center;
+  gap: 12px;
+  min-height: 68px;
+  padding: 12px;
+  border-top: 1px solid oklch(88% 0.026 236);
+}
+
+.todo:first-child {
+  border-top: 0;
+}
+
+.todo-title {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-weight: 700;
+}
+
+.todo.is-done .todo-title {
+  color: oklch(55% 0.026 247);
+  text-decoration: line-through;
+}
+
+.toggle {
+  color: oklch(42% 0.105 188);
+}
+
+.todo.is-done .toggle {
+  border-color: oklch(48% 0.105 188);
+  background: oklch(91% 0.045 188);
+}
+
+.remove {
+  color: oklch(43% 0.15 12);
+}
+
+.detail-panel {
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+  border-radius: 8px;
+}
+
+.detail-panel h2 {
+  margin: 0;
+  color: oklch(24% 0.06 239);
+  font-size: 1.65rem;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
+.detail-panel p {
+  margin: 0;
+  color: oklch(43% 0.05 239);
+  line-height: 1.6;
+}
+
+.detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.inline-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-self: start;
+  min-height: 40px;
+  padding: 0 16px;
+}
+
+.footer {
+  justify-content: space-between;
+  border-radius: 0 0 8px 8px;
+  border-top: 0;
+  color: oklch(43% 0.05 239);
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    width: min(100vw - 24px, 920px);
+    padding: 28px 0;
+  }
+
+  .panel,
+  .toolbar,
+  .app-nav {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .path-readout {
+    overflow-wrap: anywhere;
+  }
+
+  .filters {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .filter {
+    min-width: 0;
+  }
+
+  .status {
+    min-width: 0;
+    text-align: left;
+  }
+
+  .todo {
+    grid-template-columns: 72px minmax(0, 1fr);
+  }
+
+  .remove {
+    grid-column: 2;
+    justify-self: start;
+    padding: 0 14px;
+  }
+}

--- a/examples/typescript/src/vite-env.d.ts
+++ b/examples/typescript/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/examples/typescript/vite.config.mjs
+++ b/examples/typescript/vite.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
+  server: {
+    port: 3001,
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
       "import": "./src/Html.res.mjs",
       "default": "./src/Html.res.mjs"
     },
-    "./jsx": "./src/XoteJSX.res.mjs",
+    "./jsx": {
+      "types": "./dist/jsx.d.ts",
+      "import": "./src/XoteJSX.res.mjs",
+      "default": "./src/XoteJSX.res.mjs"
+    },
     "./prop": {
       "types": "./dist/prop.d.ts",
       "import": "./src/Prop.res.mjs",
@@ -46,25 +50,41 @@
       "import": "./src/ReactiveProp.res.mjs",
       "default": "./src/ReactiveProp.res.mjs"
     },
-    "./route": "./src/Route.res.mjs",
+    "./route": {
+      "types": "./dist/route.d.ts",
+      "import": "./src/Route.res.mjs",
+      "default": "./src/Route.res.mjs"
+    },
     "./router": {
+      "types": "./dist/router.d.ts",
       "import": "./dist/router.mjs",
       "require": "./dist/router.cjs",
       "default": "./dist/router.mjs"
     },
     "./ssr": {
+      "types": "./dist/ssr.d.ts",
       "import": "./dist/ssr.mjs",
       "require": "./dist/ssr.cjs",
       "default": "./dist/ssr.mjs"
     },
-    "./ssr-context": "./src/SSRContext.res.mjs",
-    "./ssr-state": "./src/SSRState.res.mjs",
+    "./ssr-context": {
+      "types": "./dist/ssr-context.d.ts",
+      "import": "./src/SSRContext.res.mjs",
+      "default": "./src/SSRContext.res.mjs"
+    },
+    "./ssr-state": {
+      "types": "./dist/ssr-state.d.ts",
+      "import": "./src/SSRState.res.mjs",
+      "default": "./src/SSRState.res.mjs"
+    },
     "./hydration": {
+      "types": "./dist/hydration.d.ts",
       "import": "./dist/hydration.mjs",
       "require": "./dist/hydration.cjs",
       "default": "./dist/hydration.mjs"
     },
     "./mdx": {
+      "types": "./dist/mdx.d.ts",
       "import": "./dist/mdx.mjs",
       "require": "./dist/mdx.cjs",
       "default": "./dist/mdx.mjs"
@@ -84,8 +104,16 @@
       "import": "./src/Effect.res.mjs",
       "default": "./src/Effect.res.mjs"
     },
-    "./jsx-runtime": "./src/jsx-runtime.mjs",
-    "./jsx-dev-runtime": "./src/jsx-dev-runtime.mjs",
+    "./jsx-runtime": {
+      "types": "./dist/jsx-runtime.d.ts",
+      "import": "./src/jsx-runtime.mjs",
+      "default": "./src/jsx-runtime.mjs"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./dist/jsx-dev-runtime.d.ts",
+      "import": "./src/jsx-dev-runtime.mjs",
+      "default": "./src/jsx-dev-runtime.mjs"
+    },
     "./src/*": "./src/*",
     "./package.json": "./package.json",
     "./rescript.json": "./rescript.json"
@@ -113,6 +141,8 @@
     "docs:start": "cd docs-website && npm run dev",
     "docs:build": "cd docs-website && npm run build",
     "docs:serve": "cd docs-website && npm run preview",
+    "example:typescript": "vite --config examples/typescript/vite.config.mjs",
+    "example:typescript:build": "vite build --config examples/typescript/vite.config.mjs",
     "test": "npx rescript && node tests/Tests.res.mjs && node tests/JSXRuntime_test.mjs"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,23 +6,46 @@
   },
   "main": "./dist/xote.cjs",
   "module": "./dist/xote.mjs",
+  "types": "./dist/client.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/client.d.ts",
       "import": "./dist/xote.mjs",
       "require": "./dist/xote.cjs",
       "default": "./dist/xote.mjs"
     },
     "./client": {
+      "types": "./dist/client.d.ts",
       "import": "./dist/client.mjs",
       "require": "./dist/client.cjs",
       "default": "./dist/client.mjs"
     },
-    "./view": "./src/View.res.mjs",
-    "./node": "./src/Node.res.mjs",
-    "./html": "./src/Html.res.mjs",
+    "./view": {
+      "types": "./dist/view.d.ts",
+      "import": "./src/View.res.mjs",
+      "default": "./src/View.res.mjs"
+    },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "import": "./src/Node.res.mjs",
+      "default": "./src/Node.res.mjs"
+    },
+    "./html": {
+      "types": "./dist/html.d.ts",
+      "import": "./src/Html.res.mjs",
+      "default": "./src/Html.res.mjs"
+    },
     "./jsx": "./src/XoteJSX.res.mjs",
-    "./prop": "./src/Prop.res.mjs",
-    "./reactive-prop": "./src/ReactiveProp.res.mjs",
+    "./prop": {
+      "types": "./dist/prop.d.ts",
+      "import": "./src/Prop.res.mjs",
+      "default": "./src/Prop.res.mjs"
+    },
+    "./reactive-prop": {
+      "types": "./dist/reactive-prop.d.ts",
+      "import": "./src/ReactiveProp.res.mjs",
+      "default": "./src/ReactiveProp.res.mjs"
+    },
     "./route": "./src/Route.res.mjs",
     "./router": {
       "import": "./dist/router.mjs",
@@ -46,9 +69,21 @@
       "require": "./dist/mdx.cjs",
       "default": "./dist/mdx.mjs"
     },
-    "./signal": "./src/Signal.res.mjs",
-    "./computed": "./src/Computed.res.mjs",
-    "./effect": "./src/Effect.res.mjs",
+    "./signal": {
+      "types": "./dist/signal.d.ts",
+      "import": "./src/Signal.res.mjs",
+      "default": "./src/Signal.res.mjs"
+    },
+    "./computed": {
+      "types": "./dist/computed.d.ts",
+      "import": "./src/Computed.res.mjs",
+      "default": "./src/Computed.res.mjs"
+    },
+    "./effect": {
+      "types": "./dist/effect.d.ts",
+      "import": "./src/Effect.res.mjs",
+      "default": "./src/Effect.res.mjs"
+    },
     "./jsx-runtime": "./src/jsx-runtime.mjs",
     "./jsx-dev-runtime": "./src/jsx-dev-runtime.mjs",
     "./src/*": "./src/*",
@@ -70,7 +105,8 @@
     "res:dev": "rescript -w",
     "format": "rescript format",
     "dev": "vite",
-    "build": "vite build && vite build --config vite.subpath.config.js",
+    "build": "vite build && vite build --config vite.subpath.config.js && node scripts/generate-types.mjs",
+    "types:generate": "npm run res:build && node scripts/generate-types.mjs",
     "bundle:size": "node scripts/bundle-size-report.mjs",
     "preview": "vite preview",
     "mdx:poc": "npm run res:build && vite build --config examples/mdx/vite.config.mjs",

--- a/rescript.json
+++ b/rescript.json
@@ -40,6 +40,11 @@
     "in-source": true
   },
   "suffix": ".res.mjs",
+  "gentypeconfig": {
+    "module": "esmodule",
+    "moduleResolution": "node16",
+    "generatedFileExtension": ".gen.tsx"
+  },
   "dependencies": [
     "@rescript/core",
     "rescript-signals"

--- a/scripts/generate-types.mjs
+++ b/scripts/generate-types.mjs
@@ -12,6 +12,12 @@ const modules = [
   { source: "TypeScriptProp", output: "Prop" },
   { source: "TypeScriptView", output: "View" },
   { source: "TypeScriptHtml", output: "Html" },
+  { source: "TypeScriptRoute", output: "Route" },
+  { source: "TypeScriptRouter", output: "Router" },
+  { source: "TypeScriptSSR", output: "SSR" },
+  { source: "TypeScriptSSRContext", output: "SSRContext" },
+  { source: "TypeScriptHydration", output: "Hydration" },
+  { source: "TypeScriptMdx", output: "Mdx" },
 ];
 
 const readGenType = (moduleName) => {
@@ -40,6 +46,7 @@ const normalizeImports = (source, moduleName) => {
     .replace(/import type \{node as View_node\} from '\.\/View\.gen\.js';/g, "import type { node as View_node } from './View.js';")
     .replace(/import type \{attrValue as TypeScriptView_attrValue\} from '\.\/TypeScriptView\.gen\.js';/g, "import type { attrValue as View_attrValue } from './View.js';")
     .replace(/import type \{node as TypeScriptView_node\} from '\.\/TypeScriptView\.gen\.js';/g, "import type { node as View_node } from './View.js';")
+    .replace(/import type \{params as TypeScriptRoute_params\} from '\.\/TypeScriptRoute\.gen\.js';/g, "import type { params as Route_params } from './Route.js';")
     .replace(/import type \{element as Dom_element\} from '\.\/Dom\.gen\.js';\n\n/g, () => {
       domAliases += "type Dom_element = Element;\n";
       return "";
@@ -49,7 +56,6 @@ const normalizeImports = (source, moduleName) => {
       return "";
     })
     .replace(/import type \{t as Obj_t\} from '\.\/Obj\.gen\.js';\n\n/g, () => {
-      domAliases += "type Obj_t = unknown;\n";
       return "";
     });
 
@@ -63,7 +69,9 @@ const normalizeImports = (source, moduleName) => {
   return normalized
     .replaceAll("TypeScriptSignal_t", "Signal_t")
     .replaceAll("TypeScriptView_attrValue", "View_attrValue")
-    .replaceAll("TypeScriptView_node", "View_node");
+    .replaceAll("TypeScriptView_node", "View_node")
+    .replaceAll("TypeScriptRoute_params", "Route_params")
+    .replaceAll("Obj_t", "unknown");
 };
 
 const normalizeDeclarations = (source, moduleName) => {
@@ -126,6 +134,70 @@ const normalizeDeclarations = (source, moduleName) => {
       .replace(/export const null: \(\) => node;/, () => "export const $$null: () => node;");
   }
 
+  if (moduleName === "Router") {
+    normalized = normalized
+      .replace(
+        /export const init: \(basePath:\(undefined \| string\)\) => void;/,
+        "export const init: (basePath?: string) => void;",
+      )
+      .replace(
+        /export const initSSR: \(basePath:\(undefined \| string\), pathname:\(undefined \| string\), search:\(undefined \| string\), hash:\(undefined \| string\)\) => void;/,
+        "export const initSSR: (basePath?: string, pathname?: string, search?: string, hash?: string) => void;",
+      )
+      .replace(
+        /export const push: \(pathname:string, search:\(undefined \| string\), hash:\(undefined \| string\)\) => void;/,
+        "export const push: (pathname: string, search?: string, hash?: string) => void;",
+      )
+      .replace(
+        /export const replace: \(pathname:string, search:\(undefined \| string\), hash:\(undefined \| string\)\) => void;/,
+        "export const replace: (pathname: string, search?: string, hash?: string) => void;",
+      )
+      .replace(
+        /export const link: \(to:string, attrs:\(undefined \| Array<\[string, View_attrValue\]>\), children:\(undefined \| View_node\[\]\)\) => View_node;/,
+        "export const link: (to: string, attrs?: Array<[string, View_attrValue]>, children?: View_node[]) => View_node;",
+      );
+  }
+
+  if (moduleName === "SSR") {
+    normalized = normalized
+      .replace(
+        /export const renderToString: \(component:\(\(\) => View_node\), options:\(undefined \| renderOptions\)\) => string;/,
+        "export const renderToString: (component: () => View_node, options?: renderOptions) => string;",
+      )
+      .replace(
+        /export const renderToStringWithRoot: \(component:\(\(\) => View_node\), rootId:\(undefined \| string\), options:\(undefined \| renderOptions\)\) => string;/,
+        "export const renderToStringWithRoot: (component: () => View_node, rootId?: string, options?: renderOptions) => string;",
+      )
+      .replace(
+        /export const generateHydrationScript: \(nonce:\(undefined \| string\)\) => string;/,
+        "export const generateHydrationScript: (nonce?: string) => string;",
+      )
+      .replace(
+        /export const renderDocument: \(component:\(\(\) => View_node\), head:\(undefined \| string\), bodyAttrs:\(undefined \| string\), scripts:\(undefined \| string\[\]\), styles:\(undefined \| string\[\]\), stateScript:\(undefined \| string\), nonce:\(undefined \| string\)\) => string;/,
+        "export const renderDocument: (head: string | undefined, bodyAttrs: string | undefined, scripts: string[] | undefined, styles: string[] | undefined, stateScript: string | undefined, nonce: string | undefined, component: () => View_node) => string;",
+      );
+  }
+
+  if (moduleName === "Hydration") {
+    normalized = normalized
+      .replace(
+        /export const hydrate: \(component:\(\(\) => View_node\), container:Dom_element, options:\(undefined \| hydrateOptions\)\) => void;/,
+        "export const hydrate: (component: () => View_node, container: Dom_element, options?: hydrateOptions) => void;",
+      )
+      .replace(
+        /export const hydrateById: \(component:\(\(\) => View_node\), containerId:string, options:\(undefined \| hydrateOptions\)\) => void;/,
+        "export const hydrateById: (component: () => View_node, containerId: string, options?: hydrateOptions) => void;",
+      );
+  }
+
+  if (moduleName === "Mdx") {
+    normalized = normalized
+      .replace(
+        /export const render: \(document:document, components:\(undefined \| components\)\) => View_node;/,
+        "export const render: (document: document, components?: components) => View_node;",
+      );
+  }
+
   if (moduleName === "Html") {
     normalized = normalized
       .replaceAll(
@@ -156,6 +228,40 @@ for (const { source, output } of modules) {
   write(join(outDir, `${output}.d.ts`), normalizeDeclarations(readGenType(source), output));
 }
 
+const ssrStateTypes = `import type { t as Signal_t } from "./Signal.js";
+
+export type Json = unknown;
+export type Codec_t<a> = {
+  readonly encode: (value: a) => Json;
+  readonly decode: (json: Json) => undefined | a;
+};
+
+export const Codec: {
+  readonly int: Codec_t<number>;
+  readonly float: Codec_t<number>;
+  readonly string: Codec_t<string>;
+  readonly bool: Codec_t<boolean>;
+  readonly array: <a>(itemCodec: Codec_t<a>) => Codec_t<a[]>;
+  readonly option: <a>(itemCodec: Codec_t<a>) => Codec_t<a | undefined>;
+  readonly tuple2: <a, b>(codec1: Codec_t<a>, codec2: Codec_t<b>) => Codec_t<[a, b]>;
+  readonly tuple3: <a, b, c>(codec1: Codec_t<a>, codec2: Codec_t<b>, codec3: Codec_t<c>) => Codec_t<[a, b, c]>;
+  readonly dict: <a>(valueCodec: Codec_t<a>) => Codec_t<Record<string, a>>;
+  readonly make: <a>(encode: (value: a) => Json, decode: (json: Json) => undefined | a) => Codec_t<a>;
+};
+
+export const register: <a>(id: string, signal: Signal_t<a>, codec: Codec_t<a>) => void;
+export const clear: () => void;
+export const generateScript: (nonce?: string) => string;
+export const getClientState: () => Record<string, Json>;
+export const restore: <a>(id: string, signal: Signal_t<a>, codec: Codec_t<a>) => void;
+export const sync: <a>(id: string, signal: Signal_t<a>, codec: Codec_t<a>) => void;
+export const make: <a>(id: string, initial: a, codec: Codec_t<a>) => Signal_t<a>;
+export const signal: typeof make;
+export const syncSignal: typeof sync;
+`;
+
+write(join(outDir, "SSRState.d.ts"), ssrStateTypes);
+
 const clientEntry = `export * as View from "./types/src/View.js";
 export * as Html from "./types/src/Html.js";
 export * as Prop from "./types/src/Prop.js";
@@ -168,6 +274,56 @@ export const XoteJSX: unknown;
 write(join(root, "dist", "client.d.ts"), clientEntry);
 write(join(root, "dist", "xote.d.ts"), clientEntry);
 
+write(
+  join(root, "dist", "router.d.ts"),
+  `export * from "./types/src/Router.js";
+export * as Router from "./types/src/Router.js";
+export * as Route from "./types/src/Route.js";
+`,
+);
+
+write(
+  join(root, "dist", "ssr.d.ts"),
+  `export * from "./types/src/SSR.js";
+export * as SSR from "./types/src/SSR.js";
+export * as SSRContext from "./types/src/SSRContext.js";
+export * as SSRState from "./types/src/SSRState.js";
+`,
+);
+
+write(
+  join(root, "dist", "hydration.d.ts"),
+  `export * from "./types/src/Hydration.js";
+export * as Hydration from "./types/src/Hydration.js";
+`,
+);
+
+write(
+  join(root, "dist", "mdx.d.ts"),
+  `export * from "./types/src/Mdx.js";
+export * as Mdx from "./types/src/Mdx.js";
+`,
+);
+
+write(join(root, "dist", "jsx.d.ts"), "export const XoteJSX: unknown;\n");
+write(
+  join(root, "dist", "jsx-runtime.d.ts"),
+  `import type { node as View_node } from "./types/src/View.js";
+
+export const Fragment: symbol;
+export const jsx: (type: unknown, props: Record<string, unknown> | null, key?: unknown) => View_node;
+export const jsxs: typeof jsx;
+`,
+);
+write(
+  join(root, "dist", "jsx-dev-runtime.d.ts"),
+  `import { jsx } from "./jsx-runtime.js";
+
+export { Fragment, jsx, jsxs } from "./jsx-runtime.js";
+export const jsxDEV: typeof jsx;
+`,
+);
+
 const subpaths = {
   view: "View",
   node: "View",
@@ -177,6 +333,9 @@ const subpaths = {
   signal: "Signal",
   computed: "Computed",
   effect: "Effect",
+  route: "Route",
+  "ssr-context": "SSRContext",
+  "ssr-state": "SSRState",
 };
 
 for (const [subpath, moduleName] of Object.entries(subpaths)) {

--- a/scripts/generate-types.mjs
+++ b/scripts/generate-types.mjs
@@ -1,0 +1,186 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+const srcDir = join(root, "src");
+const outDir = join(root, "dist", "types", "src");
+
+const modules = [
+  { source: "TypeScriptSignal", output: "Signal" },
+  { source: "TypeScriptComputed", output: "Computed" },
+  { source: "TypeScriptEffect", output: "Effect" },
+  { source: "TypeScriptProp", output: "Prop" },
+  { source: "TypeScriptView", output: "View" },
+  { source: "TypeScriptHtml", output: "Html" },
+];
+
+const readGenType = (moduleName) => {
+  const path = join(srcDir, `${moduleName}.gen.tsx`);
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    throw new Error(
+      `Missing ${path}. Run \`npm run res:build\` before generating TypeScript declarations.`,
+    );
+  }
+};
+
+const write = (path, content) => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const normalizeImports = (source, moduleName) => {
+  let domAliases = "";
+  let normalized = source
+    .replace(/import \* as .*? from '\.\/.*?\.res\.mjs';\n\n/g, "")
+    .replace(/import type \{t as Signal_t\} from '\.\/Signal\.gen\.js';/g, "import type { t as Signal_t } from './Signal.js';")
+    .replace(/import type \{t as TypeScriptSignal_t\} from '\.\/TypeScriptSignal\.gen\.js';/g, "import type { t as Signal_t } from './Signal.js';")
+    .replace(/import type \{attrValue as View_attrValue\} from '\.\/View\.gen\.js';/g, "import type { attrValue as View_attrValue } from './View.js';")
+    .replace(/import type \{node as View_node\} from '\.\/View\.gen\.js';/g, "import type { node as View_node } from './View.js';")
+    .replace(/import type \{attrValue as TypeScriptView_attrValue\} from '\.\/TypeScriptView\.gen\.js';/g, "import type { attrValue as View_attrValue } from './View.js';")
+    .replace(/import type \{node as TypeScriptView_node\} from '\.\/TypeScriptView\.gen\.js';/g, "import type { node as View_node } from './View.js';")
+    .replace(/import type \{element as Dom_element\} from '\.\/Dom\.gen\.js';\n\n/g, () => {
+      domAliases += "type Dom_element = Element;\n";
+      return "";
+    })
+    .replace(/import type \{event as Dom_event\} from '\.\/Dom\.gen\.js';\n\n/g, () => {
+      domAliases += "type Dom_event = Event;\n";
+      return "";
+    })
+    .replace(/import type \{t as Obj_t\} from '\.\/Obj\.gen\.js';\n\n/g, () => {
+      domAliases += "type Obj_t = unknown;\n";
+      return "";
+    });
+
+  if (domAliases !== "") {
+    normalized = normalized.replace(
+      "/* tslint:disable */\n\n",
+      `/* tslint:disable */\n\n${domAliases}\n`,
+    );
+  }
+
+  return normalized
+    .replaceAll("TypeScriptSignal_t", "Signal_t")
+    .replaceAll("TypeScriptView_attrValue", "View_attrValue")
+    .replaceAll("TypeScriptView_node", "View_node");
+};
+
+const normalizeDeclarations = (source, moduleName) => {
+  let normalized = normalizeImports(source, moduleName)
+    .replace(/\/\* TypeScript file generated from (.*?) by genType\. \*\//, "/* TypeScript declarations generated from $1 via genType. */")
+    .replace(/export abstract class t<([^>]+)> \{ protected opaque!: ([^}]+) \};/g, "export abstract class t<$1> { protected opaque: $2; }")
+    .replace(/export abstract class ([A-Za-z0-9_$]+) \{ protected opaque!: any \};/g, "export abstract class $1 { protected opaque: any; }")
+    .replace(/^(export const [A-Za-z0-9_$]+: .*) = [^;]+ as any;$/gm, "$1;");
+
+  if (moduleName === "Signal") {
+    normalized = normalized
+      .replace(
+        /export const make: <a>\(initialValue:a, name:\(undefined \| string\), equals:\(undefined \| \(\(\(_1:a, _2:a\) => boolean\)\)\)\) => t<a>;/,
+        "export const make: <a>(initialValue: a, name?: string, equals?: (_1: a, _2: a) => boolean) => t<a>;",
+      )
+      .replace(
+        /export const makeForComputed: <a>\(initialValue:a, name:\(undefined \| string\)\) => t<a>;/,
+        "export const makeForComputed: <a>(initialValue: a, name?: string) => t<a>;",
+      );
+  }
+
+  if (moduleName === "Computed") {
+    normalized = normalized
+      .replace(
+        /export const makeWithoutEquals: <a>\(compute:\(\(\) => a\), name:\(undefined \| string\)\) => Signal_t<a>;/,
+        "export const makeWithoutEquals: <a>(compute: () => a, name?: string) => Signal_t<a>;",
+      )
+      .replace(
+        /export const makeWithEquals: <a>\(compute:\(\(\) => a\), equalsFn:\(\(_1:a, _2:a\) => boolean\), name:\(undefined \| string\)\) => Signal_t<a>;/,
+        "export const makeWithEquals: <a>(compute: () => a, equalsFn: (_1: a, _2: a) => boolean, name?: string) => Signal_t<a>;",
+      )
+      .replace(
+        /export const make: <a>\(compute:\(\(\) => a\), name:\(undefined \| string\), equals:\(undefined \| \(\(\(_1:a, _2:a\) => boolean\)\)\)\) => Signal_t<a>;/,
+        "export const make: <a>(compute: () => a, name?: string, equals?: (_1: a, _2: a) => boolean) => Signal_t<a>;",
+      );
+  }
+
+  if (moduleName === "Effect") {
+    normalized = normalized
+      .replace(
+        /export const runWithDisposer: \(fn:\(\(\) => \(undefined \| \(\(\(\) => void\)\)\)\), name:\(undefined \| string\)\) => disposer;/,
+        "export const runWithDisposer: (fn: () => undefined | (() => void), name?: string) => disposer;",
+      )
+      .replace(
+        /export const run: \(fn:\(\(\) => \(undefined \| \(\(\(\) => void\)\)\)\), name:\(undefined \| string\)\) => void;/,
+        "export const run: (fn: () => undefined | (() => void), name?: string) => void;",
+      );
+  }
+
+  if (moduleName === "View") {
+    normalized = normalized
+      .replace(
+        /export const element: \(tag:string, attrs:\(undefined \| Array<\[string, attrValue\]>\), events:\(undefined \| Array<\[string, \(\(_1:Dom_event\) => void\)\]>\), children:\(undefined \| node\[\]\), _5:void\) => node;/,
+        "export const element: (tag: string, attrs?: Array<[string, attrValue]>, events?: Array<[string, (_1: Dom_event) => void]>, children?: node[]) => node;",
+      )
+      .replace(
+        /export const element: \(tag:string, attrs:\(undefined \| Array<\[string, attrValue\]>\), events:\(undefined \| Array<\[string, eventHandler\]>\), children:\(undefined \| node\[\]\), _5:void\) => node;/,
+        "export const element: (tag: string, attrs?: Array<[string, attrValue]>, events?: Array<[string, eventHandler]>, children?: node[]) => node;",
+      )
+      .replace(/export const null: \(\) => node;/, () => "export const $$null: () => node;");
+  }
+
+  if (moduleName === "Html") {
+    normalized = normalized
+      .replaceAll(
+        "(attrs:(undefined | attrs), events:(undefined | events), children:(undefined | children), _4:void) => View_node",
+        "(attrs?: attrs, events?: events, children?: children) => View_node",
+      )
+      .replaceAll(
+        "(attrs:(undefined | attrs), events:(undefined | events), _3:void) => View_node",
+        "(attrs?: attrs, events?: events) => View_node",
+      )
+      .replaceAll(
+        "(attrs:(undefined | Array<[string, View_attrValue]>), events:(undefined | Array<[string, ((_1:Dom_event) => void)]>), children:(undefined | View_node[]), param:void) => View_node",
+        "(attrs?: Array<[string, View_attrValue]>, events?: Array<[string, (_1: Dom_event) => void]>, children?: View_node[]) => View_node",
+      )
+      .replaceAll(
+        "(attrs:(undefined | Array<[string, View_attrValue]>), events:(undefined | Array<[string, ((_1:Dom_event) => void)]>), param:void) => View_node",
+        "(attrs?: Array<[string, View_attrValue]>, events?: Array<[string, (_1: Dom_event) => void]>) => View_node",
+      );
+  }
+
+  return normalized;
+};
+
+rmSync(join(root, "dist", "types"), { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+for (const { source, output } of modules) {
+  write(join(outDir, `${output}.d.ts`), normalizeDeclarations(readGenType(source), output));
+}
+
+const clientEntry = `export * as View from "./types/src/View.js";
+export * as Html from "./types/src/Html.js";
+export * as Prop from "./types/src/Prop.js";
+export * as Signal from "./types/src/Signal.js";
+export * as Computed from "./types/src/Computed.js";
+export * as Effect from "./types/src/Effect.js";
+export const XoteJSX: unknown;
+`;
+
+write(join(root, "dist", "client.d.ts"), clientEntry);
+write(join(root, "dist", "xote.d.ts"), clientEntry);
+
+const subpaths = {
+  view: "View",
+  node: "View",
+  html: "Html",
+  prop: "Prop",
+  "reactive-prop": "Prop",
+  signal: "Signal",
+  computed: "Computed",
+  effect: "Effect",
+};
+
+for (const [subpath, moduleName] of Object.entries(subpaths)) {
+  write(join(root, "dist", `${subpath}.d.ts`), `export * from "./types/src/${moduleName}.js";\n`);
+}
+
+console.log(`Generated TypeScript declarations for ${modules.map(({ output }) => output).join(", ")}.`);

--- a/src/TypeScriptComputed.res
+++ b/src/TypeScriptComputed.res
@@ -1,0 +1,27 @@
+@genType
+let makeWithoutEquals = (compute: unit => 'a, ~name: option<string>=?): TypeScriptSignal.t<'a> => {
+  Obj.magic(Computed.makeWithoutEquals(compute, ~name?))
+}
+
+@genType
+let makeWithEquals = (
+  compute: unit => 'a,
+  equalsFn: ('a, 'a) => bool,
+  ~name: option<string>=?,
+): TypeScriptSignal.t<'a> => {
+  Obj.magic(Computed.makeWithEquals(compute, equalsFn, ~name?))
+}
+
+@genType
+let make = (
+  compute: unit => 'a,
+  ~name: option<string>=?,
+  ~equals: option<('a, 'a) => bool>=?,
+): TypeScriptSignal.t<'a> => {
+  Obj.magic(Computed.make(compute, ~name?, ~equals?))
+}
+
+@genType
+let dispose = (signal: TypeScriptSignal.t<'a>): unit => {
+  Computed.dispose(Obj.magic(signal))
+}

--- a/src/TypeScriptEffect.res
+++ b/src/TypeScriptEffect.res
@@ -1,0 +1,12 @@
+@genType
+type disposer = Effect.disposer = {dispose: unit => unit}
+
+@genType
+let runWithDisposer = (fn: unit => option<unit => unit>, ~name: option<string>=?): disposer => {
+  Effect.runWithDisposer(fn, ~name?)
+}
+
+@genType
+let run = (fn: unit => option<unit => unit>, ~name: option<string>=?): unit => {
+  Effect.run(fn, ~name?)
+}

--- a/src/TypeScriptHtml.res
+++ b/src/TypeScriptHtml.res
@@ -1,0 +1,57 @@
+type attrs = array<(string, TypeScriptView.attrValue)>
+type events = array<(string, Dom.event => unit)>
+type children = array<TypeScriptView.node>
+
+@genType
+let div = (~attrs: attrs=[], ~events: events=[], ~children: children=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.div(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let span = (
+  ~attrs: attrs=[],
+  ~events: events=[],
+  ~children: children=[],
+  (),
+): TypeScriptView.node =>
+  Obj.magic(Html.span(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let button = (
+  ~attrs: attrs=[],
+  ~events: events=[],
+  ~children: children=[],
+  (),
+): TypeScriptView.node =>
+  Obj.magic(Html.button(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let input = (~attrs: attrs=[], ~events: events=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.input(~attrs=Obj.magic(attrs), ~events, ()))
+
+@genType
+let h1 = (~attrs: attrs=[], ~events: events=[], ~children: children=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.h1(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let h2 = (~attrs: attrs=[], ~events: events=[], ~children: children=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.h2(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let h3 = (~attrs: attrs=[], ~events: events=[], ~children: children=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.h3(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let p = (~attrs: attrs=[], ~events: events=[], ~children: children=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.p(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let ul = (~attrs: attrs=[], ~events: events=[], ~children: children=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.ul(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let li = (~attrs: attrs=[], ~events: events=[], ~children: children=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.li(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+
+@genType
+let a = (~attrs: attrs=[], ~events: events=[], ~children: children=[], ()): TypeScriptView.node =>
+  Obj.magic(Html.a(~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))

--- a/src/TypeScriptHydration.res
+++ b/src/TypeScriptHydration.res
@@ -1,0 +1,28 @@
+@genType
+type hydrateOptions = {
+  renderId?: string,
+  onHydrated?: unit => unit,
+}
+
+@genType
+let hydrate = (
+  component: unit => TypeScriptView.node,
+  container: Dom.element,
+  ~options: option<hydrateOptions>=?,
+): unit =>
+  switch options {
+  | Some(options) => Hydration.hydrate(() => Obj.magic(component()), container, ~options=Obj.magic(options))
+  | None => Hydration.hydrate(() => Obj.magic(component()), container)
+  }
+
+@genType
+let hydrateById = (
+  component: unit => TypeScriptView.node,
+  containerId: string,
+  ~options: option<hydrateOptions>=?,
+): unit =>
+  switch options {
+  | Some(options) =>
+    Hydration.hydrateById(() => Obj.magic(component()), containerId, ~options=Obj.magic(options))
+  | None => Hydration.hydrateById(() => Obj.magic(component()), containerId)
+  }

--- a/src/TypeScriptMdx.res
+++ b/src/TypeScriptMdx.res
@@ -1,0 +1,30 @@
+@genType
+type children = Obj.t
+
+@genType
+type components = dict<Obj.t => TypeScriptView.node>
+
+@genType
+type props = {components?: components}
+
+@genType
+type document = props => TypeScriptView.node
+
+@genType
+let component = (make: 'props => TypeScriptView.node): (Obj.t => TypeScriptView.node) =>
+  props => make(Obj.magic(props))
+
+@genType
+let components = (entries: array<(string, Obj.t => TypeScriptView.node)>): components =>
+  Obj.magic(Dict.fromArray(entries))
+
+@genType
+let render = (document: document, ~components: option<components>=?): TypeScriptView.node =>
+  Obj.magic(Mdx.render(Obj.magic(document), ~components=Obj.magic(components), ()))
+
+@genType
+let childrenToNodes = (children: children): array<TypeScriptView.node> =>
+  Obj.magic(Mdx.childrenToNodes(Obj.magic(children)))
+
+@genType
+let childrenToText = (children: children): string => Mdx.childrenToText(children)

--- a/src/TypeScriptProp.res
+++ b/src/TypeScriptProp.res
@@ -1,0 +1,15 @@
+@genType
+type t<'a>
+
+@genType
+let get = (value: t<'a>): 'a => Prop.get(Obj.magic(value))
+
+@genType
+let static = (value: 'a): t<'a> => Obj.magic(Prop.static(value))
+
+@genType
+let reactive = (signal: TypeScriptSignal.t<'a>): t<'a> =>
+  Obj.magic(Prop.reactive(Obj.magic(signal)))
+
+@genType
+let signal = reactive

--- a/src/TypeScriptRoute.res
+++ b/src/TypeScriptRoute.res
@@ -1,0 +1,30 @@
+@genType
+type params = Dict.t<string>
+
+@genType
+type segment
+
+@genType
+type matchResult =
+  | Match(params)
+  | NoMatch
+
+@genType
+let parsePattern = (pattern: string): array<segment> => Obj.magic(Route.parsePattern(pattern))
+
+@genType
+let matchPath = (pattern: array<segment>, pathname: string): matchResult =>
+  Obj.magic(Route.matchPath(Obj.magic(pattern), pathname))
+
+@genType
+let match = (pattern: string, pathname: string): matchResult =>
+  Obj.magic(Route.match(pattern, pathname))
+
+@genType
+let compile = parsePattern
+
+@genType
+let matchCompiled = matchPath
+
+@genType
+let matchPathname = match

--- a/src/TypeScriptRouter.res
+++ b/src/TypeScriptRouter.res
@@ -1,0 +1,68 @@
+@genType
+type location = {
+  pathname: string,
+  search: string,
+  hash: string,
+}
+
+@genType
+type routeConfig = {
+  pattern: string,
+  render: TypeScriptRoute.params => TypeScriptView.node,
+}
+
+@genType
+let init = (~basePath: option<string>=?): unit => {
+  Router.init(~basePath?, ())
+}
+
+@genType
+let initSSR = (
+  ~basePath: option<string>=?,
+  ~pathname: option<string>=?,
+  ~search: option<string>=?,
+  ~hash: option<string>=?,
+): unit => {
+  Router.initSSR(~basePath?, ~pathname?, ~search?, ~hash?, ())
+}
+
+@genType
+let location = (): TypeScriptSignal.t<location> => Obj.magic(Router.location())
+
+@genType
+let push = (pathname: string, ~search: option<string>=?, ~hash: option<string>=?): unit => {
+  Router.push(pathname, ~search?, ~hash?, ())
+}
+
+@genType
+let replace = (pathname: string, ~search: option<string>=?, ~hash: option<string>=?): unit => {
+  Router.replace(pathname, ~search?, ~hash?, ())
+}
+
+@genType
+let route = (
+  pattern: string,
+  render: TypeScriptRoute.params => TypeScriptView.node,
+): TypeScriptView.node =>
+  Obj.magic(Router.route(pattern, params => Obj.magic(render(Obj.magic(params)))))
+
+@genType
+let routes = (configs: array<routeConfig>): TypeScriptView.node =>
+  Obj.magic(Router.routes(Obj.magic(configs)))
+
+@genType
+let link = (
+  to: string,
+  ~attrs: array<(string, TypeScriptView.attrValue)>=[],
+  ~children: array<TypeScriptView.node>=[],
+): TypeScriptView.node =>
+  Obj.magic(Router.link(~to, ~attrs=Obj.magic(attrs), ~children=Obj.magic(children), ()))
+
+@genType
+let normalizeBasePath = Router.normalizeBasePath
+
+@genType
+let stripBasePath = Router.stripBasePath
+
+@genType
+let addBasePath = Router.addBasePath

--- a/src/TypeScriptSSR.res
+++ b/src/TypeScriptSSR.res
@@ -1,0 +1,59 @@
+@genType
+type renderOptions = {
+  nonce?: string,
+  renderId?: string,
+}
+
+@genType
+let renderNodeToString = (node: TypeScriptView.node): string =>
+  SSR.renderNodeToString(Obj.magic(node))
+
+@genType
+let renderToString = (
+  component: unit => TypeScriptView.node,
+  ~options: option<renderOptions>=?,
+): string =>
+  switch options {
+  | Some(options) => SSR.renderToString(() => Obj.magic(component()), ~options=Obj.magic(options))
+  | None => SSR.renderToString(() => Obj.magic(component()))
+  }
+
+@genType
+let renderToStringWithRoot = (
+  component: unit => TypeScriptView.node,
+  ~rootId: option<string>=?,
+  ~options: option<renderOptions>=?,
+): string =>
+  switch options {
+  | Some(options) =>
+    SSR.renderToStringWithRoot(
+      () => Obj.magic(component()),
+      ~rootId?,
+      ~options=Obj.magic(options),
+    )
+  | None => SSR.renderToStringWithRoot(() => Obj.magic(component()), ~rootId?)
+  }
+
+@genType
+let generateHydrationScript = (~nonce: option<string>=?): string =>
+  SSR.generateHydrationScript(~nonce?)
+
+@genType
+let renderDocument = (
+  component: unit => TypeScriptView.node,
+  ~head: option<string>=?,
+  ~bodyAttrs: option<string>=?,
+  ~scripts: option<array<string>>=?,
+  ~styles: option<array<string>>=?,
+  ~stateScript: option<string>=?,
+  ~nonce: option<string>=?,
+): string =>
+  SSR.renderDocument(
+    ~head?,
+    ~bodyAttrs?,
+    ~scripts?,
+    ~styles?,
+    ~stateScript?,
+    ~nonce?,
+    () => Obj.magic(component()),
+  )

--- a/src/TypeScriptSSRContext.res
+++ b/src/TypeScriptSSRContext.res
@@ -1,0 +1,15 @@
+@genType
+let isServer = SSRContext.isServer
+
+@genType
+let isClient = SSRContext.isClient
+
+@genType
+let onServer = SSRContext.onServer
+
+@genType
+let onClient = SSRContext.onClient
+
+@genType
+let match = (~server: unit => 'a, ~client: unit => 'a): 'a =>
+  SSRContext.match(~server, ~client)

--- a/src/TypeScriptSignal.res
+++ b/src/TypeScriptSignal.res
@@ -1,0 +1,42 @@
+@genType
+type t<'a>
+
+@genType
+let defaultEquals = Signal.defaultEquals
+
+@genType
+let neverEquals = Signal.neverEquals
+
+@genType
+let make = (initialValue: 'a, ~name: option<string>=?, ~equals: option<('a, 'a) => bool>=?): t<
+  'a,
+> => {
+  Obj.magic(Signal.make(initialValue, ~name?, ~equals?))
+}
+
+@genType
+let makeForComputed = (initialValue: 'a, ~name: option<string>=?): t<'a> => {
+  Obj.magic(Signal.makeForComputed(initialValue, ~name?))
+}
+
+@genType
+let get = (signal: t<'a>): 'a => Signal.get(Obj.magic(signal))
+
+@genType
+let peek = (signal: t<'a>): 'a => Signal.peek(Obj.magic(signal))
+
+@genType
+let set = (signal: t<'a>, newValue: 'a): unit => {
+  Signal.set(Obj.magic(signal), newValue)
+}
+
+@genType
+let update = (signal: t<'a>, fn: 'a => 'a): unit => {
+  Signal.update(Obj.magic(signal), fn)
+}
+
+@genType
+let batch = Signal.batch
+
+@genType
+let untrack = Signal.untrack

--- a/src/TypeScriptView.res
+++ b/src/TypeScriptView.res
@@ -1,0 +1,82 @@
+@genType
+type attrValue
+
+@genType
+type node
+
+type eventHandler = Dom.event => unit
+
+@genType
+let attr = (key: string, value: string): (string, attrValue) => Obj.magic(View.attr(key, value))
+
+@genType
+let signalAttr = (key: string, signal: TypeScriptSignal.t<string>): (string, attrValue) =>
+  Obj.magic(View.signalAttr(key, Obj.magic(signal)))
+
+@genType
+let computedAttr = (key: string, compute: unit => string): (string, attrValue) =>
+  Obj.magic(View.computedAttr(key, compute))
+
+@genType
+let text = (content: string): node => Obj.magic(View.text(content))
+
+@genType
+let signalText = (compute: unit => string): node => Obj.magic(View.signalText(compute))
+
+@genType
+let signalInt = (compute: unit => int): node => Obj.magic(View.signalInt(compute))
+
+@genType
+let signalFloat = (compute: unit => float): node => Obj.magic(View.signalFloat(compute))
+
+@genType
+let int = (value: int): node => Obj.magic(View.int(value))
+
+@genType
+let float = (value: float): node => Obj.magic(View.float(value))
+
+@genType
+let bool = (value: bool): node => Obj.magic(View.bool(value))
+
+@genType
+let fragment = (children: array<node>): node => Obj.magic(View.fragment(Obj.magic(children)))
+
+@genType
+let signalFragment = (signal: TypeScriptSignal.t<array<node>>): node =>
+  Obj.magic(View.signalFragment(Obj.magic(signal)))
+
+@genType
+let each = (signal: TypeScriptSignal.t<array<'a>>, renderItem: 'a => node): node =>
+  Obj.magic(View.each(Obj.magic(signal), item => Obj.magic(renderItem(item))))
+
+@genType
+let eachWithKey = (
+  signal: TypeScriptSignal.t<array<'a>>,
+  keyFn: 'a => string,
+  renderItem: 'a => node,
+): node =>
+  Obj.magic(View.eachWithKey(Obj.magic(signal), keyFn, item => Obj.magic(renderItem(item))))
+
+@genType
+let element = (
+  tag: string,
+  ~attrs: array<(string, attrValue)>=[],
+  ~events: array<(string, eventHandler)>=[],
+  ~children: array<node>=[],
+  (),
+): node => {
+  Obj.magic(View.element(tag, ~attrs=Obj.magic(attrs), ~events, ~children=Obj.magic(children), ()))
+}
+
+@genType
+let null = (): node => Obj.magic(View.null())
+
+@genType
+let mount = (node: node, container: Dom.element): unit => {
+  View.mount(Obj.magic(node), container)
+}
+
+@genType
+let mountById = (node: node, containerId: string): unit => {
+  View.mountById(Obj.magic(node), containerId)
+}


### PR DESCRIPTION
## Summary

Adds a dedicated TypeScript frontend example under `examples/typescript` that consumes Xote through the public package entries, including `xote/client` and `xote/router`.

Expands TypeScript declaration generation for the public feature modules that were previously missing types: route/router, SSR, SSR context/state, hydration, MDX, JSX, and JSX runtime entries. The package export map now advertises those generated declaration files, and the generated `.d.ts` outputs are checked in under `dist/`.

## Impact

TypeScript consumers can import more of Xote's public API without local declaration shims. The TypeScript example now validates router usage against the generated package declarations.

## Validation

- `npm run build`
- `npx -p typescript tsc --noEmit -p examples/typescript/tsconfig.json`
- `npm run example:typescript:build`
- TypeScript smoke check importing the newly typed entries
- `npm run test` (`99 passed`)