### PR TITLE
ci: add beta pre-release channel for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ let count = SSRState.signal("count", 0, SSRState.Codec.int)
 
 Check the [website](https://brnrdog.github.io/xote/) for more comprehensive documentations about Xote and Signals.
 
+## Releasing
+
+Releases are automated with semantic-release and published to npm. See [docs/RELEASING.md](docs/RELEASING.md) for the stable and beta channels and the release flow.
+
 ## License
 
 LGPL v3 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,13 @@
+# Releasing
+
+Releases are automated with [semantic-release](https://semantic-release.gitbook.io/) and triggered manually from the **Release** workflow (**Actions → Release → Run workflow**). The version is derived from the [Conventional Commit](https://www.conventionalcommits.org/) messages since the last release; semantic-release acts on whichever branch you run the workflow from. (`package.json` stays at `0.0.0` — it is not the source of truth.)
+
+| Channel | Branch | npm dist-tag | Install |
+| --- | --- | --- | --- |
+| Stable | `main` | `latest` | `npm install xote` |
+| Beta | `beta` | `beta` | `npm install xote@beta` |
+
+- **Stable:** run the workflow on `main` → publishes the next version (e.g. `6.5.0`) under `latest`.
+- **Beta (testing):** run the workflow on `beta` → publishes a pre-release (e.g. `6.5.0-beta.1`) under the `beta` dist-tag. This never moves `latest`, so only `npm install xote@beta` picks it up.
+
+When a beta is ready to ship, merge `beta` into `main` and run the workflow on `main` to cut the stable release.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,11 @@
   ],
   "release": {
     "branches": [
-      "main"
+      "main",
+      {
+        "name": "beta",
+        "prerelease": true
+      }
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Enable semantic-release pre-releases on a dedicated `beta` branch so testing builds are published under the `beta` npm dist-tag (e.g. 6.5.0-beta.1) without moving `latest`.

Releases stay manual: run the Release workflow on `main` for a stable release or on `beta` for a pre-release.