### PR TITLE
refactor!: remove deprecated modules and redundant API aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,13 @@ Instructions for AI coding agents working on this repository. This file compleme
 - **Reactivity**: [rescript-signals](https://brnrdog.github.io/rescript-signals) - `Signal`, `Computed`, `Effect`
 - **Build**: `npm run res:build` (ReScript) then `npm run build` (Vite)
 - **Watch**: `npm run res:dev` for ReScript watch mode
-- **Public API**: ReScript namespacing scopes every file in `src/` under `Xote` (e.g. `Xote.Node`, `Xote.Router`). The public set is enumerated in `rescript.json`'s `sources.public`. There is no `Xote__` prefix and no central `Xote.res` barrel.
+- **Public API**: ReScript namespacing scopes every file in `src/` under `Xote` (e.g. `Xote.View`, `Xote.Router`). The public set is enumerated in `rescript.json`'s `sources.public`. There is no `Xote__` prefix and no central `Xote.res` barrel.
 
 ## Before Making Changes
 
 1. **Read `CLAUDE.md`** for full architecture, module descriptions, API surface, and code patterns
 2. **Compile first**: Always run `npm run res:build` before testing or building
-3. **Understand the module boundary**: The public surface is the list of modules in `rescript.json`'s `sources.public` (`Node`, `View`, `Html`, `XoteJSX`, `ReactiveProp`, `Prop`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Signal`, `Computed`, `Effect`). Helpers like `DOM`, `Reactivity`, and `Render` are implementation details and should not be relied on by consumers.
+3. **Understand the module boundary**: The public surface is the list of modules in `rescript.json`'s `sources.public` (`View`, `Html`, `XoteJSX`, `Prop`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Mdx`, `Signal`, `Computed`, `Effect`). Helpers like `DOM`, `Reactivity`, and `Render` are implementation details and should not be relied on by consumers.
 
 ## Development Workflow
 
@@ -27,8 +27,7 @@ Instructions for AI coding agents working on this repository. This file compleme
 ### Key Files
 | File | Purpose |
 |------|---------|
-| `src/Node.res` | Core rendering, node primitives, mount, reconciliation |
-| `src/View.res` | Alias for `Node` with clearer UI-view naming |
+| `src/View.res` | Core rendering, node primitives, mount, reconciliation |
 | `src/Html.res` | Common HTML element constructors (`div`, `button`, ...) |
 | `src/XoteJSX.res` | JSX v4 transform and `Elements` module |
 | `src/Router.res` | Client-side routing |
@@ -37,8 +36,7 @@ Instructions for AI coding agents working on this repository. This file compleme
 | `src/Hydration.res` | Client-side hydration |
 | `src/SSRState.res` | Server-client state transfer |
 | `src/SSRContext.res` | Server/client environment detection |
-| `src/ReactiveProp.res` | Static/Reactive prop wrapper |
-| `src/Prop.res` | Alias for `ReactiveProp` with shorter prop naming |
+| `src/Prop.res` | Static/Reactive prop wrapper |
 | `src/Signal.res`, `src/Computed.res`, `src/Effect.res` | Re-export shims for `rescript-signals` |
 | `rescript.json` | ReScript compiler configuration (`namespace: true`) |
 | `vite.config.js` | Library build configuration |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ JavaScript package entries are intentionally split by feature:
 - `xote/hydration` exposes hydration only.
 - `xote/mdx` exposes the optional MDX integration.
 
-The root `xote` entry is client-focused and does not export router, SSR, hydration, MDX, or deprecated aliases such as `Node` and `ReactiveProp`. Direct source/module subpaths remain available where listed in `package.json`.
+The root `xote` entry is client-focused and does not export router, SSR, hydration, or MDX. Direct source/module subpaths remain available where listed in `package.json`.
 
 **Reactive Primitives (re-exported from rescript-signals):**
 - **`Xote.Signal`**: Reactive state cells with `make`, `get`, `peek`, `set`, `update`, plus `batch` and `untrack` from the scheduler. `Signal.make` accepts optional `~name` (for debugging) and `~equals` (a custom `('a, 'a) => bool` comparator) parameters. The default equality is JavaScript `===` (reference/strict), not structural — pass `~equals` when you need deep comparison. `set` only notifies dependents when the new value differs from the current one, preventing unnecessary updates and accidental infinite loops.
@@ -60,17 +60,15 @@ The root `xote` entry is client-focused and does not export router, SSR, hydrati
 These three are thin shims (`src/Signal.res`, `src/Computed.res`, `src/Effect.res`) that `include` the corresponding modules from `rescript-signals`.
 
 **Xote Modules:**
-- **`Xote.Node`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `computedText`, `computedInt`, `computedFloat`, `fragment`, `signalFragment`, `list`, `keyedList`, `each`, `keyedEach`, `element`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
-- **`Xote.View`**: Alias module for `Node`, useful when the term "view" reads more clearly than "node" in application code.
-- **`Xote.Html`**: Convenience constructors for common HTML tags (`div`, `span`, `button`, `input`, `h1`-`h3`, `p`, `ul`, `li`, `a`). Thin wrappers over `Node.element`. For tags not listed, call `Node.element(tag, ...)` directly or use JSX.
-- **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes). Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `Node.LazyComponent`.
-- **`Xote.ReactiveProp`**: A helper type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` for flexible prop handling in JSX - allows props to accept either static values or reactive signals.
-- **`Xote.Prop`**: Alias module for `ReactiveProp`, including `Prop.signal(signal)` as a shorter alias for `ReactiveProp.reactive(signal)`.
+- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
+- **`Xote.Html`**: Convenience constructors for common HTML tags (`div`, `span`, `button`, `input`, `h1`-`h3`, `p`, `ul`, `li`, `a`). Thin wrappers over `View.element`. For tags not listed, call `View.element(tag, ...)` directly or use JSX.
+- **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes). Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `View.LazyComponent`.
+- **`Xote.Prop`**: Static-or-reactive prop module exposing the type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` plus the `static`, `reactive`, `signal` (alias of `reactive`), and `get` helpers. Lets props accept either static values or reactive signals in JSX.
 - **`Xote.Router`**: Signal-based client-side router with pattern matching, dynamic routes, base path support, scroll position restoration, and a global singleton state (via `Symbol.for()`) that works across multiple bundles.
 - **`Xote.Route`**: Route matching utilities.
 - **`Xote.SSR`**: Server-side rendering to HTML strings with hydration markers (`<!--$-->`, `<!--#-->`, `<!--kl-->`, `<!--k:KEY-->`, `<!--lc-->`).
 - **`Xote.SSRContext`**: Runtime environment detection (`isServer`, `isClient`) and helpers (`onServer`, `onClient`, `match`).
-- **`Xote.SSRState`**: State serialization/restoration between server and client. Includes a `Codec` system for type-safe encoding/decoding and a `sync`/`make` API for seamless server-client state transfer.
+- **`Xote.SSRState`**: State serialization/restoration between server and client. Includes a `Codec` system for type-safe encoding/decoding and a `sync`/`signal` API for seamless server-client state transfer.
 - **`Xote.Hydration`**: Client-side hydration that walks server-rendered DOM, attaches reactive effects, event listeners, and sets up keyed list reconciliation without re-rendering.
 
 ### Reactivity Model
@@ -87,13 +85,13 @@ All reactive behavior is provided by **rescript-signals**:
 
 **Batching**: `Signal.batch(fn)` defers scheduler flushing until `fn` returns, so a burst of `Signal.set` calls triggers each effect at most once. Batches can be nested and return a value. `Signal.untrack(fn)` disables dependency capture inside `fn`, which is the idiomatic way to read a signal without subscribing the current observer to it (there is also `Signal.peek(signal)` for a single untracked read).
 
-**Owner System**: Components use an owner-based tracking system (`Reactivity` module in `Node.res`) that stores effect disposers and computed references on DOM elements via the `__xote_owner__` property. Owners are disposed recursively when DOM elements are removed, preventing memory leaks.
+**Owner System**: Components use an owner-based tracking system (the `RuntimeOwner` module, surfaced as `Reactivity` in `View.res`) that stores effect disposers and computed references on DOM elements via the `__xote_owner__` property. Owners are disposed recursively when DOM elements are removed, preventing memory leaks.
 
 ### ReScript Configuration
 
 - **Build system**: ReScript compiler v12+ with `esmodule` output format
 - **Output**: In-source compilation (`.res.mjs` files alongside `.res` files)
-- **Namespacing**: `namespace: true` in `rescript.json` automatically scopes every module under `Xote`. Public modules are listed explicitly in `sources.public` (`Node`, `View`, `Html`, `XoteJSX`, `ReactiveProp`, `Prop`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Signal`, `Computed`, `Effect`); everything else (e.g. `DOM`, `Reactivity`, which live inside `Node.res`) stays internal.
+- **Namespacing**: `namespace: true` in `rescript.json` automatically scopes every module under `Xote`. Public modules are listed explicitly in `sources.public` (`View`, `Html`, `XoteJSX`, `Prop`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Mdx`, `Signal`, `Computed`, `Effect`); everything else (e.g. `DOM`/`Reactivity`, which live inside `View.res`) stays internal.
 - **Dependencies**: `rescript-signals` ^2.1.0 (the only runtime dependency)
 - **JSX**: ReScript JSX v4 configured with `module: "XoteJSX"` (generic JSX transform). Consumers must mirror this in their own `rescript.json`.
 
@@ -119,11 +117,11 @@ Xote supports **two syntax styles**:
    - `signalAttr("key", signal)` - reactive attribute from a signal
    - `computedAttr("key", () => ...)` - reactive attribute from a computed function
 5. **Lists**:
-   - `list(signal, renderItem)` - simple reactive list (re-renders all items on change)
-   - `keyedList(signal, keyFn, renderItem)` - efficient keyed list with DOM reconciliation (preserves element identity, only updates changed items)
+   - `each(signal, renderItem)` - simple reactive list (re-renders all items on change)
+   - `eachWithKey(signal, keyFn, renderItem)` - efficient keyed list with DOM reconciliation (preserves element identity, only updates changed items)
 6. **Event handlers**: `events` parameter for DOM event listeners
-7. **Null node**: `Node.null()` - renders an empty text node
-8. **HTML element helpers**: `Html.div`, `Html.button`, `Html.p`, etc. live in the `Xote.Html` module — use them when writing the function-based API. For tags not covered, fall back to `Node.element("tag", ...)`.
+7. **Null node**: `View.null()` - renders an empty text node
+8. **HTML element helpers**: `Html.div`, `Html.button`, `Html.p`, etc. live in the `Xote.Html` module — use them when writing the function-based API. For tags not covered, fall back to `View.element("tag", ...)`.
 9. **Mounting**: `mount(node, container)` or `mountById(node, "element-id")` to attach to DOM
 
 #### JSX Syntax
@@ -132,9 +130,9 @@ Xote supports ReScript's generic JSX v4 for a declarative component syntax:
 ```rescript
 let app = () => {
   <div class="container">
-    <h1> {Node.text("Hello JSX")} </h1>
+    <h1> {View.text("Hello JSX")} </h1>
     <button onClick={handleClick}>
-      {Node.text("Click me")}
+      {View.text("Click me")}
     </button>
   </div>
 }
@@ -158,7 +156,7 @@ let app = () => {
   - SVG gradient/stop: `offset`, `stopColor`, `stopOpacity`, `gradientUnits`, `gradientTransform`, `spreadMethod`
   - SVG markers: `markerStart`, `markerMid`, `markerEnd`
   - SVG xlink (legacy): `xlinkHref`
-- Props support raw values, `ReactiveProp.t<'a>` (`Static` / `Reactive`), raw `Signal.t<'a>`, or a computed `unit => 'a` function for flexible static/reactive handling
+- Props support raw values, `Prop.t<'a>` (`Static` / `Reactive`), raw `Signal.t<'a>`, or a computed `unit => 'a` function for flexible static/reactive handling
 - Event handlers: `onClick`, `onInput`, `onChange`, `onSubmit`, `onFocus`, `onBlur`, `onKeyDown`, `onKeyUp`, `onMouseEnter`, `onMouseLeave`, `onMouseDown`, `onMouseMove`, `onMouseUp`, `onContextMenu`, plus drag-and-drop: `onDrag`, `onDragStart`, `onDragEnd`, `onDragOver`, `onDragEnter`, `onDragLeave`, `onDrop`
 - Children are passed via JSX syntax and rendered as nodes
 - Boolean attributes (`disabled`, `checked`, `required`, `readOnly`, `multiple`, `autofocus`, `ariaHidden`, `ariaExpanded`, `ariaSelected`, `draggable`, `hidden`, `contentEditable`, `spellcheck`) are added/removed based on the value rather than stringified
@@ -191,7 +189,7 @@ Full server-side rendering with client-side hydration:
 **State transfer (`SSRState` module)**:
 - `SSRState.Codec` - type-safe serialization with built-in codecs for `int`, `float`, `string`, `bool`, `array`, `option`, `tuple2`, `tuple3`, `dict`; and `Codec.make(~encode, ~decode)` for custom codecs
 - `SSRState.sync(id, signal, codec)` - register on server, restore on client
-- `SSRState.make(id, initial, codec)` - create and sync a signal in one call
+- `SSRState.signal(id, initial, codec)` - create and sync a signal in one call
 - `SSRState.generateScript(~nonce?)` - generate `<script>` tag with serialized state
 - Lower-level API: `SSRState.register(id, signal, codec)` (server), `SSRState.restore(id, signal, codec)` (client), `SSRState.clear()` (reset registry), `SSRState.getClientState()` (read `window.__XOTE_STATE__`)
 
@@ -209,7 +207,7 @@ Full server-side rendering with client-side hydration:
 
 ### Attribute & Property Handling
 
-The `DOM.setAttrOrProp` helper (in `Node.res`) handles the distinction between HTML attributes and DOM properties:
+The `DOM.setAttrOrProp` helper (in `View.res`, via the internal `RuntimeDom` module) handles the distinction between HTML attributes and DOM properties:
 - `value`, `checked`, `disabled` are set as DOM properties (not attributes)
 - Boolean attributes (`required`, `readonly`, `multiple`, `aria-hidden`, `aria-expanded`, `aria-selected`, `draggable`, `hidden`, `contenteditable`, `spellcheck`, `autofocus`) are added or removed based on whether the serialized value is `"true"`
 - All other attributes use `setAttribute`
@@ -228,7 +226,7 @@ The `DOM.setAttrOrProp` helper (in `Node.res`) handles the distinction between H
 
 6. **Batching**: Use `Signal.batch(fn)` to coalesce multiple writes so each dependent effect runs at most once per batch. Batches return the value produced by `fn` and can be nested safely.
 
-7. **Module naming**: Source files in `src/` use bare names (`Node.res`, `Router.res`, ...). ReScript's `namespace: true` scopes them under `Xote`, so consumers access them as `Xote.Node`, `Xote.Router`, etc. There is no `Xote__` prefix and no central `Xote.res` barrel.
+7. **Module naming**: Source files in `src/` use bare names (`View.res`, `Router.res`, ...). ReScript's `namespace: true` scopes them under `Xote`, so consumers access them as `Xote.View`, `Xote.Router`, etc. There is no `Xote__` prefix and no central `Xote.res` barrel.
 
 8. **Debug names**: `Signal.make`, `Computed.make`, `Effect.run`, and `Effect.runWithDisposer` all accept an optional `~name` argument surfaced for debugging/tooling. Prefer naming long-lived or cross-module reactive primitives when diagnosing graph issues.
 
@@ -240,7 +238,7 @@ The `DOM.setAttrOrProp` helper (in `Node.res`) handles the distinction between H
 
 12. **Owner-based cleanup**: Reactive state (effects, computeds) is tracked per-DOM-element via the owner system. When elements are removed, their owners are disposed recursively, preventing memory leaks.
 
-13. **Keyed list reconciliation**: `keyedList` uses comment-based anchors and a 3-phase algorithm (remove, build new order, reconcile DOM) for efficient updates. Preserves element identity across re-renders.
+13. **Keyed list reconciliation**: `eachWithKey` uses comment-based anchors and a 3-phase algorithm (remove, build new order, reconcile DOM) for efficient updates. Preserves element identity across re-renders.
 
 14. **SSR hydration markers**: Comment nodes mark reactive boundaries in server-rendered HTML. The hydration walker uses these to attach reactivity without re-rendering the DOM.
 
@@ -248,7 +246,7 @@ The `DOM.setAttrOrProp` helper (in `Node.res`) handles the distinction between H
 
 16. **SVG element support**: SVG elements are created with `createElementNS` using the SVG namespace. The component renderer detects SVG tags via `isSvgTag` and uses the appropriate DOM creation method automatically.
 
-17. **JSX component laziness**: `XoteJSX.jsx` wraps user component functions in `Node.LazyComponent`, deferring evaluation until render time so effects/computeds created inside a component aren't incorrectly tracked by a surrounding `Computed` context.
+17. **JSX component laziness**: `XoteJSX.jsx` wraps user component functions in `View.LazyComponent`, deferring evaluation until render time so effects/computeds created inside a component aren't incorrectly tracked by a surrounding `Computed` context.
 
 ## Common Patterns
 
@@ -325,37 +323,37 @@ Effect.run(() => {
 ### Text nodes
 ```rescript
 // Static text
-Node.text("Hello")
+View.text("Hello")
 
 // Reactive text (auto-updates)
-Node.signalText(() => Signal.get(count)->Int.toString)
+View.signalText(() => Signal.get(count)->Int.toString)
 
 // Type-specific helpers
-Node.signalInt(() => Signal.get(count))
-Node.signalFloat(() => Signal.get(price))
-Node.int(42)
-Node.float(3.14)
+View.signalInt(() => Signal.get(count))
+View.signalFloat(() => Signal.get(price))
+View.int(42)
+View.float(3.14)
 ```
 
 ### Attributes
 ```rescript
 // Static
-Node.attr("class", "btn btn-primary")
+View.attr("class", "btn btn-primary")
 
 // Reactive from signal
 let className = Signal.make("btn-primary")
-Node.signalAttr("class", className)
+View.signalAttr("class", className)
 
 // Reactive from computation
-Node.computedAttr("class", () =>
+View.computedAttr("class", () =>
   Signal.get(isActive) ? "active" : "inactive"
 )
 
 // Mixing static and reactive
 Html.button(
   ~attrs=[
-    Node.attr("type", "button"),
-    Node.computedAttr("class", () =>
+    View.attr("type", "button"),
+    View.computedAttr("class", () =>
       Signal.get(isActive) ? "active" : "inactive"
     )
   ],
@@ -367,15 +365,15 @@ Html.button(
 ```rescript
 // Simple list (re-renders all items on change)
 let items = Signal.make([1, 2, 3])
-Node.list(items, item => Node.text(Int.toString(item)))
+View.each(items, item => View.text(Int.toString(item)))
 
 // Keyed list (efficient reconciliation)
 type todo = { id: string, text: string }
 let todos = Signal.make([{ id: "1", text: "Buy milk" }])
-Node.keyedList(
+View.eachWithKey(
   todos,
   todo => todo.id,
-  todo => Html.li(~children=[Node.text(todo.text)], ())
+  todo => Html.li(~children=[View.text(todo.text)], ())
 )
 ```
 
@@ -384,12 +382,12 @@ Node.keyedList(
 #### Basic JSX elements
 ```rescript
 <div class="container">
-  {Node.text("Hello")}
+  {View.text("Hello")}
 </div>
 
 // With events
 <button onClick={handleClick}>
-  {Node.text("Click me")}
+  {View.text("Click me")}
 </button>
 
 // Input with reactive value
@@ -400,15 +398,15 @@ Node.keyedList(
 />
 ```
 
-#### Reactive props with ReactiveProp
+#### Reactive props with Prop
 ```rescript
 // Props can accept either static or reactive values
-<div class={ReactiveProp.static("container")}>
-  {Node.text("Static class")}
+<div class={Prop.static("container")}>
+  {View.text("Static class")}
 </div>
 
-<div class={ReactiveProp.reactive(classSignal)}>
-  {Node.text("Reactive class")}
+<div class={Prop.signal(classSignal)}>
+  {View.text("Reactive class")}
 </div>
 ```
 
@@ -419,7 +417,7 @@ Router.init(~basePath="/my-app", ())
 
 // JSX Link component
 <Router.Link to="/about" class="nav-link">
-  {Node.text("About")}
+  {View.text("About")}
 </Router.Link>
 
 // Route matching
@@ -436,12 +434,12 @@ Router.routes([
 ```rescript
 // Shared component (runs on both server and client)
 let app = () => {
-  let count = SSRState.make("count", 0, SSRState.Codec.int)
+  let count = SSRState.signal("count", 0, SSRState.Codec.int)
 
   <div>
-    <p> {Node.signalInt(() => Signal.get(count))} </p>
+    <p> {View.signalInt(() => Signal.get(count))} </p>
     <button onClick={_ => Signal.update(count, n => n + 1)}>
-      {Node.text("+")}
+      {View.text("+")}
     </button>
   </div>
 }
@@ -468,8 +466,8 @@ Hydration.hydrateById(app, "root")
 
 ## Known Limitations
 
-1. **SignalFragment updates**: `SignalFragment` replaces all children without diffing (no reconciliation algorithm). Use `keyedList` for efficient list updates.
+1. **SignalFragment updates**: `SignalFragment` replaces all children without diffing (no reconciliation algorithm). Use `eachWithKey` for efficient list updates.
 2. **Hydration is one-way**: After hydration, subsequent updates use full client-side rendering (no incremental/streaming hydration).
 3. **Synchronous scheduler**: All scheduling is synchronous; there is no microtask/animation-frame integration. Use `Signal.batch` to coalesce updates, but understand that effects still run inline when the batch ends.
-4. **Manual JSX key plumbing**: `jsxKeyed`/`jsxsKeyed` currently ignore the `~key` argument — use `Node.keyedList` for reconciled lists rather than relying on JSX-level keys.
-5. **`list` re-renders fully**: `Node.list` recreates every item on change (it is implemented on top of `SignalFragment`). Prefer `Node.keyedList` when item identity matters.
+4. **Manual JSX key plumbing**: `jsxKeyed`/`jsxsKeyed` currently ignore the `~key` argument — use `View.eachWithKey` (or `<View.For by=...>`) for reconciled lists rather than relying on JSX-level keys.
+5. **`each` re-renders fully**: `View.each` recreates every item on change (it is implemented on top of `SignalFragment`). Prefer `View.eachWithKey` when item identity matters.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,11 @@ Then, add it to your ReScript project's `rescript.json`. You'll need to declare 
 
 The compiler flag `-open Xote` is optional, it makes the Xote modules available unqualified inside your source files.
 
-This README uses the application-facing names introduced for public code:
+This README uses the application-facing names for public code:
 
-- `View` is the official module for building and mounting DOM nodes.
-- `Node` is a deprecated compatibility alias for `View` and will be removed in a future release.
-- `Prop` is the official static-or-reactive prop module.
-- `ReactiveProp` is a deprecated compatibility alias for `Prop`.
-- `View.Text`, `View.Int`, `View.For`, `View.Show`, `View.Attr.*`, `Router.location`, and `SSRState.signal` are preferred in examples, while the deprecated `Node.signalText`, `Node.list`, `Node.keyedList`, `Node.attr`, `ReactiveProp.*`, and `SSRState.make` names remain supported.
+- `View` is the module for building and mounting DOM nodes.
+- `Prop` is the static-or-reactive prop module.
+- `View.Text`, `View.Int`, `View.For`, `View.Show`, `View.Attr.*`, `Router.location`, and `SSRState.signal` are the building blocks used throughout these examples.
 
 ### JavaScript
 
@@ -249,20 +247,37 @@ let tone = Signal.make("badge badge-info")
 </Badge>
 ```
 
-`Prop` is the source module for static-or-reactive props. `ReactiveProp` remains available as a deprecated compatibility alias.
+`Prop` is the module for static-or-reactive props.
 
 ### Router and SSR State
 
-Router state is signal-based. Read the shared location signal directly with `Router.location()`:
+Initialize the router once at your app entry, then describe your screens with
+the `Router.routes` component. Each route matches a pattern and receives the
+parsed params:
 
 ```rescript
 Router.init(())
 
-let pathname = () =>
-  <View.Text> {() => {
-    let location = Signal.get(Router.location())
-    "Current path: " ++ location.pathname
-  }} </View.Text>
+let app = () =>
+  Router.routes([
+    {pattern: "/", render: _ => <Home />},
+    {pattern: "/about", render: _ => <About />},
+    {
+      pattern: "/users/:id",
+      render: params =>
+        <UserPage id={params->Dict.get("id")->Option.getOr("")} />,
+    },
+  ])
+```
+
+Use the `Router.Link` component for client-side navigation without a full page
+reload:
+
+```rescript
+<nav>
+  <Router.Link to="/"> <View.Text> "Home" </View.Text> </Router.Link>
+  <Router.Link to="/about" class="nav-link"> <View.Text> "About" </View.Text> </Router.Link>
+</nav>
 ```
 
 For server/client state transfer, prefer `SSRState.signal` when creating a synced signal:

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -8,12 +8,10 @@ Xote uses [rescript-signals](https://brnrdog.github.io/rescript-signals) for rea
 
 The ReScript compiler is configured with `"namespace": true`, so every source file in `src/` is namespaced under `Xote`. The public modules are listed in `rescript.json` under `sources.public`:
 
-- **`Xote.View`**: Official UI node API for constructors, attributes, rendering, and mounting.
-- **`Xote.Node`**: Deprecated compatibility alias for `View`.
+- **`Xote.View`**: UI node API for constructors, attributes, rendering, and mounting.
 - **`Xote.Html`**: Convenience constructors for common HTML tags.
 - **`Xote.XoteJSX`**: JSX v4 transform support and lowercase HTML element definitions.
-- **`Xote.Prop`**: Official static-or-reactive prop wrapper for JSX-friendly APIs.
-- **`Xote.ReactiveProp`**: Deprecated compatibility alias for `Prop`.
+- **`Xote.Prop`**: Static-or-reactive prop wrapper for JSX-friendly APIs.
 - **`Xote.Route`**: Pure route pattern parsing and matching.
 - **`Xote.Router`**: Signal-based client and SSR routing helpers.
 - **`Xote.SSR`**: Server-side rendering to HTML strings.
@@ -22,7 +20,7 @@ The ReScript compiler is configured with `"namespace": true`, so every source fi
 - **`Xote.Hydration`**: Client-side hydration for server-rendered DOM.
 - **`Xote.Signal`**, **`Xote.Computed`**, **`Xote.Effect`**: Re-export shims for `rescript-signals`.
 
-There is no central `Xote.res` barrel and no `Xote__` prefixed source module naming. Consumers access modules through the generated namespace, for example `Xote.View`, `Xote.Router`, or unqualified `View` after `-open Xote`. `Node` remains available as a deprecated compatibility alias.
+There is no central `Xote.res` barrel and no `Xote__` prefixed source module naming. Consumers access modules through the generated namespace, for example `Xote.View`, `Xote.Router`, or unqualified `View` after `-open Xote`.
 
 Some implementation modules are currently nested inside public modules, such as `View.DOM`, `View.Reactivity`, `View.Render`, `SSR.Html`, `SSR.Markers`, and `Hydration.DOMWalker`. These exist to share implementation code inside the package and should be treated as internal details unless they are explicitly documented as public API.
 
@@ -49,7 +47,7 @@ Computed values and effects are also provided by `rescript-signals`:
 
 ### View And Rendering Model
 
-Xote components are functions that return `View.node`. `Node.node` remains available as the deprecated equivalent alias.
+Xote components are functions that return `View.node`.
 
 `View.node` variants:
 
@@ -82,8 +80,6 @@ Preferred public constructors:
 - `View.mount(node, container)`
 - `View.mountById(node, "root")`
 
-Deprecated `Node.*` entry points remain supported as aliases, including `Node.list` / `Node.keyedList` alongside `View.each` / `View.eachWithKey`.
-
 Rendering is fine-grained:
 
 - Static text renders once.
@@ -100,7 +96,7 @@ Attributes are represented as `(string, View.attrValue)` pairs:
 - `View.Attr.string(key, value)` for static string attributes.
 - `View.Attr.signal(key, signal)` for reactive string attributes.
 - `View.Attr.compute(key, fn)` for computed string attributes.
-- `View.attr`, `View.signalAttr`, and `View.computedAttr` remain available, and the equivalent deprecated `Node.*` names still forward to `View`.
+- `View.attr`, `View.signalAttr`, and `View.computedAttr` are equivalent shorthands for the `View.Attr.*` helpers.
 
 The DOM renderer maps selected names to DOM properties or boolean attribute behavior:
 
@@ -125,7 +121,7 @@ SSR mirrors the same boolean attribute behavior when rendering strings.
 type t<'a> = Reactive(Signal.t<'a>) | Static('a)
 ```
 
-Use `Prop.static(value)` or `Prop.reactive(signal)` when a component prop should support either static or reactive input. `ReactiveProp` remains available as a deprecated compatibility alias.
+Use `Prop.static(value)` or `Prop.signal(signal)` (alias of `Prop.reactive`) when a component prop should support either static or reactive input.
 
 ### Router
 
@@ -182,8 +178,6 @@ SSR uses comment markers to identify reactive boundaries for hydration:
 - `SSRState.restore(id, signal, codec)` restores state on the client.
 - `SSRState.sync(id, signal, codec)` registers or restores depending on runtime.
 - `SSRState.signal(id, initial, codec)` creates a signal and syncs it.
-- `SSRState.make(id, initial, codec)` remains available as the equivalent alias.
-- `SSRState.syncSignal(id, signal, codec)` is a clearer alias for `sync`.
 - `SSRState.generateScript(~nonce?)` serializes state into a script tag.
 - `SSRState.clear()` resets the server registry between independent renders.
 

--- a/examples/ssr/App.res
+++ b/examples/ssr/App.res
@@ -5,10 +5,10 @@
 
 /* Shared state factory - creates signals that sync between server and client */
 let makeAppState = () => {
-  /* Using SSRState.make creates the signal and syncs it automatically */
-  let count = SSRState.make("count", 0, SSRState.Codec.int)
+  /* Using SSRState.signal creates the signal and syncs it automatically */
+  let count = SSRState.signal("count", 0, SSRState.Codec.int)
 
-  let items = SSRState.make(
+  let items = SSRState.signal(
     "items",
     ["Apple", "Banana", "Cherry"],
     SSRState.Codec.array(SSRState.Codec.string),
@@ -106,7 +106,7 @@ let app = (count, items, inputValue) =>
             ),
             Html.ul(
               ~attrs=[View.attr("class", "item-list")],
-              ~children=[View.list(items, item => Html.li(~children=[View.text(item)], ()))],
+              ~children=[View.each(items, item => Html.li(~children=[View.text(item)], ()))],
               (),
             ),
           ],

--- a/examples/ssr/client.res
+++ b/examples/ssr/client.res
@@ -3,7 +3,7 @@
  * This script hydrates the server-rendered HTML
  */
 
-/* Create state - SSRState.make automatically restores from server-serialized values */
+/* Create state - SSRState.signal automatically restores from server-serialized values */
 let (count, items, inputValue) = App.makeAppState()
 let appComponent = App.app(count, items, inputValue)
 

--- a/package.json
+++ b/package.json
@@ -18,11 +18,9 @@
       "default": "./dist/client.mjs"
     },
     "./view": "./src/View.res.mjs",
-    "./node": "./src/Node.res.mjs",
     "./html": "./src/Html.res.mjs",
     "./jsx": "./src/XoteJSX.res.mjs",
     "./prop": "./src/Prop.res.mjs",
-    "./reactive-prop": "./src/ReactiveProp.res.mjs",
     "./route": "./src/Route.res.mjs",
     "./router": {
       "import": "./dist/router.mjs",

--- a/rescript.json
+++ b/rescript.json
@@ -7,11 +7,9 @@
       "subdirs": true,
       "public": [
         "View",
-        "Node",
         "Html",
         "XoteJSX",
         "Prop",
-        "ReactiveProp",
         "Route",
         "Router",
         "SSR",

--- a/src/Node.res
+++ b/src/Node.res
@@ -1,2 +1,0 @@
-@deprecated("Use View instead. Node is deprecated and will be removed in a future release.")
-include View

--- a/src/ReactiveProp.res
+++ b/src/ReactiveProp.res
@@ -1,2 +1,0 @@
-@deprecated("Use Prop instead. ReactiveProp is deprecated and will be removed in a future release.")
-include Prop

--- a/src/SSRState.res
+++ b/src/SSRState.res
@@ -239,11 +239,8 @@ let sync = (id: string, signal: Signal.t<'a>, codec: Codec.t<'a>): unit => {
 }
 
 /* Create and sync a signal in one call */
-let make = (id: string, initial: 'a, codec: Codec.t<'a>): Signal.t<'a> => {
+let signal = (id: string, initial: 'a, codec: Codec.t<'a>): Signal.t<'a> => {
   let signal = Signal.make(initial)
   sync(id, signal, codec)
   signal
 }
-
-let signal = make
-let syncSignal = sync

--- a/src/View.res
+++ b/src/View.res
@@ -568,8 +568,6 @@ let each = (signal: Signal.t<array<'a>>, renderItem: 'a => node): node => {
   SignalFragment(nodesSignal)
 }
 
-let list = each
-
 let eachWithKey = (
   signal: Signal.t<array<'a>>,
   keyFn: 'a => string,
@@ -581,8 +579,6 @@ let eachWithKey = (
     renderItem: Obj.magic(renderItem),
   })
 }
-
-let keyedList = eachWithKey
 
 /* JSX rendering primitives */
 module For = {

--- a/tests/Component_test.res
+++ b/tests/Component_test.res
@@ -157,7 +157,7 @@ let suite = Zekr.suite(
       let {container} = Dom.render("")
       let items = Signal.make(["Apple", "Banana"])
       let _ = mountTo(
-        Html.div(~children=[View.list(items, item => Html.p(~children=[View.text(item)], ()))], ()),
+        Html.div(~children=[View.each(items, item => Html.p(~children=[View.text(item)], ()))], ()),
         container,
       )
       let r1 = Dom.Assert.toHaveTextContent(container, "AppleBanana")

--- a/tests/KeyedList_test.res
+++ b/tests/KeyedList_test.res
@@ -27,7 +27,7 @@ let suite = Zekr.suite(
           ~children=[
             Html.ul(
               ~children=[
-                View.keyedList(
+                View.eachWithKey(
                   items,
                   item => item.id,
                   item => Html.li(~children=[View.text(item.label)], ()),
@@ -50,7 +50,7 @@ let suite = Zekr.suite(
           ~children=[
             Html.ul(
               ~children=[
-                View.keyedList(
+                View.eachWithKey(
                   items,
                   item => item.id,
                   item => Html.li(~children=[View.text(item.label)], ()),
@@ -77,7 +77,7 @@ let suite = Zekr.suite(
           ~children=[
             Html.ul(
               ~children=[
-                View.keyedList(
+                View.eachWithKey(
                   items,
                   item => item.id,
                   item => Html.li(~children=[View.text(item.label)], ()),
@@ -108,7 +108,7 @@ let suite = Zekr.suite(
           ~children=[
             Html.ul(
               ~children=[
-                View.keyedList(
+                View.eachWithKey(
                   items,
                   item => item.id,
                   item => Html.li(~children=[View.text(item.label)], ()),
@@ -139,7 +139,7 @@ let suite = Zekr.suite(
           ~children=[
             Html.ul(
               ~children=[
-                View.keyedList(
+                View.eachWithKey(
                   items,
                   item => item.id,
                   item => Html.li(~children=[View.text(item.label)], ()),
@@ -166,7 +166,7 @@ let suite = Zekr.suite(
           ~children=[
             Html.ul(
               ~children=[
-                View.keyedList(
+                View.eachWithKey(
                   items,
                   item => item.id,
                   item => Html.li(~children=[View.text(item.label)], ()),
@@ -190,7 +190,7 @@ let suite = Zekr.suite(
           ~children=[
             Html.ul(
               ~children=[
-                View.keyedList(
+                View.eachWithKey(
                   items,
                   item => item.id,
                   item => Html.li(~children=[View.text(item.label)], ()),

--- a/tests/SSR_test.res
+++ b/tests/SSR_test.res
@@ -60,7 +60,7 @@ let suite = Zekr.suite(
     test("wraps keyed list items with key markers", () => {
       let html = SSR.renderToString(() => {
         let items = Signal.make(["a", "b"])
-        View.keyedList(items, item => item, item => Html.span(~children=[View.text(item)], ()))
+        View.eachWithKey(items, item => item, item => Html.span(~children=[View.text(item)], ()))
       })
       combineResults([
         assertContains(html, "<!--kl-->"),


### PR DESCRIPTION
Prepare for the next major release by deleting APIs that were already deprecated and trimming redundant function/alias surface.

BREAKING CHANGE:
- Remove the deprecated `Node` module (use `View`)
- Remove the deprecated `ReactiveProp` module (use `Prop`)
- Remove `View.list` / `View.keyedList` aliases (use `View.each` / `View.eachWithKey`)
- Remove `SSRState.make` (use `SSRState.signal`) and `SSRState.syncSignal` (use `SSRState.sync`)

Also drops the `Node`/`ReactiveProp` entries from `rescript.json` `sources.public` and the `./node` / `./reactive-prop` package exports, migrates in-repo examples/tests to the canonical names, and refreshes the README (favouring the Router/Route/Link component APIs in the Router section), CLAUDE.md, AGENTS.md, and the technical overview.