### PR TITLE
View.tracked and @xote.component for automatic fine-grained leaves

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,10 @@ docs-website/**/* linguist-documentation
 # Config files
 vite.config.js linguist-vendored
 
+# Shell scripts must keep LF endings even when checked out on Windows, where
+# git's core.autocrlf would otherwise rewrite them. The ppx binary matrix runs
+# ppx/build.sh under Cygwin bash on windows-latest, and a CRLF `set -e` fails
+# with "set: -: invalid option" before the script does anything.
+*.sh text eol=lf
+
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,15 @@ jobs:
       - name: Run tests
         run: node tests/Tests.res.mjs
 
+      # The @tracked ppx (ppx/) is an opt-in native binary, not part of the
+      # published package. Build and exercise it here so it can't rot; needs
+      # only ocamlopt (no opam).
+      - name: Set up OCaml (for @tracked ppx)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ocaml-nox
+
+      - name: Build & verify @tracked ppx
+        run: npm run ppx:test
+
       - name: Vite Build
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,14 @@ permissions:
   pull-requests: write
 
 jobs:
+  # The five-platform ppx binary matrix does NOT run here on every push: it
+  # lives in ppx-binaries.yml, triggered by release.yml, by changes to
+  # ppx/** or that workflow, and by a weekly drift-canary schedule. The test
+  # job below still builds and e2e-tests the ppx on Linux each run.
   test:
-    runs-on: ubuntu-latest
+    # Pinned (not -latest) so apt's OCaml stays 4.14, matching the compiler
+    # ppx-binaries.yml pins for the shipped binaries. Bump both together.
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -36,13 +42,14 @@ jobs:
       - name: Run tests
         run: node tests/Tests.res.mjs
 
-      # The @tracked ppx (ppx/) is an opt-in native binary, not part of the
-      # published package. Build and exercise it here so it can't rot; needs
-      # only ocamlopt (no opam).
-      - name: Set up OCaml (for @tracked ppx)
+      # The @xote.component ppx (ppx/) ships in the npm package as prebuilt
+      # binaries (see ppx-binaries.yml / release.yml). Build it from source
+      # and run the example's jsdom verification here so the transform can't
+      # rot; needs only ocamlopt (no opam).
+      - name: Set up OCaml (for the @xote.component ppx)
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ocaml-nox
 
-      - name: Build & verify @tracked ppx
+      - name: Build & verify @xote.component ppx
         run: npm run ppx:test
 
       - name: Vite Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,14 @@ permissions:
   pull-requests: write
 
 jobs:
+  # The five-platform ppx binary matrix does NOT run here on every push: it
+  # lives in ppx-binaries.yml, triggered by release.yml, by changes to
+  # ppx/** or that workflow, and by a weekly drift-canary schedule. The test
+  # job below still builds and e2e-tests the ppx on Linux each run.
   test:
-    runs-on: ubuntu-latest
+    # Pinned (not -latest) so apt's OCaml stays 4.14, matching the compiler
+    # ppx-binaries.yml pins for the shipped binaries. Bump both together.
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -35,6 +41,30 @@ jobs:
 
       - name: Run tests
         run: node tests/Tests.res.mjs
+
+      # The @xote.component ppx (ppx/) ships in the npm package as prebuilt
+      # binaries (see ppx-binaries.yml / release.yml). Build it from source
+      # and run the example's jsdom verification here so the transform can't
+      # rot; needs only ocamlopt (no opam).
+      - name: Set up OCaml (for the @xote.component ppx)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ocaml-nox
+
+      - name: Build & verify @xote.component ppx
+        run: npm run ppx:test
+
+      # The docs site is the only real *consumer* of the ppx in this repo — its
+      # own rescript.json carries the ppx-flags and its sources are ordinary
+      # @xote.component components, so this catches a broken consumer config or
+      # a ppx regression the in-repo example cannot see. deploy-docs.yml runs
+      # only on push to main, so before this step a malformed
+      # docs-website/rescript.json passed PR CI green and broke after merge —
+      # which is exactly how it reached this branch. Compiling 47 modules takes
+      # about two seconds; the vite/SSR/prerender stages stay in deploy-docs.
+      - name: Compile docs site through the ppx (real consumer)
+        run: |
+          cd docs-website
+          npm install
+          npm run res:build
 
       - name: Vite Build
         run: npm run build

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,6 +39,11 @@ jobs:
           cd docs-website
           npm ci
 
+      # The docs site uses the @tracked ppx (a native binary built from
+      # ppx/ppx.ml during its res:build); ocamlopt is the only build dep.
+      - name: Set up OCaml (for @tracked ppx)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ocaml-nox
+
       - name: Build website
         env:
           SITE_URL: https://xote.dev

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Pinned (not -latest) so apt's OCaml stays 4.14, matching the compiler
+    # ppx-binaries.yml pins for the shipped binaries. Bump both together.
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,9 +41,9 @@ jobs:
           cd docs-website
           npm ci
 
-      # The docs site uses the @tracked ppx (a native binary built from
+      # The docs site uses the @xote.component ppx (a native binary built from
       # ppx/ppx.ml during its res:build); ocamlopt is the only build dep.
-      - name: Set up OCaml (for @tracked ppx)
+      - name: Set up OCaml (for the @xote.component ppx)
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ocaml-nox
 
       - name: Build website

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Pinned (not -latest) so apt's OCaml stays 4.14, matching the compiler
+    # ppx-binaries.yml pins for the shipped binaries. Bump both together.
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,6 +40,11 @@ jobs:
         run: |
           cd docs-website
           npm ci
+
+      # The docs site uses the @xote.component ppx (a native binary built from
+      # ppx/ppx.ml during its res:build); ocamlopt is the only build dep.
+      - name: Set up OCaml (for the @xote.component ppx)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ocaml-nox
 
       - name: Build website
         env:

--- a/.github/workflows/ppx-binaries.yml
+++ b/.github/workflows/ppx-binaries.yml
@@ -1,0 +1,78 @@
+name: PPX binaries
+
+# Builds the @xote.component ppx as a native binary for every supported
+# platform. Runs where it can actually catch something, not on every push:
+#   - called from release.yml (the binaries are downloaded into ppx/bin/ and
+#     shipped in the npm tarball; ppx/postinstall.js selects one at install);
+#   - on PRs/pushes that touch the ppx source or this workflow;
+#   - weekly, as a canary for environment drift (runner retirements,
+#     setup-ocaml changes) so a broken target surfaces before release day.
+# The regular CI test job still compiles and e2e-tests the ppx on Linux on
+# every push.
+
+on:
+  workflow_call: {}
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "ppx/**"
+      - ".github/workflows/ppx-binaries.yml"
+  push:
+    branches: [main]
+    paths:
+      - "ppx/**"
+      - ".github/workflows/ppx-binaries.yml"
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+          - os: macos-15-intel
+            target: darwin-x64
+          - os: macos-latest
+            target: darwin-arm64
+          - os: windows-latest
+            target: win32-x64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "4.14"
+
+      # Call ppx/build.sh rather than repeating its ocamlopt line here: it takes
+      # the output path (relative to ppx/) for exactly this reason. This step
+      # used to inline the command under a "same invocation as build.sh" comment,
+      # and when build.sh started compiling ast.ml alongside ppx.ml the copy here
+      # did not, so all five platforms failed with "Unbound module Ast" while the
+      # local build was green. One definition, no drift.
+      - name: Compile ppx binary
+        shell: bash
+        run: opam exec -- sh ppx/build.sh "bin/ppx-${{ matrix.target }}.exe"
+
+      # The binary must actually *run* on its host platform — `--help` proves
+      # the executable loads (right arch, libc, DLLs), which the release
+      # workflow's size check cannot. This is the only step that executes the
+      # exact artifact that ships.
+      - name: Smoke-test binary
+        shell: bash
+        run: ./ppx/bin/ppx-${{ matrix.target }}.exe --help
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ppx-${{ matrix.target }}
+          path: ppx/bin/ppx-*.exe
+          if-no-files-found: error

--- a/.github/workflows/ppx-binaries.yml
+++ b/.github/workflows/ppx-binaries.yml
@@ -1,0 +1,75 @@
+name: PPX binaries
+
+# Builds the @xote.component ppx as a native binary for every supported
+# platform. Runs where it can actually catch something, not on every push:
+#   - called from release.yml (the binaries are downloaded into ppx/bin/ and
+#     shipped in the npm tarball; ppx/postinstall.js selects one at install);
+#   - on PRs/pushes that touch the ppx source or this workflow;
+#   - weekly, as a canary for environment drift (runner retirements,
+#     setup-ocaml changes) so a broken target surfaces before release day.
+# The regular CI test job still compiles and e2e-tests the ppx on Linux on
+# every push.
+
+on:
+  workflow_call: {}
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "ppx/**"
+      - ".github/workflows/ppx-binaries.yml"
+  push:
+    branches: [main]
+    paths:
+      - "ppx/**"
+      - ".github/workflows/ppx-binaries.yml"
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+          - os: macos-15-intel
+            target: darwin-x64
+          - os: macos-latest
+            target: darwin-arm64
+          - os: windows-latest
+            target: win32-x64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "4.14"
+
+      # Same invocation as ppx/build.sh, with the target-specific output path.
+      - name: Compile ppx binary
+        shell: bash
+        run: |
+          mkdir -p ppx/bin
+          opam exec -- ocamlopt -w -a-31 ppx/ppx.ml -o "ppx/bin/ppx-${{ matrix.target }}.exe"
+
+      # The binary must actually *run* on its host platform — `--help` proves
+      # the executable loads (right arch, libc, DLLs), which the release
+      # workflow's size check cannot. This is the only step that executes the
+      # exact artifact that ships.
+      - name: Smoke-test binary
+        shell: bash
+        run: ./ppx/bin/ppx-${{ matrix.target }}.exe --help
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ppx-${{ matrix.target }}
+          path: ppx/bin/ppx-*.exe
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Build the per-platform @xote.component ppx binaries that ship in the npm
+  # tarball (ppx/bin/, selected at install time by ppx/postinstall.js).
+  ppx-binaries:
+    uses: ./.github/workflows/ppx-binaries.yml
+
   release:
     runs-on: ubuntu-latest
+    needs: ppx-binaries
 
     steps:
       - name: Checkout
@@ -41,6 +47,36 @@ jobs:
 
       - name: Vite Build
         run: npm run build
+
+      - name: Download prebuilt ppx binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ppx-*
+          path: ppx/bin
+          merge-multiple: true
+
+      - name: Verify ppx binaries
+        run: |
+          for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64; do
+            test -s "ppx/bin/ppx-$target.exe" || { echo "missing ppx binary for $target"; exit 1; }
+          done
+          chmod +x ppx/bin/*.exe
+          ls -l ppx/bin
+          # execute the one binary this runner can run (the per-platform
+          # smoke test lives in ppx-binaries.yml, on each native runner)
+          ./ppx/bin/ppx-linux-x64.exe --help
+
+      # Binaries present on disk is not enough: ignore rules can silently
+      # strip them from the tarball (nested .gitignore files are honored by
+      # npm pack even inside "files"-whitelisted directories). Assert the
+      # packed file list itself.
+      - name: Verify ppx binaries are packed
+        run: |
+          pack="$(npm pack --dry-run 2>&1)"
+          for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64; do
+            echo "$pack" | grep -q "ppx/bin/ppx-$target.exe" \
+              || { echo "ppx binary for $target missing from npm tarball"; exit 1; }
+          done
 
       - name: Release
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ bundle-size-*.json
 /docs-website/build/
 /docs-website/.cache-loader/
 /docs-website/static/assets/
+
+# Compiled ppx binaries (kept out of ppx/.gitignore on purpose: npm honors
+# nested ignore files when packing, and ppx/bin must ship in the tarball)
+/ppx/ppx
+/ppx/ppx.exe
+/ppx/bin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ The root `xote` entry is client-focused and does not export router, SSR, hydrati
 These three are thin shims (`src/Signal.res`, `src/Computed.res`, `src/Effect.res`) that `include` the corresponding modules from `rescript-signals`.
 
 **Xote Modules:**
-- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
+- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `tracked`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
 - **`Xote.Html`**: Convenience constructors for common HTML tags (`div`, `span`, `button`, `input`, `h1`-`h3`, `p`, `ul`, `li`, `a`). Thin wrappers over `View.element`. For tags not listed, call `View.element(tag, ...)` directly or use JSX.
 - **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes) plus an `attrs` escape hatch for anything else. Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `View.LazyComponent`.
 - **`Xote.MaybeSignal`**: Static-or-reactive value wrapper exposing the type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` plus `static`, `reactive`, `computed` (derives a `Reactive` from a `unit => 'a`), `get` (tracked read), `peek` (untracked read), `isStatic`/`isReactive`, `map`, `toSignal`, and `ofUnknown`. Use it anywhere an API should accept either a plain value or a signal — JSX props are the most common case, not the only one. Notes on the trickier members:
@@ -385,6 +385,22 @@ Html.button(
   ()
 )
 ```
+
+### Auto-tracked blocks
+```rescript
+/* Every signal read inside the body subscribes the block automatically —
+   no thunk-per-binding. The block re-evaluates and replaces its children
+   wholesale (no diffing) when any dependency changes, so keep tracked
+   blocks small and use eachWithKey/For for lists. */
+View.tracked(() =>
+  if Signal.get(loggedIn) {
+    Html.p(~children=[View.text("Hello, " ++ Signal.get(name))], ())
+  } else {
+    View.text("Please log in")
+  }
+)
+```
+Dependencies are re-discovered on every run, so conditional reads work: above, `name` is only tracked while `loggedIn` is true. `tracked` lowers to `SignalFragment` + `Computed`, so SSR markers and hydration work unchanged.
 
 ### Lists
 ```rescript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,16 @@ Xote is a lightweight UI library for ReScript that combines fine-grained reactiv
 ### Testing
 - `npm run test` - Compile ReScript and run `node tests/Tests.res.mjs`. Tests are built on the [zekr](https://www.npmjs.com/package/zekr) framework (see `tests/Tests.res`) and include snapshot fixtures under `tests/__snapshots__/`.
 
+### PPX (`@xote.component`)
+- `npm run ppx:build` - Compile the native PPX binary from `ppx/ppx.ml` (needs `ocamlopt`)
+- `npm run ppx:test` - Build the PPX and run the end-to-end example verification (`ppx/example/`, jsdom)
+
 ### Documentation
 - `npm run docs:start` - Start documentation site
 - `npm run docs:build` - Build documentation site
 - `npm run docs:serve` - Serve built documentation site
+
+Note: the docs site is a real PPX consumer — its `res:build` compiles the PPX first, so building `docs-website/` locally requires `ocamlopt` on the `PATH` (any recent OCaml; CI uses 4.14 via apt `ocaml-nox`).
 
 ### Build Artifacts
 The build process generates:
@@ -98,8 +104,8 @@ All reactive behavior is provided by **rescript-signals**:
 
 - **Build system**: ReScript compiler v12+ with `esmodule` output format
 - **Output**: In-source compilation (`.res.mjs` files alongside `.res` files)
-- **Namespacing**: `namespace: true` in `rescript.json` automatically scopes every module under `Xote`. Public modules are listed explicitly in `sources.public` (`View`, `Html`, `XoteJSX`, `MaybeSignal`, `Prop`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Mdx`, `Signal`, `Computed`, `Effect`); everything else (e.g. `DOM`/`Reactivity`, which live inside `View.res`) stays internal.
-- **Dependencies**: `rescript-signals` ^3.1.0 (the only runtime dependency)
+- **Namespacing**: `namespace: true` in `rescript.json` automatically scopes every module under `Xote`. Public modules are listed explicitly in `sources.public` (`View`, `Html`, `XoteJSX`, `MaybeSignal`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Mdx`, `Signal`, `Computed`, `Effect`); everything else (e.g. `DOM`/`Reactivity`, which live inside `View.res`) stays internal.
+- **Dependencies**: `rescript-signals` ^3.1.0 and `@rescript/core` ^1.6.1 (the only runtime dependencies)
 - **JSX**: ReScript JSX v4 configured with `module: "XoteJSX"` (generic JSX transform). Consumers must mirror this in their own `rescript.json`.
 
 ### Component System
@@ -131,6 +137,18 @@ Xote supports **two syntax styles**:
 7. **Null node**: `View.null()` - renders an empty text node
 8. **HTML element helpers**: `Html.div`, `Html.button`, `Html.p`, etc. live in the `Xote.Html` module — use them when writing the function-based API. For tags not covered, fall back to `View.element("tag", ...)`.
 9. **Mounting**: `mount(node, container)` or `mountById(node, "element-id")` to attach to DOM
+
+#### The `@xote.component` PPX (standard authoring model)
+
+`@xote.component` (implemented by the native PPX in `ppx/ppx.ml`, enabled by consumers via `"ppx-flags": ["xote/ppx/ppx"]`) is the recommended way to write components. It derives the props record exactly like `@jsx.component` (which it emits under the hood, so its one-component-per-module rule applies) **and** decomposes the returned JSX into fine-grained reactive leaves:
+
+- an attribute or `<View.Text/Int/Float/Bool>` child that *eagerly* reads a signal is thunked, so only that leaf re-runs;
+- a **bare `{…}` child** (scalar, signal read, array, node) is wrapped in `View.child`, which coerces it at runtime — no value-primitive ceremony;
+- an `if`/`switch` in child position is wrapped in `View.tracked`, tracking only the condition/scrutinee (including reads in `when` guards); leaves inside branches stay fine-grained;
+- values that are already reactive (a `() => …` thunk, a `Computed`, `Prop.reactive(…)`) are left alone — the annotation is a safe drop-in;
+- **user-component props are never thunked**: `<Card label={Signal.get(x)} />` is a deliberate one-shot read; pass the signal itself for a reactive prop. Children and JSX-valued props of user components are still decomposed.
+
+Detection follows local aliases (`let g = Signal.get`, `module S = Signal`, `open Signal`, local reactive helpers) but is syntactic: reads hidden behind imported helpers, or hoisted into a plain `let` binding (`let label = Signal.get(count)->Int.toString`), compile to *static one-shot values with no error*. The escape hatch is to wrap the value in `() => …` yourself. Full rules and limitations: `ppx/README.md`. The npm package ships the PPX as prebuilt per-platform binaries selected by `ppx/postinstall.js`; Xote's own `src/` never uses the annotation.
 
 #### JSX Syntax
 Xote supports ReScript's generic JSX v4 for a declarative component syntax:
@@ -596,6 +614,9 @@ Guidance for AI coding agents (and humans) making changes to this repository.
 | `src/MaybeSignal.res` | Static/Reactive value wrapper |
 | `src/Prop.res`, `src/Prop.resi` | Deprecated alias of `MaybeSignal` (the interface file is what makes the deprecations warn) |
 | `src/Signal.res`, `src/Computed.res`, `src/Effect.res` | Re-export shims for `rescript-signals` |
+| `ppx/ppx.ml` | The `@xote.component` fine-grained PPX (vendored OCaml 4.06 AST + rewriter) |
+| `ppx/example/` | Standalone PPX consumer project; `verify.mjs` is its jsdom regression suite (`npm run ppx:test`) |
+| `ppx/postinstall.js` | Selects/installs the prebuilt PPX binary at npm install time |
 | `rescript.json` | ReScript compiler configuration (`namespace: true`) |
 | `vite.config.js` | Library build configuration |
 
@@ -626,6 +647,7 @@ The project has a test suite using the [zekr](https://github.com/nicholasgasior/
 3. Successful Vite build (`npm run build`)
 4. Manual testing with demo apps (`npm run dev`)
 5. For SSR changes, check the `examples/ssr/` setup
+6. For PPX or `View.child`/`View.tracked` changes, run the end-to-end suite: `npm run ppx:test` (needs `ocamlopt`)
 
 #### Test Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ The root `xote` entry is client-focused and does not export router, SSR, hydrati
 These three are thin shims (`src/Signal.res`, `src/Computed.res`, `src/Effect.res`) that `include` the corresponding modules from `rescript-signals`.
 
 **Xote Modules:**
-- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `tracked`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
+- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `tracked`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. It also exposes the two helpers `@xote.component` emits: `child` (runtime coercion of a bare JSX child) and `probe` (hidden-read detection — see the PPX section below). The owner-based reactivity system for resource cleanup also lives here.
 - **`Xote.Html`**: Convenience constructors for common HTML tags (`div`, `span`, `button`, `input`, `h1`-`h3`, `p`, `ul`, `li`, `a`). Thin wrappers over `View.element`. For tags not listed, call `View.element(tag, ...)` directly or use JSX.
 - **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes) plus an `attrs` escape hatch for anything else. Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `View.LazyComponent`.
 - **`Xote.MaybeSignal`**: Static-or-reactive value wrapper exposing the type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` plus `static`, `reactive`, `computed` (derives a `Reactive` from a `unit => 'a`), `get` (tracked read), `peek` (untracked read), `isStatic`/`isReactive`, `map`, `toSignal`, and `ofUnknown`. Use it anywhere an API should accept either a plain value or a signal — JSX props are the most common case, not the only one. Notes on the trickier members:
@@ -148,7 +148,9 @@ Xote supports **two syntax styles**:
 - values that are already reactive (a `() => …` thunk, a `Computed`, `Prop.reactive(…)`) are left alone — the annotation is a safe drop-in;
 - **user-component props are never thunked**: `<Card label={Signal.get(x)} />` is a deliberate one-shot read; pass the signal itself for a reactive prop. Children and JSX-valued props of user components are still decomposed.
 
-Detection follows local aliases (`let g = Signal.get`, `module S = Signal`, `open Signal`, local reactive helpers) but is syntactic: reads hidden behind imported helpers, or hoisted into a plain `let` binding (`let label = Signal.get(count)->Int.toString`), compile to *static one-shot values with no error*. The escape hatch is to wrap the value in `() => …` yourself. Full rules and limitations: `ppx/README.md`. The npm package ships the PPX as prebuilt per-platform binaries selected by `ppx/postinstall.js`; Xote's own `src/` never uses the annotation.
+Detection covers `Signal.get` **and** `MaybeSignal.get`/`Prop.get`, and follows aliases (`let g = Signal.get`, `module S = Signal`, `open Signal`), local reactive helpers, and helpers in a module declared in the same file. It is still syntactic, so reads hidden behind an **imported** helper, or hoisted into a plain `let` binding (`let label = Signal.get(count)->Int.toString`), compile to static one-shot values; the escape hatch is to wrap the value in `() => …` yourself.
+
+Those remaining cases are no longer silent. A value leaf whose expression contains a call the PPX cannot resolve is emitted wrapped in `View.probe`: on its **first** evaluation it runs inside a throwaway computed and, if that computed subscribed to anything, a warning naming the source location is logged (and the value is read back through the computed, so an enclosing `tracked` block's dependencies are unchanged). No dependencies means no warning and no behaviour change, so there are no false positives. Each site is probed once — later evaluations are a plain call — and probing is skipped entirely when `globalThis.__XOTE_DEV__` or `process.env.NODE_ENV` says production. Full rules and limitations: `ppx/README.md`. The npm package ships the PPX as prebuilt per-platform binaries selected by `ppx/postinstall.js`; Xote's own `src/` never uses the annotation.
 
 #### JSX Syntax
 Xote supports ReScript's generic JSX v4 for a declarative component syntax:
@@ -615,7 +617,7 @@ Guidance for AI coding agents (and humans) making changes to this repository.
 | `src/Prop.res`, `src/Prop.resi` | Deprecated alias of `MaybeSignal` (the interface file is what makes the deprecations warn) |
 | `src/Signal.res`, `src/Computed.res`, `src/Effect.res` | Re-export shims for `rescript-signals` |
 | `ppx/ppx.ml` | The `@xote.component` fine-grained PPX (vendored OCaml 4.06 AST + rewriter) |
-| `ppx/example/` | Standalone PPX consumer project; `verify.mjs` is its jsdom regression suite (`npm run ppx:test`) |
+| `ppx/example/` | Standalone PPX consumer project; `verify.mjs` is its jsdom regression suite (`npm run ppx:test`). `src/Store.res` is deliberately a *second* file, so its helpers model the cross-module reads detection cannot follow |
 | `ppx/postinstall.js` | Selects/installs the prebuilt PPX binary at npm install time |
 | `rescript.json` | ReScript compiler configuration (`namespace: true`) |
 | `vite.config.js` | Library build configuration |
@@ -658,6 +660,7 @@ The project has a test suite using the [zekr](https://github.com/nicholasgasior/
 | `tests/JSX_test.res` | JSX transform |
 | `tests/MaybeSignal_test.res` | `MaybeSignal` helpers and the deprecated `Prop` alias |
 | `tests/KeyedList_test.res` | Keyed list reconciliation |
+| `tests/Probe_test.res` | `View.probe` hidden-read detection (reports, false positives, dedupe) |
 | `tests/Route_test.res` | Route matching |
 | `tests/SSR_test.res` | Server-side rendering |
 | `tests/SSRState_test.res` | State serialization |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,16 @@ Xote is a lightweight UI library for ReScript that combines fine-grained reactiv
 ### Testing
 - `npm run test` - Compile ReScript and run `node tests/Tests.res.mjs`. Tests are built on the [zekr](https://www.npmjs.com/package/zekr) framework (see `tests/Tests.res`) and include snapshot fixtures under `tests/__snapshots__/`.
 
+### PPX (`@xote.component`)
+- `npm run ppx:build` - Compile the native PPX binary from `ppx/ppx.ml` (needs `ocamlopt`)
+- `npm run ppx:test` - Build the PPX and run the end-to-end example verification (`ppx/example/`, jsdom)
+
 ### Documentation
 - `npm run docs:start` - Start documentation site
 - `npm run docs:build` - Build documentation site
 - `npm run docs:serve` - Serve built documentation site
+
+Note: the docs site is a real PPX consumer — its `res:build` compiles the PPX first, so building `docs-website/` locally requires `ocamlopt` on the `PATH` (any recent OCaml; CI uses 4.14 via apt `ocaml-nox`).
 
 ### Build Artifacts
 The build process generates:
@@ -62,7 +68,7 @@ The root `xote` entry is client-focused and does not export router, SSR, hydrati
 These three are thin shims (`src/Signal.res`, `src/Computed.res`, `src/Effect.res`) that `include` the corresponding modules from `rescript-signals`.
 
 **Xote Modules:**
-- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
+- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `tracked`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. It also exposes the two helpers `@xote.component` emits: `child` (runtime coercion of a bare JSX child) and `probe` (hidden-read detection — see the PPX section below). Note that `child` is typed `'a => node`, so it **erases type checking in child position**: under the annotation a record or variant in `{…}` compiles and renders `"[object Object]"` with a development-only console warning (gated on the same `__XOTE_DEV__` / `NODE_ENV` flag as `probe`), where unannotated code would have failed to compile. That is the deliberate price of the zero-ceremony bare child. The owner-based reactivity system for resource cleanup also lives here.
 - **`Xote.Html`**: Convenience constructors for common HTML tags (`div`, `span`, `button`, `input`, `h1`-`h3`, `p`, `ul`, `li`, `a`). Thin wrappers over `View.element`. For tags not listed, call `View.element(tag, ...)` directly or use JSX.
 - **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes) plus an `attrs` escape hatch for anything else. Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `View.LazyComponent`.
 - **`Xote.MaybeSignal`**: Static-or-reactive value wrapper exposing the type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` plus `static`, `reactive`, `computed` (derives a `Reactive` from a `unit => 'a`), `get` (tracked read), `peek` (untracked read), `isStatic`/`isReactive`, `map`, `toSignal`, and `ofUnknown`. Use it anywhere an API should accept either a plain value or a signal — JSX props are the most common case, not the only one. Notes on the trickier members:
@@ -98,8 +104,8 @@ All reactive behavior is provided by **rescript-signals**:
 
 - **Build system**: ReScript compiler v12+ with `esmodule` output format
 - **Output**: In-source compilation (`.res.mjs` files alongside `.res` files)
-- **Namespacing**: `namespace: true` in `rescript.json` automatically scopes every module under `Xote`. Public modules are listed explicitly in `sources.public` (`View`, `Html`, `XoteJSX`, `MaybeSignal`, `Prop`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Mdx`, `Signal`, `Computed`, `Effect`); everything else (e.g. `DOM`/`Reactivity`, which live inside `View.res`) stays internal.
-- **Dependencies**: `rescript-signals` ^3.1.0 (the only runtime dependency)
+- **Namespacing**: `namespace: true` in `rescript.json` automatically scopes every module under `Xote`. Public modules are listed explicitly in `sources.public` (`View`, `Html`, `XoteJSX`, `MaybeSignal`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Mdx`, `Signal`, `Computed`, `Effect`); everything else (e.g. `DOM`/`Reactivity`, which live inside `View.res`) stays internal.
+- **Dependencies**: `rescript-signals` ^3.1.0 and `@rescript/core` ^1.6.1 (the only runtime dependencies)
 - **JSX**: ReScript JSX v4 configured with `module: "XoteJSX"` (generic JSX transform). Consumers must mirror this in their own `rescript.json`.
 
 ### Component System
@@ -131,6 +137,20 @@ Xote supports **two syntax styles**:
 7. **Null node**: `View.null()` - renders an empty text node
 8. **HTML element helpers**: `Html.div`, `Html.button`, `Html.p`, etc. live in the `Xote.Html` module — use them when writing the function-based API. For tags not covered, fall back to `View.element("tag", ...)`.
 9. **Mounting**: `mount(node, container)` or `mountById(node, "element-id")` to attach to DOM
+
+#### The `@xote.component` PPX (recommended; semantics not yet frozen)
+
+`@xote.component` (implemented by the native PPX in `ppx/ppx.ml`, enabled by consumers via `"ppx-flags": ["xote/ppx/ppx"]`) is the recommended way to write components. Its semantics are **not frozen** — the per-file opt-in, `View.child`'s untyped child position, and never-thunking user-component props are all still open (see "Not settled yet" in `ppx/README.md`). It derives the props record exactly like `@jsx.component` (which it emits under the hood, so its one-component-per-module rule applies) **and** decomposes the returned JSX into fine-grained reactive leaves:
+
+- an attribute or `<View.Text/Int/Float/Bool>` child that *eagerly* reads a signal is thunked, so only that leaf re-runs;
+- a **bare `{…}` child** (scalar, signal read, array, node) is wrapped in `View.child`, which coerces it at runtime — no value-primitive ceremony;
+- an `if`/`switch` in child position is wrapped in `View.tracked`, tracking only the condition/scrutinee (including reads in `when` guards); leaves inside branches stay fine-grained;
+- values that are already reactive (a `() => …` thunk, a `Computed`, `Prop.reactive(…)`) are left alone — the annotation is a safe drop-in;
+- **user-component props are never thunked**: `<Card label={Signal.get(x)} />` is a deliberate one-shot read; pass the signal itself for a reactive prop. Children and JSX-valued props of user components are still decomposed.
+
+Detection covers `Signal.get` **and** `MaybeSignal.get`/`Prop.get`, and follows aliases (`let g = Signal.get`, `module S = Signal`, `open Signal`), local reactive helpers, and helpers in a module declared in the same file. It is still syntactic, so reads hidden behind an **imported** helper, or hoisted into a plain `let` binding (`let label = Signal.get(count)->Int.toString`), compile to static one-shot values; the escape hatch is to wrap the value in `() => …` yourself.
+
+Those remaining cases are no longer silent. A value leaf whose expression contains a call the PPX cannot resolve is emitted wrapped in `View.probe`: on its **first** evaluation it runs inside a throwaway computed and, if that computed subscribed to anything, a warning naming the source location is logged (and the value is read back through the computed, so an enclosing `tracked` block's dependencies are unchanged). No dependencies means no warning and no behaviour change, so there are no false positives. Each site is probed once — later evaluations are a plain call — and probing is skipped entirely when `globalThis.__XOTE_DEV__` or `process.env.NODE_ENV` says production. Full rules and limitations: `ppx/README.md`. The npm package ships the PPX as prebuilt per-platform binaries selected by `ppx/postinstall.js`; Xote's own `src/` never uses the annotation.
 
 #### JSX Syntax
 Xote supports ReScript's generic JSX v4 for a declarative component syntax:
@@ -261,6 +281,8 @@ The `DOM.setAttrOrProp` helper (in `View.res`, via the internal `RuntimeDom` mod
 
 17. **JSX component laziness**: `XoteJSX.jsx` wraps user component functions in `View.LazyComponent`, deferring evaluation until render time so effects/computeds created inside a component aren't incorrectly tracked by a surrounding `Computed` context.
 
+18. **Tracked blocks**: `View.tracked(body)` lowers to `SignalFragment(Computed.make(() => [body()]))`. Every signal read while `body` runs subscribes the block, and dependencies are re-discovered on each run — a read reached only on one branch is unsubscribed when that branch stops being taken. On change the block's children are replaced **wholesale**: no diffing, and local DOM state inside (input focus, scroll) does not survive. Because it lowers to existing node types, SSR emits the standard fragment markers (`<!--#-->` … `<!--/#-->`) and hydration is unchanged. Keep tracked blocks small, use `For`/`eachWithKey` for lists, and prefer `@xote.component` where you want the same inline-read ergonomics without the wholesale rebuild.
+
 ## Common Patterns
 
 ### Creating reactive state
@@ -385,6 +407,22 @@ Html.button(
   ()
 )
 ```
+
+### Auto-tracked blocks
+```rescript
+/* Every signal read inside the body subscribes the block automatically —
+   no thunk-per-binding. The block re-evaluates and replaces its children
+   wholesale (no diffing) when any dependency changes, so keep tracked
+   blocks small and use eachWithKey/For for lists. */
+View.tracked(() =>
+  if Signal.get(loggedIn) {
+    Html.p(~children=[View.text("Hello, " ++ Signal.get(name))], ())
+  } else {
+    View.text("Please log in")
+  }
+)
+```
+Dependencies are re-discovered on every run, so conditional reads work: above, `name` is only tracked while `loggedIn` is true. `tracked` lowers to `SignalFragment` + `Computed`, so SSR markers and hydration work unchanged.
 
 ### Lists
 ```rescript
@@ -580,6 +618,9 @@ Guidance for AI coding agents (and humans) making changes to this repository.
 | `src/MaybeSignal.res` | Static/Reactive value wrapper |
 | `src/Prop.res`, `src/Prop.resi` | Deprecated alias of `MaybeSignal` (the interface file is what makes the deprecations warn) |
 | `src/Signal.res`, `src/Computed.res`, `src/Effect.res` | Re-export shims for `rescript-signals` |
+| `ppx/ppx.ml` | The `@xote.component` fine-grained PPX (vendored OCaml 4.06 AST + rewriter) |
+| `ppx/example/` | Standalone PPX consumer project; `verify.mjs` is its jsdom regression suite (`npm run ppx:test`). `src/Store.res` is deliberately a *second* file, so its helpers model the cross-module reads detection cannot follow |
+| `ppx/postinstall.js` | Selects/installs the prebuilt PPX binary at npm install time |
 | `rescript.json` | ReScript compiler configuration (`namespace: true`) |
 | `vite.config.js` | Library build configuration |
 
@@ -610,6 +651,7 @@ The project has a test suite using the [zekr](https://github.com/nicholasgasior/
 3. Successful Vite build (`npm run build`)
 4. Manual testing with demo apps (`npm run dev`)
 5. For SSR changes, check the `examples/ssr/` setup
+6. For PPX or `View.child`/`View.tracked` changes, run the end-to-end suite: `npm run ppx:test` (needs `ocamlopt`)
 
 #### Test Files
 
@@ -620,6 +662,7 @@ The project has a test suite using the [zekr](https://github.com/nicholasgasior/
 | `tests/JSX_test.res` | JSX transform |
 | `tests/MaybeSignal_test.res` | `MaybeSignal` helpers and the deprecated `Prop` alias |
 | `tests/KeyedList_test.res` | Keyed list reconciliation |
+| `tests/Probe_test.res` | `View.probe` hidden-read detection (reports, false positives, dedupe) |
 | `tests/Route_test.res` | Route matching |
 | `tests/SSR_test.res` | Server-side rendering |
 | `tests/SSRState_test.res` | State serialization |

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ The `ppx-flags` line enables the **`@xote.component`** annotation — the standa
 This README uses the application-facing names for public code:
 
 - `View` is the module for building and mounting DOM nodes.
-- `MaybeSignal` is the static-or-reactive value wrapper (it replaces the deprecated `Prop` module).
-- `View.Text`, `View.Int`, `View.For`, `View.Show`, `View.Attr.*`, `Router.location`, and `SSRState.signal` are the building blocks used throughout these examples.
+- `MaybeSignal` is the static-or-reactive prop module.
+- `View.For`, `View.Show`, `View.Attr.*`, `Router.location`, and `SSRState.signal` are the building blocks used throughout these examples.
+- `View.Text`, `View.Int`, `View.Float`, and `View.Bool` turn a value into a node. Under `@xote.component` you do not need them: a bare `{…}` child works directly (see [Bare children](#bare-children)). They stay available for code that does not use the PPX, and for the stronger `int`/`float` typing on the child.
 
 ### Quick Example
 
@@ -95,9 +96,7 @@ Here's an example of a reusable component with properties:
 // Greeting.res
 @xote.component
 let make = (~name: string, ~greeting: string="Hello") => {
-  <p>
-    <View.Text> {`${greeting}, ${name}!`} </View.Text>
-  </p>
+  <p> {`${greeting}, ${name}!`} </p>
 }
 
 // Usage from another file:
@@ -136,9 +135,34 @@ On top of the reactive primitives with signals, Xote provides a declarative view
 ```rescript
 let className = Signal.make("card")
 
-<div class={className}>
-  <View.Text> "Status: " </View.Text>
-  <View.Text> {className} </View.Text>
+<div class={MaybeSignal.reactive(className)}>
+  {"Status: "}
+  {Signal.get(className)}
+</div>
+```
+
+#### Bare children
+
+Under `@xote.component`, any `{…}` child works directly in element position. The annotation wraps it in the runtime helper `View.child`, which coerces it at runtime:
+
+```rescript
+<div>
+  {"Count: "}            // static text
+  {Signal.get(count)}    // reactive text leaf, re-runs on its own
+  {View.text("node")}    // already a node, passes through
+  {someOption}           // None renders nothing
+</div>
+```
+
+An eager signal read becomes a reactive leaf; a static scalar becomes static text; a value that is already a node passes through; `null`/`undefined` render nothing; an array is coerced element-wise.
+
+The explicit value primitives are still there for code that does not use the PPX, and when you want the stronger `int`/`float` typing:
+
+```rescript
+// equivalent, without the annotation
+<div>
+  <View.Text> "Count: " </View.Text>
+  <View.Int> {count} </View.Int>
 </div>
 ```
 
@@ -158,52 +182,32 @@ let todos = Signal.make([
 <View.For
   each={MaybeSignal.reactive(todos)}
   by={todo => todo.id}
-  render={todo => <li> <View.Text> {todo.title} </View.Text> </li>}
+  render={todo => <li> {todo.title} </li>}
 />
 ```
 
-`View` also provides component primitives for static or reactive values. Their children can be raw values, signals, `MaybeSignal.t` values, or functions.
+The other view components take static or reactive values through `MaybeSignal.t`, and their render callbacks are fine-grained too:
 
 ```rescript
 <View.For
   each={MaybeSignal.static(["Draft", "Review", "Ship"])}
-  render={label => <span> <View.Text> {label} </View.Text> </span>}
+  render={label => <span> {label} </span>}
 />
 
-<ul>
-  <View.For
-    each={MaybeSignal.reactive(todos)}
-    by={todo => todo.id}
-    render={todo => <li> <View.Text> {todo.title} </View.Text> </li>}
-  />
-</ul>
-
-<View.Show when_={MaybeSignal.reactive(isReady)} fallback={<p> <View.Text> "Loading" </View.Text> </p>}>
-  <p> <View.Text> "Ready" </View.Text> </p>
+<View.Show when_={MaybeSignal.reactive(isReady)} fallback={<p> {"Loading"} </p>}>
+  <p> {"Ready"} </p>
 </View.Show>
 
 <View.Maybe
   value={MaybeSignal.reactive(selectedTodo)}
-  fallback={<p> <View.Text> "No selection" </View.Text> </p>}
-  render={todo => <p> <View.Text> {todo.title} </View.Text> </p>}
+  fallback={<p> {"No selection"} </p>}
+  render={todo => <p> {todo.title} </p>}
 />
 
 <View.Value
   value={MaybeSignal.reactive(count)}
-  render={count =>
-    <p>
-      <View.Text> "Count: " </View.Text>
-      <View.Int> {count} </View.Int>
-    </p>
-  }
+  render={count => <p> {"Count: "} {count} </p>}
 />
-
-<p>
-  <View.Text> "Count: " </View.Text>
-  <View.Int> {count} </View.Int>
-  <View.Text> ", ready: " </View.Text>
-  <View.Bool> {isReady} </View.Bool>
-</p>
 ```
 
 ### Auto-tracked Blocks
@@ -216,9 +220,9 @@ let name = Signal.make("Ada")
 
 {View.tracked(() =>
   if Signal.get(loggedIn) {
-    <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
+    <p> {`Hello, ${Signal.get(name)}`} </p>
   } else {
-    <p> <View.Text> "Please log in" </View.Text> </p>
+    <p> {"Please log in"} </p>
   }
 )}
 ```
@@ -246,7 +250,7 @@ let make = (~className: MaybeSignal.t<string>=MaybeSignal.static("badge"), ~chil
 let tone = Signal.make("badge badge-info")
 
 <Badge className={MaybeSignal.reactive(tone)}>
-  <View.Text> "Live" </View.Text>
+  {"Live"}
 </Badge>
 ```
 
@@ -289,8 +293,8 @@ reload:
 
 ```rescript
 <nav>
-  <Router.Link to="/"> <View.Text> "Home" </View.Text> </Router.Link>
-  <Router.Link to="/about" class="nav-link"> <View.Text> "About" </View.Text> </Router.Link>
+  <Router.Link to="/"> {"Home"} </Router.Link>
+  <Router.Link to="/about" class="nav-link"> {"About"} </Router.Link>
 </nav>
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,23 +33,27 @@ Then, add it to your ReScript project's `rescript.json`. You'll need to declare 
     "version": 4,
     "module": "XoteJSX"
   },
+  "ppx-flags": ["xote/ppx/ppx"],
   "compiler-flags": ["-open Xote"]
 }
 ```
 
 The compiler flag `-open Xote` is optional, it makes the Xote modules available unqualified inside your source files.
 
+The `ppx-flags` line enables the **`@xote.component`** annotation — the recommended way to write components today, though its semantics are not frozen yet. It derives props from labeled arguments (like `@jsx.component`) and additionally lets you read signals **inline** in JSX with fine-grained updates: no `() => …` thunks, no value-primitive wrappers. The npm package ships the PPX prebuilt for linux-x64/arm64, macOS x64/arm64, and Windows x64, selected automatically at install time — no OCaml toolchain needed. See [`ppx/README.md`](ppx/README.md) for how it works and the (few) limitations; to skip the PPX entirely, omit `ppx-flags` and use `@jsx.component` with explicit thunks and `<View.Text>`/`<View.Int>` primitives, as shown further below.
+
 This README uses the application-facing names for public code:
 
 - `View` is the module for building and mounting DOM nodes.
-- `MaybeSignal` is the static-or-reactive value wrapper (it replaces the deprecated `Prop` module).
-- `View.Text`, `View.Int`, `View.For`, `View.Show`, `View.Attr.*`, `Router.location`, and `SSRState.signal` are the building blocks used throughout these examples.
+- `MaybeSignal` is the static-or-reactive prop module.
+- `View.For`, `View.Show`, `View.Attr.*`, `Router.location`, and `SSRState.signal` are the building blocks used throughout these examples.
+- `View.Text`, `View.Int`, `View.Float`, and `View.Bool` turn a value into a node. Under `@xote.component` you do not need them: a bare `{…}` child works directly (see [Bare children](#bare-children)). They stay available for code that does not use the PPX, and for the stronger `int`/`float` typing on the child.
 
 ### Quick Example
 
 ```rescript
 module App = {
-  @jsx.component
+  @xote.component
   let make = () => {
     // Create reactive state
     let count = Signal.make(0)
@@ -64,19 +68,13 @@ module App = {
       None // Optional clean up function
     })
 
-    // Build the UI with JSX
+    // Build the UI with JSX — signal reads inline, only the leaves re-run
     <div>
-      <h1> <View.Text> "Counter" </View.Text> </h1>
-      <p>
-        <View.Text> "Count: " </View.Text>
-        <View.Int> {count} </View.Int>
-      </p>
-      <p>
-        <View.Text> "Doubled: " </View.Text>
-        <View.Int> {doubled} </View.Int>
-      </p>
+      <h1> {"Counter"} </h1>
+      <p> {"Count: "} {Signal.get(count)} </p>
+      <p> {"Doubled: "} {Signal.get(doubled)} </p>
       <button onClick={(_evt: Dom.event) => Signal.update(count, n => n + 1)}>
-        <View.Text> "Increment" </View.Text>
+        {"Increment"}
       </button>
     </div>
   }
@@ -86,19 +84,19 @@ module App = {
 View.mountById(<App />, "app")
 ```
 
+When `count` changes, only the two text leaves that read it update — the elements are built once and keep their DOM identity.
+
 Since in ReScript each file is its own module, you can define a reusable component by exporting a `make` function from that file. The file name becomes the component name: `Counter.res` gives you `<Counter />`. 
 
-The `@jsx.component` attribute instructs the compiler to derive a props type from the function's labeled arguments, enabling JSX usage without boilerplate. 
+The `@xote.component` attribute derives a props type from the function's labeled arguments (exactly like ReScript's `@jsx.component`, which it emits under the hood) and fine-grains the returned JSX. 
 
 Here's an example of a reusable component with properties:
 
 ```res
 // Greeting.res
-@jsx.component
+@xote.component
 let make = (~name: string, ~greeting: string="Hello") => {
-  <p>
-    <View.Text> {`${greeting}, ${name}!`} </View.Text>
-  </p>
+  <p> {`${greeting}, ${name}!`} </p>
 }
 
 // Usage from another file:
@@ -137,14 +135,72 @@ On top of the reactive primitives with signals, Xote provides a declarative view
 ```rescript
 let className = Signal.make("card")
 
-<div class={className}>
-  <View.Text> "Status: " </View.Text>
-  <View.Text> {className} </View.Text>
+<div class={MaybeSignal.reactive(className)}>
+  {"Status: "}
+  {Signal.get(className)}
+</div>
+```
+
+#### Bare children
+
+Under `@xote.component`, any `{…}` child works directly in element position. The annotation wraps it in the runtime helper `View.child`, which coerces it at runtime:
+
+```rescript
+<div>
+  {"Count: "}            // static text
+  {Signal.get(count)}    // reactive text leaf, re-runs on its own
+  {View.text("node")}    // already a node, passes through
+  {someOption}           // None renders nothing
+</div>
+```
+
+An eager signal read becomes a reactive leaf; a static scalar becomes static text; a value that is already a node passes through; `null`/`undefined` render nothing; an array is coerced element-wise.
+
+The explicit value primitives are still there for code that does not use the PPX, and when you want the stronger `int`/`float` typing:
+
+```rescript
+// equivalent, without the annotation
+<div>
+  <View.Text> "Count: " </View.Text>
+  <View.Int> {count} </View.Int>
 </div>
 ```
 
 Built-in attributes take a plain value, a signal, or a `unit => 'a` function, so
 a signal can be passed straight through without wrapping it.
+
+#### Keep signal reads visible
+
+`@xote.component` decides what to make reactive by *reading your source*. It
+follows `Signal.get` and `MaybeSignal.get`, aliases (`let g = Signal.get`,
+`module S = Signal`, `open Signal`), local helpers that read a signal, and
+helpers in a module in the same file. It cannot follow a call into **another
+module** — nothing in `Store.waitingCount(store)` says "signal" — so that leaf is
+compiled as a plain value and renders its first result forever:
+
+```rescript
+<p> {Store.waitingCount(store)} </p>   // ⚠️ one-shot: never updates
+<p> {() => Store.waitingCount(store)} </p>   // ✅ reactive
+```
+
+The same applies to a read hoisted into a `let` (`let n = Signal.get(count)`,
+then `{n}`): reactivity follows the expression written in JSX position. In both
+cases the fix is a thunk — `() => …` — and the PPX never double-wraps one you
+wrote yourself.
+
+You do not have to catch these by eye. A leaf whose expression contains a call
+the PPX cannot resolve is emitted wrapped in `View.probe`, which checks at
+runtime whether evaluating it actually subscribed to a signal and, if it did,
+logs the source location once:
+
+```
+[Xote] Queue.res:42:19: this value reads a signal through a call
+@xote.component cannot see … Wrap it in a thunk (`{() => ...}`).
+```
+
+There are no false positives — the check is on what the evaluation really read,
+not on how it looks — and probing is skipped in production builds. Full rules:
+[`ppx/README.md`](ppx/README.md#hidden-reads).
 
 For rendering collections in JSX, prefer `View.For`. Add `by` when items have stable identity and should reconcile by key:
 
@@ -159,55 +215,56 @@ let todos = Signal.make([
 <View.For
   each={MaybeSignal.reactive(todos)}
   by={todo => todo.id}
-  render={todo => <li> <View.Text> {todo.title} </View.Text> </li>}
+  render={todo => <li> {todo.title} </li>}
 />
 ```
 
-`View` also provides component primitives for static or reactive values. Their children can be raw values, signals, `MaybeSignal.t` values, or functions.
+The other view components take static or reactive values through `MaybeSignal.t`, and their render callbacks are fine-grained too:
 
 ```rescript
 <View.For
   each={MaybeSignal.static(["Draft", "Review", "Ship"])}
-  render={label => <span> <View.Text> {label} </View.Text> </span>}
+  render={label => <span> {label} </span>}
 />
 
-<ul>
-  <View.For
-    each={MaybeSignal.reactive(todos)}
-    by={todo => todo.id}
-    render={todo => <li> <View.Text> {todo.title} </View.Text> </li>}
-  />
-</ul>
-
-<View.Show when_={MaybeSignal.reactive(isReady)} fallback={<p> <View.Text> "Loading" </View.Text> </p>}>
-  <p> <View.Text> "Ready" </View.Text> </p>
+<View.Show when_={MaybeSignal.reactive(isReady)} fallback={<p> {"Loading"} </p>}>
+  <p> {"Ready"} </p>
 </View.Show>
 
 <View.Maybe
   value={MaybeSignal.reactive(selectedTodo)}
-  fallback={<p> <View.Text> "No selection" </View.Text> </p>}
-  render={todo => <p> <View.Text> {todo.title} </View.Text> </p>}
+  fallback={<p> {"No selection"} </p>}
+  render={todo => <p> {todo.title} </p>}
 />
 
 <View.Value
   value={MaybeSignal.reactive(count)}
-  render={count =>
-    <p>
-      <View.Text> "Count: " </View.Text>
-      <View.Int> {count} </View.Int>
-    </p>
-  }
+  render={count => <p> {"Count: "} {count} </p>}
 />
-
-<p>
-  <View.Text> "Count: " </View.Text>
-  <View.Int> {count} </View.Int>
-  <View.Text> ", ready: " </View.Text>
-  <View.Bool> {isReady} </View.Bool>
-</p>
 ```
 
-### Static or Reactive Values
+### Auto-tracked Blocks
+
+When a block of UI depends on several signals at once, `View.tracked` lets you read them inline — every signal read while the body runs subscribes the block automatically, and the block re-renders when any of them changes:
+
+```rescript
+let loggedIn = Signal.make(false)
+let name = Signal.make("Ada")
+
+{View.tracked(() =>
+  if Signal.get(loggedIn) {
+    <p> {`Hello, ${Signal.get(name)}`} </p>
+  } else {
+    <p> {"Please log in"} </p>
+  }
+)}
+```
+
+Dependencies are re-discovered on every run, so conditional reads work: above, `name` is only tracked while `loggedIn` is true. The tradeoff is granularity — a tracked block replaces its children wholesale (no diffing) when a dependency changes, so keep tracked blocks small and prefer `View.For` with `by` for lists.
+
+Under `@xote.component` you rarely write `View.tracked` yourself: an `if`/`switch` in child position is wrapped in it automatically, tracking only the condition — reactive leaves inside the branches stay fine-grained.
+
+### Static or Reactive Props
 
 `MaybeSignal` is how a value says whether it is plain or reactive. There is one
 rule for when you need it:
@@ -218,7 +275,7 @@ rule for when you need it:
 | Props with a declared type — `View.Show`, `View.For`, `View.Maybe`, `View.Value`, and the components you write | a `MaybeSignal.t`, so the wrapper is how the caller says which one they are passing. |
 
 ```rescript
-@jsx.component
+@xote.component
 let make = (~className: MaybeSignal.t<string>=MaybeSignal.static("badge"), ~children) => {
   <span class={className}> {children} </span>
 }
@@ -226,7 +283,7 @@ let make = (~className: MaybeSignal.t<string>=MaybeSignal.static("badge"), ~chil
 let tone = Signal.make("badge badge-info")
 
 <Badge className={MaybeSignal.reactive(tone)}>
-  <View.Text> "Live" </View.Text>
+  {"Live"}
 </Badge>
 ```
 
@@ -269,8 +326,8 @@ reload:
 
 ```rescript
 <nav>
-  <Router.Link to="/"> <View.Text> "Home" </View.Text> </Router.Link>
-  <Router.Link to="/about" class="nav-link"> <View.Text> "About" </View.Text> </Router.Link>
+  <Router.Link to="/"> {"Home"} </Router.Link>
+  <Router.Link to="/about" class="nav-link"> {"About"} </Router.Link>
 </nav>
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ Then, add it to your ReScript project's `rescript.json`. You'll need to declare 
     "version": 4,
     "module": "XoteJSX"
   },
+  "ppx-flags": ["xote/ppx/ppx"],
   "compiler-flags": ["-open Xote"]
 }
 ```
 
 The compiler flag `-open Xote` is optional, it makes the Xote modules available unqualified inside your source files.
+
+The `ppx-flags` line enables the **`@xote.component`** annotation — the standard authoring model. It derives props from labeled arguments (like `@jsx.component`) and additionally lets you read signals **inline** in JSX with fine-grained updates: no `() => …` thunks, no value-primitive wrappers. The npm package ships the PPX prebuilt for linux-x64/arm64, macOS x64/arm64, and Windows x64, selected automatically at install time — no OCaml toolchain needed. See [`ppx/README.md`](ppx/README.md) for how it works and the (few) limitations; to skip the PPX entirely, omit `ppx-flags` and use `@jsx.component` with explicit thunks and `<View.Text>`/`<View.Int>` primitives, as shown further below.
 
 This README uses the application-facing names for public code:
 
@@ -49,7 +52,7 @@ This README uses the application-facing names for public code:
 
 ```rescript
 module App = {
-  @jsx.component
+  @xote.component
   let make = () => {
     // Create reactive state
     let count = Signal.make(0)
@@ -64,19 +67,13 @@ module App = {
       None // Optional clean up function
     })
 
-    // Build the UI with JSX
+    // Build the UI with JSX — signal reads inline, only the leaves re-run
     <div>
-      <h1> <View.Text> "Counter" </View.Text> </h1>
-      <p>
-        <View.Text> "Count: " </View.Text>
-        <View.Int> {count} </View.Int>
-      </p>
-      <p>
-        <View.Text> "Doubled: " </View.Text>
-        <View.Int> {doubled} </View.Int>
-      </p>
+      <h1> {"Counter"} </h1>
+      <p> {"Count: "} {Signal.get(count)} </p>
+      <p> {"Doubled: "} {Signal.get(doubled)} </p>
       <button onClick={(_evt: Dom.event) => Signal.update(count, n => n + 1)}>
-        <View.Text> "Increment" </View.Text>
+        {"Increment"}
       </button>
     </div>
   }
@@ -86,15 +83,17 @@ module App = {
 View.mountById(<App />, "app")
 ```
 
+When `count` changes, only the two text leaves that read it update — the elements are built once and keep their DOM identity.
+
 Since in ReScript each file is its own module, you can define a reusable component by exporting a `make` function from that file. The file name becomes the component name: `Counter.res` gives you `<Counter />`. 
 
-The `@jsx.component` attribute instructs the compiler to derive a props type from the function's labeled arguments, enabling JSX usage without boilerplate. 
+The `@xote.component` attribute derives a props type from the function's labeled arguments (exactly like ReScript's `@jsx.component`, which it emits under the hood) and fine-grains the returned JSX. 
 
 Here's an example of a reusable component with properties:
 
 ```res
 // Greeting.res
-@jsx.component
+@xote.component
 let make = (~name: string, ~greeting: string="Hello") => {
   <p>
     <View.Text> {`${greeting}, ${name}!`} </View.Text>
@@ -226,7 +225,9 @@ let name = Signal.make("Ada")
 
 Dependencies are re-discovered on every run, so conditional reads work: above, `name` is only tracked while `loggedIn` is true. The tradeoff is granularity — a tracked block replaces its children wholesale (no diffing) when a dependency changes, so keep tracked blocks small and prefer `View.For` with `by` for lists.
 
-### Static or Reactive Values
+Under `@xote.component` you rarely write `View.tracked` yourself: an `if`/`switch` in child position is wrapped in it automatically, tracking only the condition — reactive leaves inside the branches stay fine-grained.
+
+### Static or Reactive Props
 
 `MaybeSignal` is how a value says whether it is plain or reactive. There is one
 rule for when you need it:
@@ -237,7 +238,7 @@ rule for when you need it:
 | Props with a declared type — `View.Show`, `View.For`, `View.Maybe`, `View.Value`, and the components you write | a `MaybeSignal.t`, so the wrapper is how the caller says which one they are passing. |
 
 ```rescript
-@jsx.component
+@xote.component
 let make = (~className: MaybeSignal.t<string>=MaybeSignal.static("badge"), ~children) => {
   <span class={className}> {children} </span>
 }

--- a/README.md
+++ b/README.md
@@ -207,6 +207,25 @@ let todos = Signal.make([
 </p>
 ```
 
+### Auto-tracked Blocks
+
+When a block of UI depends on several signals at once, `View.tracked` lets you read them inline — every signal read while the body runs subscribes the block automatically, and the block re-renders when any of them changes:
+
+```rescript
+let loggedIn = Signal.make(false)
+let name = Signal.make("Ada")
+
+{View.tracked(() =>
+  if Signal.get(loggedIn) {
+    <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
+  } else {
+    <p> <View.Text> "Please log in" </View.Text> </p>
+  }
+)}
+```
+
+Dependencies are re-discovered on every run, so conditional reads work: above, `name` is only tracked while `loggedIn` is true. The tradeoff is granularity — a tracked block replaces its children wholesale (no diffing) when a dependency changes, so keep tracked blocks small and prefer `View.For` with `by` for lists.
+
 ### Static or Reactive Values
 
 `MaybeSignal` is how a value says whether it is plain or reactive. There is one

--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ The explicit value primitives are still there for code that does not use the PPX
 Built-in attributes take a plain value, a signal, or a `unit => 'a` function, so
 a signal can be passed straight through without wrapping it.
 
+#### Keep signal reads visible
+
+`@xote.component` decides what to make reactive by *reading your source*. It
+follows `Signal.get` and `MaybeSignal.get`, aliases (`let g = Signal.get`,
+`module S = Signal`, `open Signal`), local helpers that read a signal, and
+helpers in a module in the same file. It cannot follow a call into **another
+module** — nothing in `Store.waitingCount(store)` says "signal" — so that leaf is
+compiled as a plain value and renders its first result forever:
+
+```rescript
+<p> {Store.waitingCount(store)} </p>   // ⚠️ one-shot: never updates
+<p> {() => Store.waitingCount(store)} </p>   // ✅ reactive
+```
+
+The same applies to a read hoisted into a `let` (`let n = Signal.get(count)`,
+then `{n}`): reactivity follows the expression written in JSX position. In both
+cases the fix is a thunk — `() => …` — and the PPX never double-wraps one you
+wrote yourself.
+
+You do not have to catch these by eye. A leaf whose expression contains a call
+the PPX cannot resolve is emitted wrapped in `View.probe`, which checks at
+runtime whether evaluating it actually subscribed to a signal and, if it did,
+logs the source location once:
+
+```
+[Xote] Queue.res:42:19: this value reads a signal through a call
+@xote.component cannot see … Wrap it in a thunk (`{() => ...}`).
+```
+
+There are no false positives — the check is on what the evaluation really read,
+not on how it looks — and probing is skipped in production builds. Full rules:
+[`ppx/README.md`](ppx/README.md#hidden-reads).
+
 For rendering collections in JSX, prefer `View.For`. Add `by` when items have stable identity and should reconcile by key:
 
 ```rescript

--- a/docs-website/package-lock.json
+++ b/docs-website/package-lock.json
@@ -19,7 +19,8 @@
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "rescript": "^12.2.0",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "xote-tracked-ppx": "file:../ppx"
       }
     },
     "..": {
@@ -44,6 +45,14 @@
         "semantic-release": "^25.0.1",
         "vite": "^8.0.16",
         "zekr": "^1.7.0"
+      }
+    },
+    "../ppx": {
+      "name": "xote-tracked-ppx",
+      "version": "0.1.0",
+      "dev": true,
+      "bin": {
+        "xote-tracked-ppx": "ppx"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3351,6 +3360,10 @@
     },
     "node_modules/xote": {
       "resolved": "..",
+      "link": true
+    },
+    "node_modules/xote-tracked-ppx": {
+      "resolved": "../ppx",
       "link": true
     },
     "node_modules/zwitch": {

--- a/docs-website/package-lock.json
+++ b/docs-website/package-lock.json
@@ -18,7 +18,8 @@
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "rescript": "^12.2.0",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "xote-tracked-ppx": "file:../ppx"
       }
     },
     "..": {
@@ -41,6 +42,14 @@
         "semantic-release": "^25.0.1",
         "vite": "^8.0.16",
         "zekr": "^1.7.0"
+      }
+    },
+    "../ppx": {
+      "name": "xote-tracked-ppx",
+      "version": "0.1.0",
+      "dev": true,
+      "bin": {
+        "xote-tracked-ppx": "ppx"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3339,6 +3348,10 @@
     },
     "node_modules/xote": {
       "resolved": "..",
+      "link": true
+    },
+    "node_modules/xote-tracked-ppx": {
+      "resolved": "../ppx",
       "link": true
     },
     "node_modules/zwitch": {

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "generate-repo-data": "node scripts/generate-repo-data.cjs",
-    "res:build": "npm run generate-repo-data && rescript",
+    "ppx:build": "sh ../ppx/build.sh",
+  "res:build": "npm run ppx:build && npm run generate-repo-data && rescript",
     "res:clean": "rescript clean",
     "res:dev": "rescript -w",
     "dev": "node server.mjs",
@@ -28,6 +29,7 @@
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "rescript": "^12.2.0",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "xote-tracked-ppx": "file:../ppx"
   }
 }

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "generate-repo-data": "node scripts/generate-repo-data.cjs",
-    "res:build": "npm run generate-repo-data && rescript",
+    "ppx:build": "sh ../ppx/build.sh",
+  "res:build": "npm run ppx:build && npm run generate-repo-data && rescript",
     "res:clean": "rescript clean",
     "res:dev": "rescript -w",
     "dev": "node server.mjs",
@@ -27,6 +28,7 @@
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "rescript": "^12.2.0",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "xote-tracked-ppx": "file:../ppx"
   }
 }

--- a/docs-website/rescript.json
+++ b/docs-website/rescript.json
@@ -18,5 +18,6 @@
     "version": 4,
     "module": "XoteJSX"
   },
+  "ppx-flags": ["xote-tracked-ppx/ppx"],
   "compiler-flags": ["-open RescriptCore", "-open Xote"]
 }

--- a/docs-website/rescript.json
+++ b/docs-website/rescript.json
@@ -18,5 +18,6 @@
     "version": 4,
     "module": "XoteJSX"
   },
-  "compiler-flags": ["-open Xote"]
+  "compiler-flags": ["-open Xote"],
+  "ppx-flags": ["xote-tracked-ppx/ppx"]
 }

--- a/docs-website/src/DocsExamplePanel.res
+++ b/docs-website/src/DocsExamplePanel.res
@@ -1,4 +1,4 @@
-@jsx.component
+@xote.component
 let make = (~filename, ~code, ~caption=?, ~children=?) => {
   let activeTab = Signal.make("code")
   let hasDemo = switch children {

--- a/docs-website/src/HomePage.res
+++ b/docs-website/src/HomePage.res
@@ -536,7 +536,7 @@ let symbolFor = u =>
   | Kelvin => "K"
   }
 
-@jsx.component
+@xote.component
 let make = (~value: float, ~unit: tempUnit) =>
   <div class="temp-display">
     <span class="temp-value">
@@ -556,7 +556,7 @@ let kelvin = Computed.make(() =>
   Signal.get(celsius) +. 273.15
 )
 
-@jsx.component
+@xote.component
 let make = () =>
   <div class="temp-row">
     <TemperatureDisplay

--- a/docs-website/src/demos/ComputedOrderDemo.res
+++ b/docs-website/src/demos/ComputedOrderDemo.res
@@ -19,7 +19,7 @@ let setPremium = (_evt: Dom.event) => Signal.set(unitPrice, 42)
 let setStandardShipping = (_evt: Dom.event) => Signal.set(expressShipping, false)
 let setExpressShipping = (_evt: Dom.event) => Signal.set(expressShipping, true)
 
-@jsx.component
+@xote.component
 let make = () => {
   <div class="computed-order-demo">
     <div class="computed-order-demo-section">
@@ -50,7 +50,7 @@ let make = () => {
           <div class="computed-order-demo-label"> {View.text("Plan")} </div>
           <div class="computed-order-demo-choice-row">
             <button
-              class={() =>
+              class={
                 if Signal.get(unitPrice) == 24 {
                   "computed-order-demo-choice active"
                 } else {
@@ -60,7 +60,7 @@ let make = () => {
               {View.text("Standard")}
             </button>
             <button
-              class={() =>
+              class={
                 if Signal.get(unitPrice) == 42 {
                   "computed-order-demo-choice active"
                 } else {
@@ -76,7 +76,7 @@ let make = () => {
           <div class="computed-order-demo-label"> {View.text("Shipping")} </div>
           <div class="computed-order-demo-choice-row">
             <button
-              class={() =>
+              class={
                 if !Signal.get(expressShipping) {
                   "computed-order-demo-choice active"
                 } else {
@@ -86,7 +86,7 @@ let make = () => {
               {View.text("Standard")}
             </button>
             <button
-              class={() =>
+              class={
                 if Signal.get(expressShipping) {
                   "computed-order-demo-choice active"
                 } else {

--- a/docs-website/src/demos/CounterDemo.res
+++ b/docs-website/src/demos/CounterDemo.res
@@ -24,45 +24,39 @@ let statusLabel = value =>
   }
 
 /* The @xote.component annotation lets the reactive parts read `count` inline —
-   no `() => ...` thunks, no `View.signalText`. It derives props like
-   @jsx.component and the fine-grained ppx turns each attribute/text that reads
-   a signal into its own reactive leaf, so only the class and the number update
-   when `count` changes; the surrounding markup is built once. */
+   no `() => ...` thunks, no `View.signalText`, and no `<View.Int>` value
+   primitives: a bare `{...}` child is coerced to a node by `View.child`. It
+   derives props like @jsx.component and the fine-grained ppx turns each
+   attribute/text that reads a signal into its own reactive leaf, so only the
+   class and the number update when `count` changes; the surrounding markup is
+   built once. */
 @xote.component
 let make = () => {
   <div class="counter-demo">
     <div class="counter-demo-panel">
       <div class="counter-demo-head">
         <div>
-          <div class="counter-demo-kicker"> {View.text("Signal state")} </div>
-          <h3 class="counter-demo-title"> {View.text("Counter")} </h3>
+          <div class="counter-demo-kicker"> {"Signal state"} </div>
+          <h3 class="counter-demo-title"> {"Counter"} </h3>
         </div>
         <div class={"counter-demo-status " ++ String.toLowerCase(statusLabel(Signal.get(count)))}>
-          <View.Text> {statusLabel(Signal.get(count))} </View.Text>
+          {statusLabel(Signal.get(count))}
         </div>
       </div>
 
       <div class="counter-demo-readout">
-        <div class={toneClass(Signal.get(count))}>
-          <View.Int> {Signal.get(count)} </View.Int>
-        </div>
-        <div class="counter-demo-label"> {View.text("Current Count")} </div>
+        <div class={toneClass(Signal.get(count))}> {Signal.get(count)} </div>
+        <div class="counter-demo-label"> {"Current Count"} </div>
       </div>
 
       <div class="counter-demo-note">
-        {View.text("One writable signal updates the UI immediately when the value changes.")}
+        {"One writable signal updates the UI immediately when the value changes."}
       </div>
 
       <div class="counter-demo-actions">
-        <button class="counter-demo-btn" onClick={decrement}>
-          {View.text("Decrease")}
-        </button>
-        <button class="counter-demo-btn subtle" onClick={reset}>
-          {View.text("Reset")}
-        </button>
-        <button class="counter-demo-btn" onClick={increment}>
-          {View.text("Increase")}
-        </button>
+        <button class="counter-demo-btn" onClick={decrement}> {"Decrease"} </button>
+        <button class="counter-demo-btn subtle" onClick={reset}> {"Reset"} </button>
+        <button class="counter-demo-btn" onClick={increment}> {"Increase"} </button>
       </div>
     </div>
   </div>

--- a/docs-website/src/demos/CounterDemo.res
+++ b/docs-website/src/demos/CounterDemo.res
@@ -4,61 +4,59 @@ let increment = (_evt: Dom.event) => Signal.update(count, n => n + 1)
 let decrement = (_evt: Dom.event) => Signal.update(count, n => n - 1)
 let reset = (_evt: Dom.event) => Signal.set(count, 0)
 
-@jsx.component
+/* Pure derivations of the count — no thunks, no signal reads here. */
+let toneClass = value =>
+  if value > 0 {
+    "counter-demo-value positive"
+  } else if value < 0 {
+    "counter-demo-value negative"
+  } else {
+    "counter-demo-value neutral"
+  }
+
+let statusLabel = value =>
+  if value > 0 {
+    "Positive"
+  } else if value < 0 {
+    "Negative"
+  } else {
+    "Neutral"
+  }
+
+/* The @xote.component annotation lets the reactive parts read `count` inline —
+   no `() => ...` thunks, no `View.signalText`, and no `<View.Int>` value
+   primitives: a bare `{...}` child is coerced to a node by `View.child`. It
+   derives props like @jsx.component and the fine-grained ppx turns each
+   attribute/text that reads a signal into its own reactive leaf, so only the
+   class and the number update when `count` changes; the surrounding markup is
+   built once. */
+@xote.component
 let make = () => {
-  let countTone = () => {
-    let value = Signal.get(count)
-    if value > 0 {
-      "counter-demo-value positive"
-    } else if value < 0 {
-      "counter-demo-value negative"
-    } else {
-      "counter-demo-value neutral"
-    }
-  }
-
-  let countStatus = () => {
-    let value = Signal.get(count)
-    if value > 0 {
-      "Positive"
-    } else if value < 0 {
-      "Negative"
-    } else {
-      "Neutral"
-    }
-  }
-
   <div class="counter-demo">
     <div class="counter-demo-panel">
       <div class="counter-demo-head">
         <div>
-          <div class="counter-demo-kicker"> {View.text("Signal state")} </div>
-          <h3 class="counter-demo-title"> {View.text("Counter")} </h3>
+          <div class="counter-demo-kicker"> {"Signal state"} </div>
+          <h3 class="counter-demo-title"> {"Counter"} </h3>
         </div>
-        <div class={() => "counter-demo-status " ++ String.toLowerCase(countStatus())}>
-          {View.signalText(countStatus)}
+        <div class={"counter-demo-status " ++ String.toLowerCase(statusLabel(Signal.get(count)))}>
+          {statusLabel(Signal.get(count))}
         </div>
       </div>
 
       <div class="counter-demo-readout">
-        <div class={() => countTone()}> <View.Int> {count} </View.Int> </div>
-        <div class="counter-demo-label"> {View.text("Current Count")} </div>
+        <div class={toneClass(Signal.get(count))}> {Signal.get(count)} </div>
+        <div class="counter-demo-label"> {"Current Count"} </div>
       </div>
 
       <div class="counter-demo-note">
-        {View.text("One writable signal updates the UI immediately when the value changes.")}
+        {"One writable signal updates the UI immediately when the value changes."}
       </div>
 
       <div class="counter-demo-actions">
-        <button class="counter-demo-btn" onClick={decrement}>
-          {View.text("Decrease")}
-        </button>
-        <button class="counter-demo-btn subtle" onClick={reset}>
-          {View.text("Reset")}
-        </button>
-        <button class="counter-demo-btn" onClick={increment}>
-          {View.text("Increase")}
-        </button>
+        <button class="counter-demo-btn" onClick={decrement}> {"Decrease"} </button>
+        <button class="counter-demo-btn subtle" onClick={reset}> {"Reset"} </button>
+        <button class="counter-demo-btn" onClick={increment}> {"Increase"} </button>
       </div>
     </div>
   </div>

--- a/docs-website/src/demos/CounterDemo.res
+++ b/docs-website/src/demos/CounterDemo.res
@@ -4,30 +4,32 @@ let increment = (_evt: Dom.event) => Signal.update(count, n => n + 1)
 let decrement = (_evt: Dom.event) => Signal.update(count, n => n - 1)
 let reset = (_evt: Dom.event) => Signal.set(count, 0)
 
-@jsx.component
+/* Pure derivations of the count — no thunks, no signal reads here. */
+let toneClass = value =>
+  if value > 0 {
+    "counter-demo-value positive"
+  } else if value < 0 {
+    "counter-demo-value negative"
+  } else {
+    "counter-demo-value neutral"
+  }
+
+let statusLabel = value =>
+  if value > 0 {
+    "Positive"
+  } else if value < 0 {
+    "Negative"
+  } else {
+    "Neutral"
+  }
+
+/* The @xote.component annotation lets the reactive parts read `count` inline —
+   no `() => ...` thunks, no `View.signalText`. It derives props like
+   @jsx.component and the fine-grained ppx turns each attribute/text that reads
+   a signal into its own reactive leaf, so only the class and the number update
+   when `count` changes; the surrounding markup is built once. */
+@xote.component
 let make = () => {
-  let countTone = () => {
-    let value = Signal.get(count)
-    if value > 0 {
-      "counter-demo-value positive"
-    } else if value < 0 {
-      "counter-demo-value negative"
-    } else {
-      "counter-demo-value neutral"
-    }
-  }
-
-  let countStatus = () => {
-    let value = Signal.get(count)
-    if value > 0 {
-      "Positive"
-    } else if value < 0 {
-      "Negative"
-    } else {
-      "Neutral"
-    }
-  }
-
   <div class="counter-demo">
     <div class="counter-demo-panel">
       <div class="counter-demo-head">
@@ -35,13 +37,15 @@ let make = () => {
           <div class="counter-demo-kicker"> {View.text("Signal state")} </div>
           <h3 class="counter-demo-title"> {View.text("Counter")} </h3>
         </div>
-        <div class={() => "counter-demo-status " ++ String.toLowerCase(countStatus())}>
-          {View.signalText(countStatus)}
+        <div class={"counter-demo-status " ++ String.toLowerCase(statusLabel(Signal.get(count)))}>
+          <View.Text> {statusLabel(Signal.get(count))} </View.Text>
         </div>
       </div>
 
       <div class="counter-demo-readout">
-        <div class={() => countTone()}> <View.Int> {count} </View.Int> </div>
+        <div class={toneClass(Signal.get(count))}>
+          <View.Int> {Signal.get(count)} </View.Int>
+        </div>
         <div class="counter-demo-label"> {View.text("Current Count")} </div>
       </div>
 

--- a/docs-website/src/demos/EffectAutosaveDemo.res
+++ b/docs-website/src/demos/EffectAutosaveDemo.res
@@ -39,7 +39,7 @@ Effect.run(() => {
   }
 })
 
-@jsx.component
+@xote.component
 let make = () => {
   let hasSavedDrafts = Computed.make(() => Signal.get(savedDrafts)->Array.length > 0)
 

--- a/docs-website/src/demos/TodoListDemo.res
+++ b/docs-website/src/demos/TodoListDemo.res
@@ -55,7 +55,7 @@ let removeTodo = id => {
 }
 
 module TodoComposer = {
-  @jsx.component
+  @xote.component
   let make = () => {
     <div class="todo-demo-form">
       <input
@@ -73,7 +73,7 @@ module TodoComposer = {
 }
 
 module TodoSummary = {
-  @jsx.component
+  @xote.component
   let make = () => {
     <div class="todo-list-demo-toolbar">
       <div class="todo-demo-summary">
@@ -95,7 +95,7 @@ module TodoSummary = {
 }
 
 module TodoRow = {
-  @jsx.component
+  @xote.component
   let make = (~todo: todo) => {
     let itemClass =
       "todo-demo-item" ++
@@ -121,7 +121,7 @@ module TodoRow = {
 }
 
 module TodoList = {
-  @jsx.component
+  @xote.component
   let make = () => {
     <ul class="todo-demo-list">
       <View.For
@@ -133,7 +133,7 @@ module TodoList = {
   }
 }
 
-@jsx.component
+@xote.component
 let make = () => {
   <div class="todo-list-demo">
     <div class="todo-list-demo-hero">

--- a/docs-website/src/demos/TutorialDemos.res
+++ b/docs-website/src/demos/TutorialDemos.res
@@ -27,7 +27,7 @@ let unitLabel = u =>
 // Takes a thunk so the value can be driven by signals or computeds.
 
 module TemperatureDisplay = {
-  @jsx.component
+  @xote.component
   let make = (~value: unit => float, ~unit: tempUnit) =>
     <div class={unitClass(unit)}>
       <span class="temp-value">
@@ -41,7 +41,7 @@ module TemperatureDisplay = {
 // ---- Step 1: static display ----
 
 module Step1 = {
-  @jsx.component
+  @xote.component
   let make = () =>
     <div class="temp-row">
       <TemperatureDisplay value={() => 22.0} unit=Celsius />
@@ -83,7 +83,7 @@ module DomInspector = {
     }
   }
 
-  @jsx.component
+  @xote.component
   let make = (~stageId: string) => {
     let entries = Signal.make([])
 
@@ -198,7 +198,7 @@ module Step2 = {
 
   let stageId = "tutorial-step2-stage"
 
-  @jsx.component
+  @xote.component
   let make = () =>
     <div class="tutorial-step2">
       <div class="tutorial-stage" id=stageId>
@@ -311,7 +311,7 @@ module Step3 = {
     | Ready(_) => " "
     }
 
-  @jsx.component
+  @xote.component
   let make = () =>
     <div class="tutorial-stage">
       <div class="tutorial-capital">

--- a/docs-website/src/docs/ApiViewDoc.mdx
+++ b/docs-website/src/docs/ApiViewDoc.mdx
@@ -155,6 +155,16 @@ let signalFragment: Signal.t<array<View.node>> => View.node
 
 Render an array of nodes from a signal and replace the fragment when it changes.
 
+<a id="view-tracked" />
+
+### View.tracked
+
+```rescript
+let tracked: (unit => View.node) => View.node
+```
+
+Create an auto-tracked reactive block. Every signal read while the body runs subscribes the block, and the body re-evaluates when any dependency changes. Dependencies are re-discovered on each run, so conditional reads work. The block's children are replaced wholesale (no diffing) on update — keep tracked blocks small and use [`View.For`](#view-for) or [`View.eachWithKey`](#view-eachwithkey) for lists.
+
 <a id="view-each" />
 
 ### View.each

--- a/docs-website/src/docs/ComputedDoc.mdx
+++ b/docs-website/src/docs/ComputedDoc.mdx
@@ -104,19 +104,20 @@ let total = Computed.make(() =>
   Signal.get(subtotal) + Signal.get(shippingCost)
 )
 
-let app = () => {
+@xote.component
+let make = () => {
   <div>
     <p>
       <View.Text> "Subtotal: $" </View.Text>
-      <View.Int> {subtotal} </View.Int>
+      <View.Int> {Signal.get(subtotal)} </View.Int>
     </p>
     <p>
       <View.Text> "Shipping: $" </View.Text>
-      <View.Int> {shippingCost} </View.Int>
+      <View.Int> {Signal.get(shippingCost)} </View.Int>
     </p>
     <p>
       <View.Text> "Total: $" </View.Text>
-      <View.Int> {total} </View.Int>
+      <View.Int> {Signal.get(total)} </View.Int>
     </p>
   </div>
 }`}

--- a/docs-website/src/docs/IntroDoc.mdx
+++ b/docs-website/src/docs/IntroDoc.mdx
@@ -29,14 +29,9 @@ let increment = (_evt: Dom.event) => {
 @xote.component
 let make = () => {
   <div>
-    <h1> <View.Text> "Counter" </View.Text> </h1>
-    <p>
-      <View.Text> "Count: " </View.Text>
-      <View.Int> {Signal.get(count)} </View.Int>
-    </p>
-    <button onClick={increment}>
-      <View.Text> "Increment" </View.Text>
-    </button>
+    <h1> {"Counter"} </h1>
+    <p> {"Count: "} {Signal.get(count)} </p>
+    <button onClick={increment}> {"Increment"} </button>
   </div>
 }
 
@@ -45,7 +40,7 @@ View.mountById(<Counter />, "app")
 
 When `count` changes, only the reactive view node updates. The component does not need a render loop or a dependency array.
 
-The `@xote.component` annotation is what lets you read signals **inline** (no `() => …` thunks) while keeping updates fine-grained. It needs a one-time setup (a small native PPX) — see [Views → JSX Configuration](/docs/view/overview#jsx-configuration).
+The `@xote.component` annotation is what lets you read signals **inline** (no `() => …` thunks) while keeping updates fine-grained. It also lets you write plain `{…}` children — strings, numbers, or signal reads — with no `<View.Int>`/`<View.Text>` wrapper; each is coerced to a reactive text node for you. It needs a one-time setup (a small native PPX) — see [Views → JSX Configuration](/docs/view/overview#jsx-configuration).
 
 ## How the Docs Are Organized
 

--- a/docs-website/src/docs/IntroDoc.mdx
+++ b/docs-website/src/docs/IntroDoc.mdx
@@ -34,6 +34,13 @@ let make = () => {
     <button onClick={increment}> {"Increment"} </button>
   </div>
 }
+```
+
+Mount it from your entry file (a module can't reference itself by its file name, so the mount lives one file up):
+
+```rescript
+// App.res
+open Xote
 
 View.mountById(<Counter />, "app")
 ```

--- a/docs-website/src/docs/IntroDoc.mdx
+++ b/docs-website/src/docs/IntroDoc.mdx
@@ -17,6 +17,7 @@ This counter shows the core model: a signal stores state, an event updates it, a
 ### Using JSX Syntax
 
 ```rescript
+// Counter.res
 open Xote
 
 let count = Signal.make(0)
@@ -25,12 +26,13 @@ let increment = (_evt: Dom.event) => {
   Signal.update(count, n => n + 1)
 }
 
-let app = () => {
+@xote.component
+let make = () => {
   <div>
     <h1> <View.Text> "Counter" </View.Text> </h1>
     <p>
       <View.Text> "Count: " </View.Text>
-      <View.Int> {count} </View.Int>
+      <View.Int> {Signal.get(count)} </View.Int>
     </p>
     <button onClick={increment}>
       <View.Text> "Increment" </View.Text>
@@ -38,10 +40,12 @@ let app = () => {
   </div>
 }
 
-View.mountById(app(), "app")
+View.mountById(<Counter />, "app")
 ```
 
 When `count` changes, only the reactive view node updates. The component does not need a render loop or a dependency array.
+
+The `@xote.component` annotation is what lets you read signals **inline** (no `() => …` thunks) while keeping updates fine-grained. It needs a one-time setup (a small native PPX) — see [Views → JSX Configuration](/docs/view/overview#jsx-configuration).
 
 ## How the Docs Are Organized
 

--- a/docs-website/src/docs/IntroDoc.mdx
+++ b/docs-website/src/docs/IntroDoc.mdx
@@ -17,6 +17,7 @@ This counter shows the core model: a signal stores state, an event updates it, a
 ### Using JSX Syntax
 
 ```rescript
+// Counter.res
 open Xote
 
 let count = Signal.make(0)
@@ -25,23 +26,28 @@ let increment = (_evt: Dom.event) => {
   Signal.update(count, n => n + 1)
 }
 
-let app = () => {
+@xote.component
+let make = () => {
   <div>
-    <h1> <View.Text> "Counter" </View.Text> </h1>
-    <p>
-      <View.Text> "Count: " </View.Text>
-      <View.Int> {count} </View.Int>
-    </p>
-    <button onClick={increment}>
-      <View.Text> "Increment" </View.Text>
-    </button>
+    <h1> {"Counter"} </h1>
+    <p> {"Count: "} {Signal.get(count)} </p>
+    <button onClick={increment}> {"Increment"} </button>
   </div>
 }
+```
 
-View.mountById(app(), "app")
+Mount it from your entry file (a module can't reference itself by its file name, so the mount lives one file up):
+
+```rescript
+// App.res
+open Xote
+
+View.mountById(<Counter />, "app")
 ```
 
 When `count` changes, only the reactive view node updates. The component does not need a render loop or a dependency array.
+
+The `@xote.component` annotation is what lets you read signals **inline** (no `() => …` thunks) while keeping updates fine-grained. It also lets you write plain `{…}` children — strings, numbers, or signal reads — with no `<View.Int>`/`<View.Text>` wrapper; each is coerced to a reactive text node for you. It needs a one-time setup (a small native PPX) — see [Views → JSX Configuration](/docs/view/overview#jsx-configuration).
 
 ## How the Docs Are Organized
 

--- a/docs-website/src/docs/SignalsDoc.mdx
+++ b/docs-website/src/docs/SignalsDoc.mdx
@@ -152,11 +152,12 @@ let reset = (_evt: Dom.event) => {
   Signal.set(count, 0)
 }
 
-let app = () => {
+@xote.component
+let make = () => {
   <div>
     <h1>
       <View.Text> "Count: " </View.Text>
-      <View.Int> {count} </View.Int>
+      <View.Int> {Signal.get(count)} </View.Int>
     </h1>
     <button onClick={increment}>
       <View.Text> "+" </View.Text>
@@ -170,7 +171,7 @@ let app = () => {
   </div>
 }
 
-View.mountById(app(), "app")`}
+View.mountById(<Counter />, "app")`}
     >
       <CounterDemo />
     </DocsExamplePanel>

--- a/docs-website/src/docs/SignalsDoc.mdx
+++ b/docs-website/src/docs/SignalsDoc.mdx
@@ -152,11 +152,12 @@ let reset = (_evt: Dom.event) => {
   Signal.set(count, 0)
 }
 
-let app = () => {
+@xote.component
+let make = () => {
   <div>
     <h1>
       <View.Text> "Count: " </View.Text>
-      <View.Int> {count} </View.Int>
+      <View.Int> {Signal.get(count)} </View.Int>
     </h1>
     <button onClick={increment}>
       <View.Text> "+" </View.Text>
@@ -170,7 +171,9 @@ let app = () => {
   </div>
 }
 
-View.mountById(app(), "app")`}
+// in App.res (the entry point — a module can't reference
+// itself by its own file name):
+// View.mountById(<Counter />, "app")`}
     >
       <CounterDemo />
     </DocsExamplePanel>

--- a/docs-website/src/docs/SignalsDoc.mdx
+++ b/docs-website/src/docs/SignalsDoc.mdx
@@ -171,7 +171,9 @@ let make = () => {
   </div>
 }
 
-View.mountById(<Counter />, "app")`}
+// in App.res (the entry point — a module can't reference
+// itself by its own file name):
+// View.mountById(<Counter />, "app")`}
     >
       <CounterDemo />
     </DocsExamplePanel>

--- a/docs-website/src/docs/ViewsDoc.mdx
+++ b/docs-website/src/docs/ViewsDoc.mdx
@@ -78,11 +78,25 @@ module Greeting = {
 
 ### Reactive Output
 
-JSX expressions are just nodes. For direct value output, use primitives such as [`View.Text`](/docs/api/view#view-text-component), [`View.Int`](/docs/api/view#view-int-component), [`View.Float`](/docs/api/view#view-float-component), and [`View.Bool`](/docs/api/view#view-bool-component). Their children can be raw values, signals, `MaybeSignal.t` values, or computed functions. For arrays and lists, use [`View.For`](/docs/api/view#view-for); pass `by` when item identity matters.
+Under [`@xote.component`](#jsx-configuration), a **bare `{…}` child** — a string, a number, or a signal read — is the ergonomic default. The annotation coerces it to a reactive text node (via `View.child`), so no value-primitive wrapper is needed:
 
 ```rescript
 let count = Signal.make(0)
 
+@xote.component
+let make = () =>
+  <div>
+    {"Count: "}
+    {Signal.get(count)}
+  </div>
+```
+
+Only the number re-renders when `count` changes; the `<div>` and the static `"Count: "` text are built once.
+
+The explicit primitives — [`View.Text`](/docs/api/view#view-text-component), [`View.Int`](/docs/api/view#view-int-component), [`View.Float`](/docs/api/view#view-float-component), [`View.Bool`](/docs/api/view#view-bool-component) — remain available and are what you use **without** the PPX (or when you want the stronger `int`/`float` typing on the child). Their children can be raw values, signals, `Prop.t` values, or computed functions. For arrays and lists, use [`View.For`](/docs/api/view#view-for); pass `by` when item identity matters.
+
+```rescript
+// equivalent, without the annotation:
 <div>
   <View.Text> "Count: " </View.Text>
   <View.Int> {count} </View.Int>

--- a/docs-website/src/docs/ViewsDoc.mdx
+++ b/docs-website/src/docs/ViewsDoc.mdx
@@ -13,7 +13,7 @@ Think in two layers:
 
 ### JSX Configuration
 
-To use JSX with Xote, point ReScript at `XoteJSX`.
+To use JSX with Xote, point ReScript at `XoteJSX`. The standard setup also enables the `@xote.component` annotation — fine-grained reactive components — via Xote's native PPX:
 
 ```rescript
 {
@@ -22,32 +22,44 @@ To use JSX with Xote, point ReScript at `XoteJSX`.
     "version": 4,
     "module": "XoteJSX"
   },
+  "ppx-flags": ["xote/ppx/ppx"],
   "compiler-flags": ["-open Xote"]
 }
 ```
+
+No toolchain or build step is needed: the npm package ships the PPX as a prebuilt binary for linux-x64, linux-arm64, darwin-x64, darwin-arm64 and win32-x64, and Xote's install script selects the one for your platform. Two situations need a manual step:
+
+- If your package manager skips dependency install scripts (pnpm does by default), allow them for `xote` (for pnpm, `pnpm approve-builds`) or run `node node_modules/xote/ppx/postinstall.js` once after installing.
+- On a platform without a prebuilt binary, the install script compiles the PPX from its bundled source instead, which needs `ocamlopt` (`sh node_modules/xote/ppx/build.sh` runs it manually).
+
+Prefer no PPX at all? Omit `ppx-flags` and use `@jsx.component` instead of `@xote.component`. You then write reactive attributes/text with explicit `() => …` thunks, and bare `{…}` children (a PPX feature) become the explicit value primitives (`<View.Text>`, `<View.Int>`, …) shown under [Reactive Output](#reactive-output).
 
 ### Writing Components
 
 #### Recommended Pattern
 
-Use a module with a `make` function and annotate it with `@jsx.component`. ReScript derives the props shape from labeled arguments.
+Use a module with a `make` function and annotate it with `@xote.component`. It derives the props shape from labeled arguments (exactly like `@jsx.component`) **and** fine-grains the returned JSX, so you read signals inline — no `() => …` thunks.
 
 ```rescript
 open Xote
 
+let highlight = Signal.make(false)
+
 module Greeting = {
-  @jsx.component
-  let make = (~name: string, ~emphasis=false) => {
-    <div class={emphasis ? "greeting strong" : "greeting"}>
+  @xote.component
+  let make = (~name: string) => {
+    <div class={Signal.get(highlight) ? "greeting strong" : "greeting"}>
       <h1> <View.Text> {`Hello, ${name}`} </View.Text> </h1>
     </div>
   }
 }
 
 let app = () => {
-  <Greeting name="World" emphasis />
+  <Greeting name="World" />
 }
 ```
+
+Only one component per module (inherited from `@jsx.component`) — put each in its own file, or a submodule.
 
 #### JSX Components
 
@@ -55,7 +67,7 @@ let app = () => {
 open Xote
 
 module Greeting = {
-  @jsx.component
+  @xote.component
   let make = (~name: string) => {
     <section class="greeting-card">
       <h2> <View.Text> {`Hello, ${name}`} </View.Text> </h2>
@@ -67,11 +79,25 @@ module Greeting = {
 
 ### Reactive Output
 
-JSX expressions are just nodes. For direct value output, use primitives such as [`View.Text`](/docs/api/view#view-text-component), [`View.Int`](/docs/api/view#view-int-component), [`View.Float`](/docs/api/view#view-float-component), and [`View.Bool`](/docs/api/view#view-bool-component). Their children can be raw values, signals, `MaybeSignal.t` values, or computed functions. For arrays and lists, use [`View.For`](/docs/api/view#view-for); pass `by` when item identity matters.
+Under [`@xote.component`](#jsx-configuration), a **bare `{…}` child** — a string, a number, or a signal read — is the ergonomic default. The annotation coerces it to a reactive text node (via `View.child`), so no value-primitive wrapper is needed:
 
 ```rescript
 let count = Signal.make(0)
 
+@xote.component
+let make = () =>
+  <div>
+    {"Count: "}
+    {Signal.get(count)}
+  </div>
+```
+
+Only the number re-renders when `count` changes; the `<div>` and the static `"Count: "` text are built once.
+
+The explicit primitives — [`View.Text`](/docs/api/view#view-text-component), [`View.Int`](/docs/api/view#view-int-component), [`View.Float`](/docs/api/view#view-float-component), [`View.Bool`](/docs/api/view#view-bool-component) — remain available and are what you use **without** the PPX (or when you want the stronger `int`/`float` typing on the child). Their children can be raw values, signals, `MaybeSignal.t` values, or computed functions. For arrays and lists, use [`View.For`](/docs/api/view#view-for); pass `by` when item identity matters.
+
+```rescript
+// equivalent, without the annotation:
 <div>
   <View.Text> "Count: " </View.Text>
   <View.Int> {count} </View.Int>
@@ -81,7 +107,7 @@ let count = Signal.make(0)
 When a formatted string depends on a value that can be static or reactive, keep the prop as `MaybeSignal.t` and read it inside a function child.
 
 ```rescript
-@jsx.component
+@xote.component
 let make = (~name: MaybeSignal.t<string>) => {
   <View.Text> {() => `Hello, ${MaybeSignal.get(name)}`} </View.Text>
 }
@@ -181,6 +207,44 @@ Use [`View.Show`](/docs/api/view#view-show) for boolean branches, [`View.Maybe`]
 </p>
 ```
 
+### Auto-tracked Blocks
+
+When one block of UI depends on several signals at once, the primitives above require you to wire each dependency explicitly — a `MaybeSignal.reactive` here, a computed there. [`View.tracked`](/docs/api/view#view-tracked) is the escape hatch for those cases: every signal read while its body runs subscribes the block automatically, and the block re-renders when any of them changes.
+
+```rescript
+let loggedIn = Signal.make(false)
+let name = Signal.make("Ada")
+
+{View.tracked(() =>
+  if Signal.get(loggedIn) {
+    <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
+  } else {
+    <p> <View.Text> "Please log in" </View.Text> </p>
+  }
+)}
+```
+
+Dependencies are re-discovered on every run, so conditional reads work: above, `name` is only tracked while `loggedIn` is true.
+
+The tradeoff is granularity. A tracked block replaces its children wholesale when a dependency changes — there is no diffing, and local DOM state inside the block (like input focus) does not survive an update. Keep tracked blocks small, and reach for [`View.Show`](/docs/api/view#view-show), [`View.Value`](/docs/api/view#view-value), or [`View.For`](/docs/api/view#view-for) with `by` when a more targeted primitive fits.
+
+### How `@xote.component` stays fine-grained
+
+`@xote.component` (set up in [JSX Configuration](#jsx-configuration) above) is how the demos on this site are written, and the recommended way to write reactive components. Its semantics are still settling, so check the [limitations](https://github.com/brnrdog/xote/blob/main/ppx/README.md#not-settled-yet) before it becomes load-bearing in your app. It replaces `@jsx.component`: it derives props from the labeled args **and** fine-grains the returned JSX.
+
+```rescript
+@xote.component
+let make = () => {
+  <div class={Signal.get(active) ? "on" : "off"}>
+    <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text>
+  </div>
+}
+```
+
+Rather than wrapping the whole block in one computed, the PPX **decomposes** it: each attribute or text that reads a signal becomes its own reactive leaf (a `computedAttr` / reactive text node), and `View.tracked` is emitted only around a child region whose node *structure* varies (an `if`/`switch`), tracking just the condition. The enclosing elements are built once and keep their DOM identity — so it stays fine-grained even for large components.
+
+The PPX is a small native binary that ships prebuilt in the npm package; enabling it is one `ppx-flags` line in your `rescript.json` (see [JSX Configuration](#jsx-configuration) above). Projects that do not add the flag are unaffected — Xote's own published sources compile without it. See [`ppx/README.md`](https://github.com/brnrdog/xote/blob/main/ppx/README.md) for the decomposition rules, signal-detection details, and limitations.
+
 ### Mounting
 
 Use [`View.mount`](/docs/api/view#view-mount) when you already have a DOM element, or [`View.mountById`](/docs/api/view#view-mountbyid) when you want to look one up by id.
@@ -217,7 +281,7 @@ let todos = Signal.make([
 let draft = Signal.make("")
 
 module TodoComposer = {
-  @jsx.component
+  @xote.component
   let make = () => {
     <div>
       <input onInput={handleInput} value={() => Signal.get(draft)} />
@@ -227,7 +291,7 @@ module TodoComposer = {
 }
 
 module TodoRow = {
-  @jsx.component
+  @xote.component
   let make = (~todo: todo) => {
     <li>
       <span> <View.Text> {todo.title} </View.Text> </span>
@@ -236,7 +300,7 @@ module TodoRow = {
   }
 }
 
-@jsx.component
+@xote.component
 let make = () => {
   <div>
     <TodoComposer />

--- a/docs-website/src/docs/ViewsDoc.mdx
+++ b/docs-website/src/docs/ViewsDoc.mdx
@@ -13,7 +13,7 @@ Think in two layers:
 
 ### JSX Configuration
 
-To use JSX with Xote, point ReScript at `XoteJSX`.
+To use JSX with Xote, point ReScript at `XoteJSX`. The recommended setup also enables the `@xote.component` annotation — fine-grained reactive components — via Xote's opt-in native PPX:
 
 ```rescript
 {
@@ -22,32 +22,43 @@ To use JSX with Xote, point ReScript at `XoteJSX`.
     "version": 4,
     "module": "XoteJSX"
   },
+  "ppx-flags": ["xote/ppx/ppx"],
   "compiler-flags": ["-open Xote"]
 }
 ```
+
+Build the PPX once after installing — its only dependency is `ocamlopt`:
+
+```sh
+sh node_modules/xote/ppx/build.sh
+```
+
+Prefer not to add a build step? Omit `ppx-flags` and use `@jsx.component` instead of `@xote.component` — everything below still works, you just write reactive attributes/text with explicit `() => …` thunks.
 
 ### Writing Components
 
 #### Recommended Pattern
 
-Use a module with a `make` function and annotate it with `@jsx.component`. ReScript derives the props shape from labeled arguments.
+Use a module with a `make` function and annotate it with `@xote.component`. It derives the props shape from labeled arguments (exactly like `@jsx.component`) **and** fine-grains the returned JSX, so you read signals inline — no `() => …` thunks.
 
 ```rescript
 open Xote
 
 module Greeting = {
-  @jsx.component
-  let make = (~name: string, ~emphasis=false) => {
-    <div class={emphasis ? "greeting strong" : "greeting"}>
+  @xote.component
+  let make = (~name: string) => {
+    <div class={Signal.get(highlight) ? "greeting strong" : "greeting"}>
       <h1> <View.Text> {`Hello, ${name}`} </View.Text> </h1>
     </div>
   }
 }
 
 let app = () => {
-  <Greeting name="World" emphasis />
+  <Greeting name="World" />
 }
 ```
+
+Only one component per module (inherited from `@jsx.component`) — put each in its own file, or a submodule.
 
 #### JSX Components
 
@@ -55,7 +66,7 @@ let app = () => {
 open Xote
 
 module Greeting = {
-  @jsx.component
+  @xote.component
   let make = (~name: string) => {
     <section class="greeting-card">
       <h2> <View.Text> {`Hello, ${name}`} </View.Text> </h2>
@@ -81,7 +92,7 @@ let count = Signal.make(0)
 When a formatted string depends on a value that can be static or reactive, keep the prop as `MaybeSignal.t` and read it inside a function child.
 
 ```rescript
-@jsx.component
+@xote.component
 let make = (~name: MaybeSignal.t<string>) => {
   <View.Text> {() => `Hello, ${MaybeSignal.get(name)}`} </View.Text>
 }
@@ -202,6 +213,23 @@ Dependencies are re-discovered on every run, so conditional reads work: above, `
 
 The tradeoff is granularity. A tracked block replaces its children wholesale when a dependency changes — there is no diffing, and local DOM state inside the block (like input focus) does not survive an update. Keep tracked blocks small, and reach for [`View.Show`](/docs/api/view#view-show), [`View.Value`](/docs/api/view#view-value), or [`View.For`](/docs/api/view#view-for) with `by` when a more targeted primitive fits.
 
+### How `@xote.component` stays fine-grained
+
+`@xote.component` (set up in [JSX Configuration](#jsx-configuration) above) is how the demos on this site are written, and the recommended way to write reactive components. It replaces `@jsx.component`: it derives props from the labeled args **and** fine-grains the returned JSX.
+
+```rescript
+@xote.component
+let make = () => {
+  <div class={Signal.get(active) ? "on" : "off"}>
+    <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text>
+  </div>
+}
+```
+
+Rather than wrapping the whole block in one computed, the PPX **decomposes** it: each attribute or text that reads a signal becomes its own reactive leaf (a `computedAttr` / reactive text node), and `View.tracked` is emitted only around a child region whose node *structure* varies (an `if`/`switch`), tracking just the condition. The enclosing elements are built once and keep their DOM identity — so it stays fine-grained even for large components.
+
+It is **opt-in** at the tooling level — a small native binary (`ocamlopt` only) you build with `sh node_modules/xote/ppx/build.sh`, not part of the published npm package. Xote's own published config carries no PPX, so libraries that depend on Xote are unaffected whether or not they use it. See [`ppx/README.md`](https://github.com/brnrdog/xote/blob/main/ppx/README.md) for the decomposition rules, signal-detection details, and limitations.
+
 ### Mounting
 
 Use [`View.mount`](/docs/api/view#view-mount) when you already have a DOM element, or [`View.mountById`](/docs/api/view#view-mountbyid) when you want to look one up by id.
@@ -238,7 +266,7 @@ let todos = Signal.make([
 let draft = Signal.make("")
 
 module TodoComposer = {
-  @jsx.component
+  @xote.component
   let make = () => {
     <div>
       <input onInput={handleInput} value={() => Signal.get(draft)} />
@@ -248,7 +276,7 @@ module TodoComposer = {
 }
 
 module TodoRow = {
-  @jsx.component
+  @xote.component
   let make = (~todo: todo) => {
     <li>
       <span> <View.Text> {todo.title} </View.Text> </span>
@@ -257,7 +285,7 @@ module TodoRow = {
   }
 }
 
-@jsx.component
+@xote.component
 let make = () => {
   <div>
     <TodoComposer />

--- a/docs-website/src/docs/ViewsDoc.mdx
+++ b/docs-website/src/docs/ViewsDoc.mdx
@@ -13,7 +13,7 @@ Think in two layers:
 
 ### JSX Configuration
 
-To use JSX with Xote, point ReScript at `XoteJSX`. The recommended setup also enables the `@xote.component` annotation — fine-grained reactive components — via Xote's opt-in native PPX:
+To use JSX with Xote, point ReScript at `XoteJSX`. The standard setup also enables the `@xote.component` annotation — fine-grained reactive components — via Xote's native PPX:
 
 ```rescript
 {
@@ -27,13 +27,12 @@ To use JSX with Xote, point ReScript at `XoteJSX`. The recommended setup also en
 }
 ```
 
-Build the PPX once after installing — its only dependency is `ocamlopt`:
+No toolchain or build step is needed: the npm package ships the PPX as a prebuilt binary for linux-x64, linux-arm64, darwin-x64, darwin-arm64 and win32-x64, and Xote's install script selects the one for your platform. Two situations need a manual step:
 
-```sh
-sh node_modules/xote/ppx/build.sh
-```
+- If your package manager skips dependency install scripts (pnpm does by default), allow them for `xote` (for pnpm, `pnpm approve-builds`) or run `node node_modules/xote/ppx/postinstall.js` once after installing.
+- On a platform without a prebuilt binary, the install script compiles the PPX from its bundled source instead, which needs `ocamlopt` (`sh node_modules/xote/ppx/build.sh` runs it manually).
 
-Prefer not to add a build step? Omit `ppx-flags` and use `@jsx.component` instead of `@xote.component` — everything below still works, you just write reactive attributes/text with explicit `() => …` thunks.
+Prefer no PPX at all? Omit `ppx-flags` and use `@jsx.component` instead of `@xote.component`. You then write reactive attributes/text with explicit `() => …` thunks, and bare `{…}` children (a PPX feature) become the explicit value primitives (`<View.Text>`, `<View.Int>`, …) shown under [Reactive Output](#reactive-output).
 
 ### Writing Components
 
@@ -43,6 +42,8 @@ Use a module with a `make` function and annotate it with `@xote.component`. It d
 
 ```rescript
 open Xote
+
+let highlight = Signal.make(false)
 
 module Greeting = {
   @xote.component
@@ -242,7 +243,7 @@ let make = () => {
 
 Rather than wrapping the whole block in one computed, the PPX **decomposes** it: each attribute or text that reads a signal becomes its own reactive leaf (a `computedAttr` / reactive text node), and `View.tracked` is emitted only around a child region whose node *structure* varies (an `if`/`switch`), tracking just the condition. The enclosing elements are built once and keep their DOM identity — so it stays fine-grained even for large components.
 
-It is **opt-in** at the tooling level — a small native binary (`ocamlopt` only) you build with `sh node_modules/xote/ppx/build.sh`, not part of the published npm package. Xote's own published config carries no PPX, so libraries that depend on Xote are unaffected whether or not they use it. See [`ppx/README.md`](https://github.com/brnrdog/xote/blob/main/ppx/README.md) for the decomposition rules, signal-detection details, and limitations.
+The PPX is a small native binary that ships prebuilt in the npm package; enabling it is one `ppx-flags` line in your `rescript.json` (see [JSX Configuration](#jsx-configuration) above). Projects that do not add the flag are unaffected — Xote's own published sources compile without it. See [`ppx/README.md`](https://github.com/brnrdog/xote/blob/main/ppx/README.md) for the decomposition rules, signal-detection details, and limitations.
 
 ### Mounting
 

--- a/docs-website/src/docs/ViewsDoc.mdx
+++ b/docs-website/src/docs/ViewsDoc.mdx
@@ -94,7 +94,7 @@ let make = () =>
 
 Only the number re-renders when `count` changes; the `<div>` and the static `"Count: "` text are built once.
 
-The explicit primitives — [`View.Text`](/docs/api/view#view-text-component), [`View.Int`](/docs/api/view#view-int-component), [`View.Float`](/docs/api/view#view-float-component), [`View.Bool`](/docs/api/view#view-bool-component) — remain available and are what you use **without** the PPX (or when you want the stronger `int`/`float` typing on the child). Their children can be raw values, signals, `Prop.t` values, or computed functions. For arrays and lists, use [`View.For`](/docs/api/view#view-for); pass `by` when item identity matters.
+The explicit primitives — [`View.Text`](/docs/api/view#view-text-component), [`View.Int`](/docs/api/view#view-int-component), [`View.Float`](/docs/api/view#view-float-component), [`View.Bool`](/docs/api/view#view-bool-component) — remain available and are what you use **without** the PPX (or when you want the stronger `int`/`float` typing on the child). Their children can be raw values, signals, `MaybeSignal.t` values, or computed functions. For arrays and lists, use [`View.For`](/docs/api/view#view-for); pass `by` when item identity matters.
 
 ```rescript
 // equivalent, without the annotation:
@@ -209,7 +209,7 @@ Use [`View.Show`](/docs/api/view#view-show) for boolean branches, [`View.Maybe`]
 
 ### Auto-tracked Blocks
 
-When one block of UI depends on several signals at once, the primitives above require you to wire each dependency explicitly — a `Prop.signal` here, a computed there. [`View.tracked`](/docs/api/view#view-tracked) is the escape hatch for those cases: every signal read while its body runs subscribes the block automatically, and the block re-renders when any of them changes.
+When one block of UI depends on several signals at once, the primitives above require you to wire each dependency explicitly — a `MaybeSignal.reactive` here, a computed there. [`View.tracked`](/docs/api/view#view-tracked) is the escape hatch for those cases: every signal read while its body runs subscribes the block automatically, and the block re-renders when any of them changes.
 
 ```rescript
 let loggedIn = Signal.make(false)

--- a/docs-website/src/docs/ViewsDoc.mdx
+++ b/docs-website/src/docs/ViewsDoc.mdx
@@ -181,6 +181,27 @@ Use [`View.Show`](/docs/api/view#view-show) for boolean branches, [`View.Maybe`]
 </p>
 ```
 
+### Auto-tracked Blocks
+
+When one block of UI depends on several signals at once, the primitives above require you to wire each dependency explicitly — a `Prop.signal` here, a computed there. [`View.tracked`](/docs/api/view#view-tracked) is the escape hatch for those cases: every signal read while its body runs subscribes the block automatically, and the block re-renders when any of them changes.
+
+```rescript
+let loggedIn = Signal.make(false)
+let name = Signal.make("Ada")
+
+{View.tracked(() =>
+  if Signal.get(loggedIn) {
+    <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
+  } else {
+    <p> <View.Text> "Please log in" </View.Text> </p>
+  }
+)}
+```
+
+Dependencies are re-discovered on every run, so conditional reads work: above, `name` is only tracked while `loggedIn` is true.
+
+The tradeoff is granularity. A tracked block replaces its children wholesale when a dependency changes — there is no diffing, and local DOM state inside the block (like input focus) does not survive an update. Keep tracked blocks small, and reach for [`View.Show`](/docs/api/view#view-show), [`View.Value`](/docs/api/view#view-value), or [`View.For`](/docs/api/view#view-for) with `by` when a more targeted primitive fits.
+
 ### Mounting
 
 Use [`View.mount`](/docs/api/view#view-mount) when you already have a DOM element, or [`View.mountById`](/docs/api/view#view-mountbyid) when you want to look one up by id.

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -70,6 +70,7 @@ Preferred public constructors:
 - `<View.Int value={MaybeSignal.t<int>} />`, `<View.Float value={MaybeSignal.t<float>} />`, and `<View.Bool value={MaybeSignal.t<bool>} />`
 - `View.fragment(children)`
 - `View.signalFragment(signal)`
+- `View.tracked(() => node)`
 - `View.each(signal, renderItem)`
 - `View.eachWithKey(signal, keyFn, renderItem)`
 - `<View.For each={MaybeSignal.t<array<'a>>} by={optionalKeyFn} render={renderItem} />`
@@ -87,6 +88,7 @@ Rendering is fine-grained:
 - `SignalText` attaches an effect that updates the text node.
 - Reactive attributes attach effects that update only the affected attribute/property.
 - `SignalFragment` replaces its child region when its signal changes.
+- `View.tracked(body)` lowers to `SignalFragment` over a `Computed` of the body, so every signal read while the body runs subscribes the block and its dependencies are re-discovered on each run.
 - `KeyedList` uses comment anchors and key-based reconciliation to preserve DOM identity.
 - `LazyComponent` defers component evaluation until render/hydration time.
 

--- a/docs/proposals/tracked-blocks.md
+++ b/docs/proposals/tracked-blocks.md
@@ -1,0 +1,173 @@
+# Proposal: Auto-tracked view blocks
+
+| | |
+|---|---|
+| **Status** | Phase 1 implemented (`View.tracked`); Phase 2 proposed; Phase 3 exploratory |
+| **Related** | [brnrdog/rescript-signals#34](https://github.com/brnrdog/rescript-signals/pull/34) — auto-tracking for React and the `@tracked` annotation |
+
+## Summary
+
+Bring the auto-tracking ergonomics that rescript-signals PR #34 gives React
+consumers to Xote's own view layer, in three phases:
+
+1. **`View.tracked` (implemented)** — a runtime block constructor where every
+   signal read inside the body subscribes the block automatically.
+2. **A `tracked` annotation (proposed)** — compile-time sugar that expands an
+   annotated JSX expression into `View.tracked`, reusing the
+   `rescript-tracked-ppx` from PR #34 with a configurable expansion target.
+3. **Notify-only scheduling (exploratory)** — use the new `Signals.Tracking`
+   scope to decouple invalidation from DOM writes, enabling batched
+   (microtask/`requestAnimationFrame`) update modes.
+
+## Motivation: the thunk tax
+
+Xote's reactivity is fine-grained: components run once and reactivity attaches
+at the leaves. That model is fast and predictable, but it puts a syntactic tax
+on the author — every reactive read must be wrapped in a thunk or routed
+through a wrapper component so a `Computed` can capture it:
+
+```rescript
+/* one thunk per binding */
+View.signalText(() => "Hello, " ++ Signal.get(name))
+View.computedAttr("class", () => Signal.get(isActive) ? "active" : "inactive")
+
+/* one wrapper component per reactive branch */
+<View.Show when_={Prop.signal(isReady)} fallback={...}> ... </View.Show>
+<View.Value value={Prop.signal(count)} render={count => ...} />
+```
+
+Each primitive handles exactly one dependency shape. The friction shows up when
+one block of UI depends on **several signals with control flow between them**.
+Today that takes either an intermediate `Computed` to merge the signals, or
+nested wrapper components:
+
+```rescript
+/* BEFORE — merge signals into a computed first… */
+let greeting = Computed.make(() =>
+  Signal.get(loggedIn) ? `Hello, ${Signal.get(name)}` : "Please log in"
+)
+<p> <View.Text> {greeting} </View.Text> </p>
+
+/* …or nest wrappers */
+<View.Show
+  when_={Prop.signal(loggedIn)}
+  fallback={<p> <View.Text> "Please log in" </View.Text> </p>}>
+  <View.Value
+    value={Prop.signal(name)}
+    render={name => <p> <View.Text> {`Hello, ${name}`} </View.Text> </p>}
+  />
+</View.Show>
+```
+
+Both work, but neither reads like the logic it expresses. The author is
+hand-compiling the dependency graph.
+
+## Phase 1 — `View.tracked` (implemented)
+
+```rescript
+let tracked: (unit => View.node) => View.node
+```
+
+One thunk for the whole block; the reads inside are plain `Signal.get`:
+
+```rescript
+/* AFTER */
+{View.tracked(() =>
+  if Signal.get(loggedIn) {
+    <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
+  } else {
+    <p> <View.Text> "Please log in" </View.Text> </p>
+  }
+)}
+```
+
+### Semantics
+
+- **Auto-subscription.** Every signal read while the body runs subscribes the
+  block; when any dependency changes, the body re-evaluates and the block's
+  children are replaced.
+- **Dependency re-discovery.** Dependencies are reconciled on every run, so
+  conditional reads work: above, `name` is only tracked while `loggedIn` is
+  true. Flipping `loggedIn` off also unsubscribes the block from `name`.
+- **Lowering.** `tracked(body)` is `SignalFragment(Computed.make(() => [body()]))`.
+  Because it lowers to existing node types, SSR emits the standard fragment
+  hydration markers (`<!--#-->` … `<!--/#-->`) and hydration works unchanged.
+- **Granularity tradeoff.** The block's children are replaced wholesale on
+  update — no diffing, and local DOM state (input focus, scroll) inside the
+  block does not survive. This is the same behavior as `SignalFragment` and
+  the reactive branches of `Show`/`Maybe`/`Value`. Keep tracked blocks small;
+  keyed lists stay on `eachWithKey`/`For` with `by`.
+
+### When to use what
+
+| Situation | Reach for |
+|---|---|
+| Reactive text/number | `View.Text` / `View.Int` / `signalText` |
+| Reactive attribute | `computedAttr` / function props |
+| Boolean branch on one signal | `View.Show` |
+| Node derived from one signal | `View.Value` / `View.Maybe` |
+| Lists | `View.For` with `by` (keyed reconciliation) |
+| Block over **several signals + control flow** | `View.tracked` |
+
+## Phase 2 — the `tracked` annotation (proposed)
+
+PR #34 ships `rescript-tracked-ppx`, which expands a `@tracked` attribute at
+compile time. It is currently hardcoded to the React hooks
+(`SignalsReactAuto.useTracked`), but the expansion is mechanical — the same
+PPX with a configurable target (e.g. a `--target` flag in `ppx-flags`) would
+let Xote projects write:
+
+```rescript
+@tracked()
+<div>
+  <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
+</div>
+```
+
+expanding to:
+
+```rescript
+View.tracked(() =>
+  <div>
+    <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
+  </div>
+)
+```
+
+Notes:
+
+- Only the automatic form (`@tracked()`) is useful in Xote. The explicit-deps
+  form (`@tracked([a, b])`) exists in React to avoid re-render subscriptions,
+  but inside a `Computed` every read auto-tracks — a dependency list adds
+  nothing here.
+- This requires a change in rescript-signals (configurable expansion target),
+  not in Xote. `View.tracked` is already the stable expansion target.
+
+## Phase 3 — notify-only scheduling (exploratory)
+
+Xote's scheduler is synchronous: effects run inline when a signal is set
+(known limitation — no microtask/`requestAnimationFrame` coalescing). The
+`Signals.Tracking` scope introduced in PR #34 is a *notify-only* observer:
+the scheduler notifies it when a dependency changes but never re-runs it —
+the driver re-establishes dependencies itself via `Tracking.track`.
+
+That is exactly the primitive a deferred DOM-update mode needs: on
+invalidate, mark the binding dirty and schedule a flush; on flush, re-track
+and write to the DOM. This would let Xote offer opt-in rAF-batched rendering
+without forking the effect scheduler. Out of scope for this proposal beyond
+noting that adopting `Tracking` keeps the door open.
+
+## Alternatives considered
+
+- **Compiler-granular tracking (Solid-style).** Compile JSX so each inline
+  read becomes its own leaf binding, avoiding the wholesale-replacement
+  tradeoff entirely. Strictly better output, but requires a full JSX
+  transform rather than a local attribute expansion — a much larger project
+  than reusing the PR #34 PPX. `View.tracked` does not preclude it.
+- **A `<View.Tracked>` JSX component.** JSX children evaluate eagerly, so the
+  component would need a `render: unit => node` thunk prop — no more ergonomic
+  than calling `View.tracked` directly, and it would suggest the block is
+  cheap to nest. Not worth the surface area.
+- **Status quo.** Composing `Computed` + wrapper primitives covers every case
+  `tracked` covers. The proposal is purely about ergonomics; nothing is
+  removed or deprecated.

--- a/docs/proposals/tracked-blocks.md
+++ b/docs/proposals/tracked-blocks.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Phase 1 implemented (`View.tracked`); Phase 2 proposed; Phase 3 exploratory |
+| **Status** | Phase 1 implemented (`View.tracked`); Phase 2 fine-grained PPX built, opt-in, CI-exercised and used by the docs site (see [`ppx/`](../../ppx/)); Phase 3 exploratory |
 | **Related** | [brnrdog/rescript-signals#34](https://github.com/brnrdog/rescript-signals/pull/34) — auto-tracking for React and the `@tracked` annotation |
 
 ## Summary
@@ -109,39 +109,114 @@ One thunk for the whole block; the reads inside are plain `Signal.get`:
 | Lists | `View.For` with `by` (keyed reconciliation) |
 | Block over **several signals + control flow** | `View.tracked` |
 
-## Phase 2 — the `tracked` annotation (proposed)
+## Phase 2 — the `tracked` annotation (prototyped)
 
 PR #34 ships `rescript-tracked-ppx`, which expands a `@tracked` attribute at
-compile time. It is currently hardcoded to the React hooks
-(`SignalsReactAuto.useTracked`), but the expansion is mechanical — the same
-PPX with a configurable target (e.g. a `--target` flag in `ppx-flags`) would
-let Xote projects write:
+compile time (hardcoded to the React hook `SignalsReactAuto.useTracked`). Two
+expansions are possible for Xote, and a prototype of the more ambitious one
+lives in [`ppx/`](../../ppx/).
+
+### 2a. Coarse expansion (`@tracked()` → `View.tracked`)
+
+The mechanical option: expand the annotated block to a single
+`View.tracked(() => <block>)`. Convenient, but it inherits `View.tracked`'s
+wholesale-replacement semantics — any dependency change rebuilds the whole
+block. This is what PR #34's PPX does for React, retargeted.
+
+### 2b. Fine-grained expansion (implemented in [`ppx/`](../../ppx/))
+
+The better option, and the one implemented: instead of one coarse computed,
+**decompose the returned JSX** and push reactivity to the leaves that actually
+read signals. The annotation is `@xote.component` (which also emits
+`@jsx.component`, so props derive). Given:
 
 ```rescript
-@tracked()
-<div>
-  <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
-</div>
-```
-
-expanding to:
-
-```rescript
-View.tracked(() =>
-  <div>
-    <p> <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text> </p>
+@xote.component
+let make = () => {
+  <div class={Signal.get(active) ? "on" : "off"} id="card">
+    <span class="static-label"> {View.text("Name:")} </span>
+    <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text>
   </div>
-)
+}
 ```
+
+the PPX emits (abbreviated):
+
+```js
+function make(props) {
+  return Elements.jsxs("div", {
+    id: "card",                                     // static — untouched
+    class: () => Signal.get(active) ? "on" : "off", // → View.computedAttr (leaf)
+    children: [
+      Elements.jsx("span", { class: "static-label", children: View.text("Name:") }), // untouched
+      jsx(View.Text.make, { children: () => `Hello, ` + Signal.get(name) }),          // reactive text leaf
+    ],
+  });
+}
+```
+
+No `View.tracked`, no `SignalFragment`, no rebuild — the `<div>` and `<span>`
+keep DOM identity across updates; only the `class` attribute and the greeting
+text node re-run. `View.tracked` is emitted **only** where node *structure*
+varies (an `if`/`switch` in child position), never around the stable elements
+that enclose it. The prototype's `example/verify.mjs` proves this at runtime by
+tagging elements and asserting the tags survive signal changes (27 assertions,
+all passing).
+
+Two refinements make the output genuinely fine-grained rather than a thin
+sugar over `View.tracked`:
+
+- **Alias-aware detection.** Beyond a literal `Signal.get`, the PPX threads a
+  scoped alias environment that follows value aliases (`let g = Signal.get`),
+  module aliases (`module S = Signal`), `open Signal`, and the pipe form
+  (`sig->Signal.get`), while treating the untracked `Signal.peek` as a non-read.
+- **Control flow tracks only the condition.** Branch bodies are decomposed
+  before the `View.tracked` wrapper is applied, so their leaves become thunks
+  that the tracked scope does not invoke while building nodes. The scope
+  therefore subscribes only to the condition/scrutinee; a signal read by a leaf
+  *inside* a branch (e.g. a `class` in the chosen branch) updates that leaf
+  alone and does not re-run the switch or rebuild the branch element.
+
+Decomposition rules and limitations are documented in
+[`ppx/README.md`](../../ppx/README.md). The PPX runs before ReScript's JSX
+transform, so it sees JSX as `Apply @[JSX]` nodes with attributes as labelled
+arguments — the ideal layer to redistribute reactivity before lowering.
 
 Notes:
 
-- Only the automatic form (`@tracked()`) is useful in Xote. The explicit-deps
-  form (`@tracked([a, b])`) exists in React to avoid re-render subscriptions,
-  but inside a `Computed` every read auto-tracks — a dependency list adds
-  nothing here.
-- This requires a change in rescript-signals (configurable expansion target),
-  not in Xote. `View.tracked` is already the stable expansion target.
+- PR #34's React annotation forms don't carry over. Its explicit-deps form
+  (`@tracked([a, b])`) exists to avoid re-render subscriptions, but inside
+  fine-grained leaves every read auto-tracks — a dependency list adds nothing.
+  Xote needs only automatic discovery, which `@xote.component` provides.
+- 2b is self-contained in Xote (its own vendored-AST PPX). 2a would instead
+  reuse rescript-signals' PPX with a configurable expansion target;
+  `View.tracked` is already the stable target for that path.
+- The implemented annotation is a single binding-level `@xote.component`: the
+  PPX rewrites it to `@jsx.component` so props still derive *and* fine-grains
+  the whole returned JSX — one attribute, no separate tracking annotation to
+  stack. (An earlier expression-level `@tracked` form was dropped in favour of
+  the one component-level annotation; `@xote.component` inherits
+  `@jsx.component`'s one-component-per-module rule.)
+
+### Consumer-safety constraint (why it's opt-in, not in the library core)
+
+A ReScript consumer recompiles a dependency's sources during its own build and
+applies that dependency's `ppx-flags` (verified: a cold consumer build fails
+with "ppx not found" when the dependency lists a PPX the consumer lacks). So a
+`ppx-flags` entry in Xote's *published* `rescript.json` would force `ocamlopt`
+on every Xote user. The PPX is therefore kept out of the published library
+config entirely:
+
+- The published library (`src/`, root `rescript.json`) has **no** `ppx-flags`;
+  consumers who don't opt in are unaffected.
+- The `ppx.ml` source ships in the npm tarball, so a consumer who *wants*
+  `@xote.component` builds it (`sh node_modules/xote/ppx/build.sh`) and lists it
+  in **their own** `rescript.json` (`"ppx-flags": ["xote/ppx/ppx"]`).
+- In-repo, the PPX is real: `ci.yml` builds and runs its end-to-end test on
+  every push/PR, and the docs site (`docs-website/`, its own non-published
+  config) authors the Counter demo with `@xote.component` and builds the PPX in
+  its `res:build`. This proves it through SSR + hydration without touching the
+  publish path.
 
 ## Phase 3 — notify-only scheduling (exploratory)
 
@@ -161,9 +236,11 @@ noting that adopting `Tracking` keeps the door open.
 
 - **Compiler-granular tracking (Solid-style).** Compile JSX so each inline
   read becomes its own leaf binding, avoiding the wholesale-replacement
-  tradeoff entirely. Strictly better output, but requires a full JSX
-  transform rather than a local attribute expansion — a much larger project
-  than reusing the PR #34 PPX. `View.tracked` does not preclude it.
+  tradeoff entirely. This is precisely what Phase 2b prototypes — see
+  [`ppx/`](../../ppx/). It turned out to be tractable as a local expansion
+  over the pre-JSX-transform AST rather than a full custom JSX transform,
+  because Xote's runtime already accepts thunked attribute/child values and
+  lowers them to fine-grained bindings.
 - **A `<View.Tracked>` JSX component.** JSX children evaluate eagerly, so the
   component would need a `render: unit => node` thunk prop — no more ergonomic
   than calling `View.tracked` directly, and it would suggest the block is

--- a/docs/proposals/tracked-blocks.md
+++ b/docs/proposals/tracked-blocks.md
@@ -2,8 +2,8 @@
 
 | | |
 |---|---|
-| **Status** | Phase 1 implemented (`View.tracked`); Phase 2 fine-grained PPX built, opt-in, CI-exercised and used by the docs site (see [`ppx/`](../../ppx/)); Phase 3 exploratory |
-| **Related** | [brnrdog/rescript-signals#34](https://github.com/brnrdog/rescript-signals/pull/34) — auto-tracking for React and the `@tracked` annotation |
+| **Status** | Phase 1 implemented (`View.tracked`); Phase 2 fine-grained PPX built, CI-exercised, used by the docs site, and distributed as prebuilt binaries in the npm package (see [`ppx/`](../../ppx/) and [RFC #141](https://github.com/brnrdog/xote/issues/141)); Phase 3 exploratory |
+| **Related** | [brnrdog/rescript-signals#34](https://github.com/brnrdog/rescript-signals/pull/34) — auto-tracking for React and the `@tracked` annotation; [RFC #141](https://github.com/brnrdog/xote/issues/141) — adoption and distribution decision |
 
 ## Summary
 
@@ -109,12 +109,12 @@ One thunk for the whole block; the reads inside are plain `Signal.get`:
 | Lists | `View.For` with `by` (keyed reconciliation) |
 | Block over **several signals + control flow** | `View.tracked` |
 
-## Phase 2 — the `tracked` annotation (prototyped)
+## Phase 2 — the component annotation (implemented as `@xote.component`)
 
 PR #34 ships `rescript-tracked-ppx`, which expands a `@tracked` attribute at
 compile time (hardcoded to the React hook `SignalsReactAuto.useTracked`). Two
-expansions are possible for Xote, and a prototype of the more ambitious one
-lives in [`ppx/`](../../ppx/).
+expansions are possible for Xote; the more ambitious one is implemented in
+[`ppx/`](../../ppx/) and ships with the npm package.
 
 ### 2a. Coarse expansion (`@tracked()` → `View.tracked`)
 
@@ -159,9 +159,9 @@ No `View.tracked`, no `SignalFragment`, no rebuild — the `<div>` and `<span>`
 keep DOM identity across updates; only the `class` attribute and the greeting
 text node re-run. `View.tracked` is emitted **only** where node *structure*
 varies (an `if`/`switch` in child position), never around the stable elements
-that enclose it. The prototype's `example/verify.mjs` proves this at runtime by
-tagging elements and asserting the tags survive signal changes (27 assertions,
-all passing).
+that enclose it. `ppx/example/verify.mjs` proves this at runtime by tagging
+elements and asserting the tags survive signal changes; it runs in CI on every
+push.
 
 Two refinements make the output genuinely fine-grained rather than a thin
 sugar over `View.tracked`:
@@ -198,25 +198,33 @@ Notes:
   the one component-level annotation; `@xote.component` inherits
   `@jsx.component`'s one-component-per-module rule.)
 
-### Consumer-safety constraint (why it's opt-in, not in the library core)
+### Distribution (prebuilt binaries — see RFC #141)
 
 A ReScript consumer recompiles a dependency's sources during its own build and
 applies that dependency's `ppx-flags` (verified: a cold consumer build fails
-with "ppx not found" when the dependency lists a PPX the consumer lacks). So a
-`ppx-flags` entry in Xote's *published* `rescript.json` would force `ocamlopt`
-on every Xote user. The PPX is therefore kept out of the published library
-config entirely:
+with "ppx not found" when the dependency lists a PPX the consumer lacks). Two
+consequences shape the distribution model, decided in
+[RFC #141](https://github.com/brnrdog/xote/issues/141):
 
-- The published library (`src/`, root `rescript.json`) has **no** `ppx-flags`;
-  consumers who don't opt in are unaffected.
-- The `ppx.ml` source ships in the npm tarball, so a consumer who *wants*
-  `@xote.component` builds it (`sh node_modules/xote/ppx/build.sh`) and lists it
-  in **their own** `rescript.json` (`"ppx-flags": ["xote/ppx/ppx"]`).
-- In-repo, the PPX is real: `ci.yml` builds and runs its end-to-end test on
-  every push/PR, and the docs site (`docs-website/`, its own non-published
-  config) authors the Counter demo with `@xote.component` and builds the PPX in
-  its `res:build`. This proves it through SSR + hydration without touching the
-  publish path.
+- **The binary ships prebuilt.** The npm package carries one native binary per
+  supported platform (linux-x64, linux-arm64, darwin-x64, darwin-arm64,
+  win32-x64) under `ppx/bin/`, built by
+  `.github/workflows/ppx-binaries.yml` and packed by the release workflow.
+  `ppx/postinstall.js` selects the matching one at install time, so enabling
+  `@xote.component` is a single line in the consumer's `rescript.json`
+  (`"ppx-flags": ["xote/ppx/ppx"]`) with no OCaml toolchain required. Where no
+  prebuilt binary matches, the install script falls back to compiling the
+  bundled `ppx.ml` when `ocamlopt` is available.
+- **Xote's own published `rescript.json` still carries no `ppx-flags`.**
+  `src/` contains no `@xote.component` annotations, so a flag there would make
+  every consumer build depend on the binary for no benefit (and break under
+  package managers that skip install scripts). The annotation applies to the
+  consumer's components, so the flag belongs in the consumer's config — the
+  same way the `jsx` configuration is already mirrored.
+- In-repo, the PPX is exercised end to end: `ci.yml` compiles the full binary
+  matrix and runs the e2e test on every push/PR, and the docs site
+  (`docs-website/`) authors its components with `@xote.component` and builds
+  the PPX in its `res:build`, proving it through SSR + hydration.
 
 ## Phase 3 — notify-only scheduling (exploratory)
 
@@ -236,7 +244,7 @@ noting that adopting `Tracking` keeps the door open.
 
 - **Compiler-granular tracking (Solid-style).** Compile JSX so each inline
   read becomes its own leaf binding, avoiding the wholesale-replacement
-  tradeoff entirely. This is precisely what Phase 2b prototypes — see
+  tradeoff entirely. This is precisely what Phase 2b implements — see
   [`ppx/`](../../ppx/). It turned out to be tractable as a local expansion
   over the pre-JSX-transform AST rather than a full custom JSX transform,
   because Xote's runtime already accepts thunked attribute/child values and

--- a/docs/proposals/tracked-blocks.md
+++ b/docs/proposals/tracked-blocks.md
@@ -1,0 +1,120 @@
+# Proposal: Auto-tracked view blocks
+
+| | |
+|---|---|
+| **Status** | Phases 1 and 2 shipped. This document is kept for the design record — the *why*, the rejected options, and the one phase still unbuilt. Current behaviour is documented in [`ppx/README.md`](../../ppx/README.md) and [`AGENTS.md`](../../AGENTS.md), which are the sources of truth. |
+| **Related** | [brnrdog/rescript-signals#34](https://github.com/brnrdog/rescript-signals/pull/34) — auto-tracking for React and the `@tracked` annotation; [RFC #141](https://github.com/brnrdog/xote/issues/141) — adoption and distribution decision |
+
+## Summary
+
+Bring the auto-tracking ergonomics that rescript-signals PR #34 gives React
+consumers to Xote's own view layer, in three phases:
+
+1. **`View.tracked`** — a runtime block constructor where every signal read
+   inside the body subscribes the block automatically. *Shipped.*
+2. **A component annotation** — compile-time expansion that pushes reactivity
+   down to individual leaves instead of one coarse block. *Shipped as
+   `@xote.component`; see [`ppx/README.md`](../../ppx/README.md).*
+3. **Notify-only scheduling** — use the `Signals.Tracking` scope to decouple
+   invalidation from DOM writes, enabling batched (microtask/`requestAnimationFrame`)
+   update modes. *Exploratory, below.*
+
+Phases 1 and 2 were described here while they were being designed. Now that
+they are built, that description has been removed rather than maintained in
+parallel: a second account of shipped behaviour goes stale silently, and this
+one already had — it predated `MaybeSignal.get` detection, local reactive
+helpers, bare `View.child` children, and the `View.probe` hidden-read report.
+
+## Motivation: the thunk tax
+
+Xote's reactivity is fine-grained: components run once and reactivity attaches
+at the leaves. That model is fast and predictable, but it puts a syntactic tax
+on the author — every reactive read must be wrapped in a thunk or routed
+through a wrapper component so a `Computed` can capture it:
+
+```rescript
+/* one thunk per binding */
+View.signalText(() => "Hello, " ++ Signal.get(name))
+View.computedAttr("class", () => Signal.get(isActive) ? "active" : "inactive")
+
+/* one wrapper component per reactive branch */
+<View.Show when_={Prop.signal(isReady)} fallback={...}> ... </View.Show>
+<View.Value value={Prop.signal(count)} render={count => ...} />
+```
+
+Each primitive handles exactly one dependency shape. The friction shows up when
+one block of UI depends on **several signals with control flow between them**.
+Before this work that took either an intermediate `Computed` to merge the
+signals, or nested wrapper components:
+
+```rescript
+/* BEFORE — merge signals into a computed first… */
+let greeting = Computed.make(() =>
+  Signal.get(loggedIn) ? `Hello, ${Signal.get(name)}` : "Please log in"
+)
+<p> <View.Text> {greeting} </View.Text> </p>
+
+/* …or nest wrappers */
+<View.Show
+  when_={Prop.signal(loggedIn)}
+  fallback={<p> <View.Text> "Please log in" </View.Text> </p>}>
+  <View.Value
+    value={Prop.signal(name)}
+    render={name => <p> <View.Text> {`Hello, ${name}`} </View.Text> </p>}
+  />
+</View.Show>
+```
+
+Both work, but neither reads like the logic it expresses. The author is
+hand-compiling the dependency graph. That is the tax both shipped phases exist
+to remove.
+
+## When to use what
+
+The primitives are complementary, not replacements — this is the decision table
+across all of them:
+
+| Situation | Reach for |
+|---|---|
+| Reactive text/number | `View.Text` / `View.Int` / `signalText` |
+| Reactive attribute | `computedAttr` / function props |
+| Boolean branch on one signal | `View.Show` |
+| Node derived from one signal | `View.Value` / `View.Maybe` |
+| Lists | `View.For` with `by` (keyed reconciliation) |
+| Block over **several signals + control flow** | `View.tracked` |
+| A whole component, without any of the above ceremony | `@xote.component` |
+
+## Phase 3 — notify-only scheduling (exploratory)
+
+Xote's scheduler is synchronous: effects run inline when a signal is set
+(known limitation — no microtask/`requestAnimationFrame` coalescing). The
+`Signals.Tracking` scope introduced in PR #34 is a *notify-only* observer:
+the scheduler notifies it when a dependency changes but never re-runs it —
+the driver re-establishes dependencies itself via `Tracking.track`.
+
+That is exactly the primitive a deferred DOM-update mode needs: on
+invalidate, mark the binding dirty and schedule a flush; on flush, re-track
+and write to the DOM. This would let Xote offer opt-in rAF-batched rendering
+without forking the effect scheduler. Out of scope for this proposal beyond
+noting that adopting `Tracking` keeps the door open.
+
+## Alternatives considered
+
+- **Compiler-granular tracking (Solid-style).** Compile JSX so each inline
+  read becomes its own leaf binding, avoiding `View.tracked`'s
+  wholesale-replacement tradeoff entirely. This is what Phase 2 became — see
+  [`ppx/`](../../ppx/). It turned out to be tractable as a local expansion
+  over the pre-JSX-transform AST rather than a full custom JSX transform,
+  because Xote's runtime already accepts thunked attribute/child values and
+  lowers them to fine-grained bindings.
+- **Coarse expansion only** (`@tracked()` → one `View.tracked` around the
+  block). The mechanical option, and what PR #34's PPX does for React. It
+  inherits the wholesale-replacement semantics, so it is sugar rather than a
+  fix; rejected once the fine-grained expansion proved tractable.
+- **A `<View.Tracked>` JSX component.** JSX children evaluate eagerly, so the
+  component would need a `render: unit => node` thunk prop — no more ergonomic
+  than calling `View.tracked` directly, and it would suggest the block is
+  cheap to nest. Not worth the surface area.
+- **Status quo.** Composing `Computed` + wrapper primitives covers every case
+  these phases cover. The work is purely about ergonomics; nothing is removed
+  or deprecated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "xote",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "rescript-signals": "^3.1.0"
@@ -20,6 +21,7 @@
         "@semantic-release/npm": "^13.1.1",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "glob": "^11.1.0",
+        "jsdom": "^28.1.0",
         "remark-gfm": "^4.0.1",
         "rescript": "^12.0.0",
         "semantic-release": "^25.0.1",
@@ -8581,6 +8583,7 @@
       "integrity": "sha512-DGcZI2L5W0c6FuEnspLE0MIe1UtTt1VsW/vQfzBFCEBxSsQtoA6YRHUB8Puwnb30PHqZiFK1ADhn6UgA8LWK0A==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "workspaces": [
         "packages/playground",
         "packages/@rescript/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "xote",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@rescript/core": "^1.6.1",
@@ -21,6 +22,7 @@
         "@semantic-release/npm": "^13.1.1",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "glob": "^11.1.0",
+        "jsdom": "^28.1.0",
         "remark-gfm": "^4.0.1",
         "rescript": "^12.0.0",
         "semantic-release": "^25.0.1",
@@ -249,6 +251,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -289,43 +292,18 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -538,6 +516,7 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -1162,8 +1141,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -1177,8 +1155,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -1192,8 +1169,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -1207,8 +1183,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -1222,8 +1197,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -1237,8 +1211,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -1252,8 +1225,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -1267,8 +1239,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -1282,8 +1253,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -1297,8 +1267,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -1312,8 +1281,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -1327,8 +1295,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -1342,8 +1309,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -1357,8 +1323,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -1372,8 +1337,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -1387,8 +1351,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -1402,8 +1365,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -1417,8 +1379,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -1432,8 +1393,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -1447,8 +1407,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -1462,8 +1421,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -1477,8 +1435,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -1492,8 +1449,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -1507,8 +1463,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -1522,8 +1477,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -2114,6 +2068,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4661,6 +4616,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7818,6 +7774,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8629,6 +8586,7 @@
       "resolved": "https://registry.npmjs.org/rescript/-/rescript-12.0.0.tgz",
       "integrity": "sha512-DGcZI2L5W0c6FuEnspLE0MIe1UtTt1VsW/vQfzBFCEBxSsQtoA6YRHUB8Puwnb30PHqZiFK1ADhn6UgA8LWK0A==",
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "workspaces": [
         "packages/playground",
         "packages/@rescript/*",
@@ -8782,6 +8740,7 @@
       "integrity": "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,11 @@
     "src/**/*.res.mjs",
     "src/*.mjs",
     "rescript.json",
-    "AGENTS.md"
+    "AGENTS.md",
+    "ppx/ppx.ml",
+    "ppx/build.sh",
+    "ppx/README.md",
+    "ppx/LICENSE.OCaml"
   ],
   "scripts": {
     "res:build": "rescript",
@@ -77,7 +81,9 @@
     "docs:start": "cd docs-website && npm run dev",
     "docs:build": "cd docs-website && npm run build",
     "docs:serve": "cd docs-website && npm run preview",
-    "test": "npx rescript && node tests/Tests.res.mjs && node tests/JSXRuntime_test.mjs"
+    "test": "npx rescript && node tests/Tests.res.mjs && node tests/JSXRuntime_test.mjs",
+    "ppx:build": "sh ppx/build.sh",
+    "ppx:test": "sh ppx/example/setup.sh && sh ppx/build.sh && cd ppx/example && npm run build && npm run verify"
   },
   "keywords": [
     "rescript",

--- a/package.json
+++ b/package.json
@@ -65,10 +65,14 @@
     "AGENTS.md",
     "ppx/ppx.ml",
     "ppx/build.sh",
+    "ppx/postinstall.js",
+    "ppx/bin",
     "ppx/README.md",
     "ppx/LICENSE.OCaml"
   ],
   "scripts": {
+    "postinstall": "node ppx/postinstall.js",
+    "prepublishOnly": "node scripts/check-ppx-binaries.mjs",
     "res:build": "rescript",
     "res:clean": "rescript clean",
     "res:dev": "rescript -w",
@@ -131,6 +135,7 @@
     "@semantic-release/npm": "^13.1.1",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "glob": "^11.1.0",
+    "jsdom": "^28.1.0",
     "remark-gfm": "^4.0.1",
     "rescript": "^12.0.0",
     "semantic-release": "^25.0.1",

--- a/package.json
+++ b/package.json
@@ -62,9 +62,18 @@
     "src/**/*.res.mjs",
     "src/*.mjs",
     "rescript.json",
-    "AGENTS.md"
+    "AGENTS.md",
+    "ppx/ppx.ml",
+    "ppx/ast.ml",
+    "ppx/build.sh",
+    "ppx/postinstall.js",
+    "ppx/bin",
+    "ppx/README.md",
+    "ppx/LICENSE.OCaml"
   ],
   "scripts": {
+    "postinstall": "node ppx/postinstall.js",
+    "prepublishOnly": "node scripts/check-ppx-binaries.mjs",
     "res:build": "rescript",
     "res:clean": "rescript clean",
     "res:dev": "rescript -w",
@@ -77,7 +86,9 @@
     "docs:start": "cd docs-website && npm run dev",
     "docs:build": "cd docs-website && npm run build",
     "docs:serve": "cd docs-website && npm run preview",
-    "test": "npx rescript && node tests/Tests.res.mjs && node tests/JSXRuntime_test.mjs"
+    "test": "npx rescript && node tests/Tests.res.mjs && node tests/JSXRuntime_test.mjs && node tests/DevMode_test.mjs",
+    "ppx:build": "sh ppx/build.sh",
+    "ppx:test": "sh ppx/example/setup.sh && sh ppx/build.sh && cd ppx/example && npx rescript clean && npm run build && npm run verify && npm run golden"
   },
   "keywords": [
     "rescript",
@@ -125,6 +136,7 @@
     "@semantic-release/npm": "^13.1.1",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "glob": "^11.1.0",
+    "jsdom": "^28.1.0",
     "remark-gfm": "^4.0.1",
     "rescript": "^12.0.0",
     "semantic-release": "^25.0.1",

--- a/ppx/.gitignore
+++ b/ppx/.gitignore
@@ -1,0 +1,13 @@
+# OCaml build artifacts. The compiled binaries (ppx, ppx.exe, bin/) are
+# ignored from the ROOT .gitignore instead: npm honors nested ignore files
+# when packing even inside directories whitelisted in package.json "files",
+# so a bin/ rule here would strip the prebuilt binaries from the tarball.
+*.cmi
+*.cmx
+*.cmo
+*.o
+
+# Example build output
+example/lib/
+example/node_modules/
+example/**/*.res.mjs

--- a/ppx/.gitignore
+++ b/ppx/.gitignore
@@ -1,0 +1,11 @@
+# Compiled ppx binary and OCaml build artifacts (platform-specific)
+ppx
+*.cmi
+*.cmx
+*.cmo
+*.o
+
+# Example build output
+example/lib/
+example/node_modules/
+example/**/*.res.mjs

--- a/ppx/.gitignore
+++ b/ppx/.gitignore
@@ -1,5 +1,7 @@
-# Compiled ppx binary and OCaml build artifacts (platform-specific)
-ppx
+# OCaml build artifacts. The compiled binaries (ppx, ppx.exe, bin/) are
+# ignored from the ROOT .gitignore instead: npm honors nested ignore files
+# when packing even inside directories whitelisted in package.json "files",
+# so a bin/ rule here would strip the prebuilt binaries from the tarball.
 *.cmi
 *.cmx
 *.cmo

--- a/ppx/LICENSE.OCaml
+++ b/ppx/LICENSE.OCaml
@@ -1,0 +1,548 @@
+Third-party license notice for xote-tracked-ppx
+================================================
+
+`ppx.ml` vendors the OCaml 4.06 parsetree AST types (the `Location`,
+`Longident`, `Asttypes`, and `Parsetree` modules near the top of the file),
+copied verbatim from the OCaml compiler so that ReScript's marshalled ppx
+payload round-trips exactly. Those modules retain their original OCaml
+copyright headers. Everything after them (the `@tracked` rewriter) is the
+xote project's own code.
+
+The vendored portion is:
+
+    Copyright (C) 1996-2019 Institut National de Recherche en Informatique
+                            et en Automatique (INRIA)
+
+and is distributed under the GNU Lesser General Public License version 2.1
+with the OCaml linking exception, reproduced below. The full text of the
+GNU LGPL version 2.1 follows the exception.
+
+--------------------------------------------------------------------------
+OCaml license (LGPL-2.1 with linking exception)
+--------------------------------------------------------------------------
+
+In the following, "the OCaml Core System" refers to all files marked
+"Copyright INRIA" in this distribution.
+
+The OCaml Core System is distributed under the terms of the GNU Lesser
+General Public License (LGPL) version 2.1 (reproduced below).
+
+As a special exception to the GNU Lesser General Public License, you may
+link, statically or dynamically, a "work that uses the OCaml Core System"
+with a publicly distributed version of the OCaml Core System to produce an
+executable file containing portions of the OCaml Core System, and distribute
+that executable file under terms of your choice, without any of the
+additional requirements listed in clause 6 of the GNU Lesser General Public
+License. By "a publicly distributed version of the OCaml Core System", we
+mean either the unmodified OCaml Core System as distributed by INRIA, or a
+modified version of the OCaml Core System that is distributed under the
+conditions defined in clause 2 of the GNU Lesser General Public License.
+This exception does not however invalidate any other reasons why the
+executable file might be covered by the GNU Lesser General Public License.
+
+--------------------------------------------------------------------------
+GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
+--------------------------------------------------------------------------
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/ppx/README.md
+++ b/ppx/README.md
@@ -38,8 +38,8 @@ fine-grained:
 let make = (~label: string) => {
   let count = Signal.make(0)
   <div class={Signal.get(count) > 0 ? "on" : "off"} id="card">
-    <span class="static-label"> {View.text(label)} </span>
-    <View.Int> {Signal.get(count)} </View.Int>
+    <span class="static-label"> {label} </span>
+    {Signal.get(count)}
   </div>
 }
 ```
@@ -56,21 +56,21 @@ function make(props) {
     children: [
       Elements.jsx("span", {                      // static subtree — untouched
         class: "static-label",
-        children: View.text(label),
+        children: View.child(label),              // static text (passthrough/coerce)
       }),
-      jsx(View.Int.make, {
-        children: () => Signal.get(count),        // → reactive text node (leaf)
-      }),
+      View.child(() => Signal.get(count)),        // → reactive text node (leaf)
     ],
   });
 }
 ```
 
 Props derive from the labeled args (`label` stays static); no `View.tracked`,
-no `SignalFragment`, no wholesale rebuild. The `<div>` and `<span>` keep their
-DOM identity across updates; only the `class` attribute and the number re-run.
-(`example/verify.mjs` asserts exactly this by tagging the elements and checking
-the tags survive a signal change.)
+no `SignalFragment`, no `<View.Int>` wrapper, no wholesale rebuild. The bare
+`{Signal.get(count)}` child is coerced by `View.child` into a reactive text
+leaf; the `<div>` and `<span>` keep their DOM identity across updates, and only
+the `class` attribute and the number re-run. (`example/verify.mjs` asserts
+exactly this by tagging the elements and checking the tags survive a signal
+change.)
 
 `@xote.component` is the single annotation. The PPX rewrites it to
 `@jsx.component` (so the JSX transform still derives the props record) and
@@ -89,11 +89,45 @@ Applied recursively to the component's returned JSX:
 | `<View.Text/Int/Float/Bool>` child | yes | thunked → reactive text node (leaf) |
 | `<View.Text/…>` child | no | left as-is (static text) |
 | Element / nested JSX | — | recurse into attributes and children |
-| Bare child in node position (an `if`/`switch` selecting different nodes) | yes | branches decomposed fine-grained, then wrapped in `View.tracked` — see below |
+| Fragment (`<>…</>`) | — | recurse into each child independently (so nested reactive regions stay separate — not collapsed into one thunk) |
+| Bare child, control flow (`if`/`switch` selecting different nodes) | yes | branches decomposed fine-grained, then wrapped in `View.tracked` — see below |
+| Bare child, otherwise (`{Signal.get(x)}`, `{"lit"}`, `{someNode}`) | — | wrapped in `View.child` — see [Bare value children](#bare-value-children) |
 
 The result: reactivity lives at the leaves; `View.tracked` is emitted
 **surgically**, only around a child region whose node *structure* actually
 varies, and never around the stable elements that enclose it.
+
+### Bare value children
+
+You don't need an explicit `<View.Int>`/`<View.Text>` value primitive under the
+annotation — a **bare `{…}` child** in element position works directly:
+
+```rescript
+@xote.component
+let make = () =>
+  <div>
+    {"Count: "}          // static text
+    {Signal.get(count)}  // reactive text leaf
+  </div>
+```
+
+Every bare non-control-flow child is wrapped in the runtime helper
+[`View.child`](../src/View.res), which coerces at runtime:
+
+- an eager signal read is thunked first, so it becomes a **reactive text** leaf;
+- a static scalar (`{"lit"}`, `{42}`) becomes a **static text** node — previously
+  a *compile error* (a scalar in node position), now it just works;
+- a value that is **already a node** (`{View.text(x)}`, a component call, a list)
+  passes through untouched (detected by its runtime tag);
+- `null`/`undefined` render nothing.
+
+This also covers control flow whose **branches are scalars** — the `switch` is
+still tracked for the structural swap, but each scalar branch is coerced by
+`View.child`, so `| Loading => "…"` no longer needs a value primitive either.
+
+The explicit `View.Text/Int/Float/Bool` primitives remain available (they are
+what non-PPX code uses, and give stronger `int`/`float` typing on the child);
+`View.child` is just the zero-ceremony default under `@xote.component`.
 
 ### Control flow tracks only the condition
 
@@ -238,7 +272,7 @@ Or step by step from `example/`:
 sh setup.sh             # link toolchain + Xote from the repo root (idempotent)
 sh ../build.sh          # build the ppx
 npm run build           # compile Demo.res through the ppx
-npm run verify          # jsdom runtime check (41 assertions)
+npm run verify          # jsdom runtime check (71 assertions)
 ```
 
 ## Known limitations (it's a prototype)
@@ -252,11 +286,13 @@ npm run verify          # jsdom runtime check (41 assertions)
   hatch is reliable: wrap it in `() =>` yourself and it becomes reactive (the
   eager check leaves your thunk alone, so it is never double-wrapped). An
   over-eager match only produces a harmless extra `computedAttr`.
-- **Value-component set is hard-coded** to `View.Text/Int/Float/Bool`. An
-  aliased or opened `View` (`module V = View` → `<V.Text>`, `open View` → bare
-  `<Text>`) is treated as an ordinary element, so a bare value child is put in
-  node position — which is a **compile error** (`string` where `View.node` is
-  expected), not a silent bug. Use the qualified `View.Text` form.
+- **Value-component detection is hard-coded** to the qualified
+  `View.Text/Int/Float/Bool`. An aliased or opened `View` (`module V = View` →
+  `<V.Text>`, `open View` → bare `<Text>`) is not recognized as a value
+  component. This is **not silent** — the value child lands in node position and
+  is a **compile error** (`string` where `View.node` is expected), so it fails
+  loudly at build time. Simplest fix: drop the wrapper and use a **bare `{…}`
+  child** (`View.child` coerces it), or use the qualified `View.Text` form.
 - **Coupled to ReScript's ppx ABI.** The vendored OCaml 4.06 parsetree, the
   `Caml1999M022` marshal magic, and the uncurried `Function$` construct name are
   compiler internals. A ReScript release that bumps the ppx AST version fails

--- a/ppx/README.md
+++ b/ppx/README.md
@@ -5,15 +5,18 @@ props-deriving component whose returned JSX is decomposed into **fine-grained
 reactive leaves** — the compile-time counterpart to the runtime
 [`View.tracked`](../src/View.res) helper.
 
-> **Status:** experimental, opt-in. The PPX is exercised in CI and used by the
-> [docs site](../docs-website) itself (the Counter demo), but it is **not part
-> of the published npm package** — consumers who want it build it themselves
-> (see [Opt-in for consumers](#opt-in-for-consumers)). It demonstrates that the
+> **Status:** the standard authoring model. The npm package ships the PPX as a
+> prebuilt binary per platform, selected at install time (see
+> [Distribution](#distribution)), so enabling `@xote.component` is a single
+> `ppx-flags` line with no toolchain requirement. The PPX is exercised in CI
+> and used by the [docs site](../docs-website) itself. It grew out of the
 > [`rescript-signals` #34](https://github.com/brnrdog/rescript-signals/pull/34)
-> auto-tracking idea can target Xote's view layer *and* compile away the
+> auto-tracking idea, targeting Xote's view layer *and* compiling away the
 > wholesale-replacement tradeoff of `View.tracked`. See
 > [`docs/proposals/tracked-blocks.md`](../docs/proposals/tracked-blocks.md) for
-> the full design context (this is "Phase 2, fine-grained variant").
+> the full design context, and
+> [RFC #141](https://github.com/brnrdog/xote/issues/141) for the decision to
+> distribute prebuilt binaries and make this the primary model.
 
 ## What problem it solves
 
@@ -90,12 +93,30 @@ Applied recursively to the component's returned JSX:
 | `<View.Text/…>` child | no | left as-is (static text) |
 | Element / nested JSX | — | recurse into attributes and children |
 | Fragment (`<>…</>`) | — | recurse into each child independently (so nested reactive regions stay separate — not collapsed into one thunk) |
-| Bare child, control flow (`if`/`switch` selecting different nodes) | yes | branches decomposed fine-grained, then wrapped in `View.tracked` — see below |
+| User-component prop (`<Card label={…}>`) | — | left untouched — see [User-component props](#user-component-props) |
+| Bare child, control flow (`if`/`switch` selecting different nodes) | yes | branches decomposed fine-grained, then wrapped in `View.tracked` — see below. Signal reads in `when` guards count: they are evaluated with the scrutinee |
+| Bare child, block expression (`{let x = …; <span/>}`) | — | recurse into the tail, threading `let`-bound aliases — the inner JSX keeps fine-grained leaves |
 | Bare child, otherwise (`{Signal.get(x)}`, `{"lit"}`, `{someNode}`) | — | wrapped in `View.child` — see [Bare value children](#bare-value-children) |
 
 The result: reactivity lives at the leaves; `View.tracked` is emitted
 **surgically**, only around a child region whose node *structure* actually
 varies, and never around the stable elements that enclose it.
+
+### User-component props
+
+Props of a **user component** land in that component's typed props record, so
+the PPX never thunks them — `<Card label={Signal.get(name)} />` compiles as
+written and is a deliberate **one-shot read** (the component function runs
+once; a reactive-looking scalar prop cannot be reactive anyway). For a prop
+that should react, pass the signal itself (`<Card count={count} />`) or a
+thunk, and have the component read it.
+
+The two node-shaped exceptions are still decomposed: **children**, and any
+prop whose value is **itself JSX** (`<Layout header={<span
+class={Signal.get(theme)} />} />` — the header's class stays a fine-grained
+reactive leaf). Intrinsic elements (`<div>`, …) are different: their attributes
+accept thunks at runtime, which is why *their* reactive attributes are thunked
+into `computedAttr`s.
 
 ### Bare value children
 
@@ -117,9 +138,16 @@ Every bare non-control-flow child is wrapped in the runtime helper
 - an eager signal read is thunked first, so it becomes a **reactive text** leaf;
 - a static scalar (`{"lit"}`, `{42}`) becomes a **static text** node — previously
   a *compile error* (a scalar in node position), now it just works;
-- a value that is **already a node** (`{View.text(x)}`, a component call, a list)
+- a value that is **already a node** (`{View.text(x)}`, a component call)
   passes through untouched (detected by its runtime tag);
-- `null`/`undefined` render nothing.
+- a bare **signal** (`{count}` where `count: Signal.t<_>`) becomes reactive
+  text — signals are detected positively by their runtime shape, so an
+  arbitrary record is never mistaken for one;
+- an **array** is coerced element-wise into a fragment (an array of nodes
+  renders each node; an array of scalars renders their text);
+- `null`/`undefined` render nothing;
+- any **other object** (a record, a dict) cannot be rendered as a node: it is
+  stringified with a console warning pointing at the value.
 
 This also covers control flow whose **branches are scalars** — the `switch` is
 still tracked for the structural swap, but each scalar branch is coerced by
@@ -171,9 +199,10 @@ shadowing it with a non-alias removes it) recognises all of these:
 | Local reactive helper | `let cls = () => Signal.get(x) ? …` … `cls()` | function binding whose body eagerly reads a signal; its *call* counts |
 
 `Signal.peek` is intentionally **not** a read — it is an untracked read, so a
-value that only peeks stays static (verified by the shadowing case, where an
-alias rebound to a `peek`-based function is dropped and its attribute is left
-as a plain string).
+value that only peeks stays static (verified by the example's `PeekShadow`
+case, where a reactive helper rebound to a `peek`-based function is dropped
+from the alias environment and its attribute is left as a plain, once-evaluated
+string).
 
 Only *eager* reads trigger a thunk. A read deferred inside a nested lambda — a
 `() => …` you wrote yourself, a `Computed`, a `Prop.reactive(Computed.make(…))`,
@@ -207,41 +236,61 @@ exception**; they keep their original copyright headers. The
 and license text is in [`LICENSE.OCaml`](./LICENSE.OCaml), which ships in the
 npm tarball alongside `ppx.ml`.
 
-## Build
+## Distribution
 
-```sh
-sh build.sh   # produces ./ppx (needs ocamlopt; any recent OCaml, tested 4.14)
-```
+The npm package ships the PPX **prebuilt** for the common platforms, under
+`ppx/bin/`:
 
-Wire it into a project's `rescript.json`:
+| Platform | Binary |
+|---|---|
+| Linux x64 | `ppx-linux-x64.exe` |
+| Linux arm64 | `ppx-linux-arm64.exe` |
+| macOS x64 (Intel) | `ppx-darwin-x64.exe` |
+| macOS arm64 (Apple Silicon) | `ppx-darwin-arm64.exe` |
+| Windows x64 | `ppx-win32-x64.exe` |
 
-```json
-{ "ppx-flags": ["xote-tracked-ppx/ppx"] }
-```
-
-## Opt-in for consumers
-
-The compiled binary is platform-specific and is **not** shipped in the npm
-package, and — deliberately — neither is a `ppx-flags` entry in Xote's own
-published `rescript.json`. That last point matters: a ReScript consumer
-recompiles a dependency's sources during its own build and applies that
-dependency's `ppx-flags`, so a PPX listed in Xote's published config would
-force `ocamlopt` on **every** Xote user. Instead the PPX is strictly opt-in.
-
-The `ppx.ml` source *is* published, so a consumer who wants `@xote.component`
-can build it from the installed package and reference it from **their own**
-`rescript.json`:
-
-```sh
-npm install xote
-sh node_modules/xote/ppx/build.sh      # needs ocamlopt
-```
+The binaries are compiled in CI by
+[`.github/workflows/ppx-binaries.yml`](../.github/workflows/ppx-binaries.yml)
+and injected into the tarball by the release workflow. On install, Xote's
+`postinstall` script ([`postinstall.js`](./postinstall.js)) copies the binary
+matching `process.platform`-`process.arch` to `ppx/ppx` (`ppx/ppx.exe` on
+Windows), which is the path consumers reference:
 
 ```json
 { "ppx-flags": ["xote/ppx/ppx"] }
 ```
 
-Consumers who don't do this are entirely unaffected.
+That one line in your `rescript.json` is the whole setup — no OCaml toolchain
+required. Two edge cases:
+
+- **Install scripts disabled.** Some package managers skip dependency install
+  scripts (pnpm does by default). Approve them for `xote`
+  (`pnpm approve-builds`) or run `node node_modules/xote/ppx/postinstall.js`
+  once.
+- **Unsupported platform.** If no prebuilt binary matches — or the matching
+  one does not execute on the host (the install script smoke-runs it; the
+  Linux prebuilts are glibc-linked, so musl systems like Alpine fall through
+  here) — the script falls back to compiling `ppx.ml` from source when
+  `ocamlopt` is on the `PATH`, and otherwise prints instructions without
+  failing the install.
+
+A `ppx-flags` entry is deliberately **not** in Xote's own published
+`rescript.json`: a ReScript consumer recompiles a dependency's sources during
+its own build and applies that dependency's `ppx-flags`, and Xote's `src/`
+carries no `@xote.component` annotations, so listing the PPX there would make
+every build depend on the binary for no benefit. The annotation applies to
+*your* components, which is why the flag lives in *your* `rescript.json` —
+exactly like the `jsx` configuration you already mirror.
+
+## Build from source
+
+```sh
+sh build.sh   # produces ./ppx (needs ocamlopt; any recent OCaml, tested 4.14)
+```
+
+`build.sh` also accepts an output path relative to `ppx/`
+(`sh build.sh bin/ppx-linux-x64.exe`), which is how the CI matrix produces
+the prebuilt binaries.
 
 ## In this repo
 
@@ -272,10 +321,10 @@ Or step by step from `example/`:
 sh setup.sh             # link toolchain + Xote from the repo root (idempotent)
 sh ../build.sh          # build the ppx
 npm run build           # compile Demo.res through the ppx
-npm run verify          # jsdom runtime check (71 assertions)
+npm run verify          # jsdom runtime check (every case above, asserted on real DOM)
 ```
 
-## Known limitations (it's a prototype)
+## Known limitations
 
 - **Signal detection is syntactic** (though alias- and helper-aware — see the
   table above). It follows `let`/`module`/`open` aliases and *local* reactive
@@ -286,6 +335,21 @@ npm run verify          # jsdom runtime check (71 assertions)
   hatch is reliable: wrap it in `() =>` yourself and it becomes reactive (the
   eager check leaves your thunk alone, so it is never double-wrapped). An
   over-eager match only produces a harmless extra `computedAttr`.
+- **Hoisting a read into a `let` makes it a one-shot read.** Reactivity follows
+  the *expression in JSX position*: `<div> {Signal.get(count)} </div>` is a
+  reactive leaf, but
+
+  ```rescript
+  let label = Signal.get(count)->Int.toString
+  <div> {label} </div>
+  ```
+
+  reads `count` once, at component setup, and renders a static value — the
+  binding is an ordinary eager evaluation, exactly as it would be in any
+  signals library without a compiler. When extracting a reactive expression
+  into a binding, bind a *thunk* instead: `let label = () =>
+  Signal.get(count)->Int.toString` and use `{label()}` (a tracked reactive
+  helper) or `{label}` (coerced by `View.child`).
 - **Value-component detection is hard-coded** to the qualified
   `View.Text/Int/Float/Bool`. An aliased or opened `View` (`module V = View` →
   `<V.Text>`, `open View` → bare `<Text>`) is not recognized as a value
@@ -295,14 +359,17 @@ npm run verify          # jsdom runtime check (71 assertions)
   child** (`View.child` coerces it), or use the qualified `View.Text` form.
 - **Coupled to ReScript's ppx ABI.** The vendored OCaml 4.06 parsetree, the
   `Caml1999M022` marshal magic, and the uncurried `Function$` construct name are
-  compiler internals. A ReScript release that bumps the ppx AST version fails
-  loudly (magic mismatch); one that renamed `Function$` could fail *quietly*.
-  Validated against ReScript 12; CI building the docs site through the PPX is the
-  canary on upgrade.
+  compiler internals. A ReScript release that bumps the ppx AST version makes
+  the ppx **fail the build immediately** with an error naming the mismatched
+  magic (interface ASTs still pass through untouched); a release that renamed
+  `Function$` could fail *quietly*. Validated against ReScript 12; CI building
+  the docs site through the PPX is the early warning on upgrade.
 - **A branch swap still rebuilds that branch's subtree.** Control flow tracks
   only the condition (leaves inside branches stay fine-grained, see above), but
   when the condition *does* change, the selected branch is built fresh — there
   is no keyed diffing between the old and new branch. This matches Xote's own
   `View.Show`/`View.tracked`; use `View.For` with `by` for lists.
-- **Not wired into the main build.** This lives outside `src/` and is not part
-  of `npm run build`/`test`; it is a standalone proof of concept.
+- **Separate from the library build.** The PPX is never needed to build or use
+  Xote itself (`npm run build`/`npm run test` don't involve it). It is compiled
+  per platform in CI, shipped prebuilt in the npm tarball, and exercised
+  end-to-end by `npm run ppx:test` on every push.

--- a/ppx/README.md
+++ b/ppx/README.md
@@ -94,8 +94,11 @@ Applied recursively to the component's returned JSX:
 | Element / nested JSX | — | recurse into attributes and children |
 | Fragment (`<>…</>`) | — | recurse into each child independently (so nested reactive regions stay separate — not collapsed into one thunk) |
 | User-component prop (`<Card label={…}>`) | — | left untouched — see [User-component props](#user-component-props) |
+| User-component render callback (`render={row => <li>…</li>}`) | — | the callback body is node position: decomposed like any other node, so bare children are coerced and leaves stay fine-grained |
 | Bare child, control flow (`if`/`switch` selecting different nodes) | yes | branches decomposed fine-grained, then wrapped in `View.tracked` — see below. Signal reads in `when` guards count: they are evaluated with the scrutinee |
+| Bare child, control flow | no | branches decomposed fine-grained, **no** `View.tracked` — a condition that cannot change needs no reactive scope, but its branches are still node position, so their bare children are coerced and their leaves stay fine-grained |
 | Bare child, block expression (`{let x = …; <span/>}`) | — | recurse into the tail, threading `let`-bound aliases — the inner JSX keeps fine-grained leaves |
+| Bare child, anything containing JSX (`{View.tracked(() => …)}`, `{View.fragment([<p/>])}`, `{xs->Array.map(x => <li/>)}`, `{try {<p/>} catch {…}}`) | — | the whole expression is walked: JSX inside it, and functions returning JSX, are node position and get decomposed; the result is then wrapped in `View.child` |
 | Bare child, otherwise (`{Signal.get(x)}`, `{"lit"}`, `{someNode}`) | — | wrapped in `View.child` — see [Bare value children](#bare-value-children) |
 
 The result: reactivity lives at the leaves; `View.tracked` is emitted
@@ -111,12 +114,47 @@ once; a reactive-looking scalar prop cannot be reactive anyway). For a prop
 that should react, pass the signal itself (`<Card count={count} />`) or a
 thunk, and have the component read it.
 
-The two node-shaped exceptions are still decomposed: **children**, and any
-prop whose value is **itself JSX** (`<Layout header={<span
-class={Signal.get(theme)} />} />` — the header's class stays a fine-grained
-reactive leaf). Intrinsic elements (`<div>`, …) are different: their attributes
-accept thunks at runtime, which is why *their* reactive attributes are thunked
-into `computedAttr`s.
+The node-shaped exceptions are still decomposed:
+
+- **children**;
+- any prop whose value is **itself JSX** (`<Layout header={<span
+  class={Signal.get(theme)} />} />` — the header's class stays a fine-grained
+  reactive leaf);
+- any prop whose value is a **function returning JSX** — a render callback such
+  as `View.For`'s `render={row => <li> {row.author} </li>}`. Its body is node
+  position once applied, so it is decomposed like any other node: bare children
+  are coerced and reactive leaves inside stay fine-grained. Function props whose
+  body is *not* JSX (`by={row => row.id}`, `onClick={…}`) are left alone.
+
+Intrinsic elements (`<div>`, …) are different: their attributes accept thunks
+at runtime, which is why *their* reactive attributes are thunked into
+`computedAttr`s.
+
+### Where the annotation reaches
+
+`@xote.component` marks a *file* as written in the fine-grained style, not just
+one binding. In a file containing at least one annotated component, JSX is
+decomposed wherever it appears:
+
+- the annotated component's returned markup, and everything nested in it;
+- JSX bound to a name (`let row = <p> {"x"} </p>`);
+- **plain helper functions that return markup**, at the top level or in a
+  sibling module:
+
+```rescript
+/* no annotation needed: helpers that return markup are components in all but
+   name, and are decomposed like inline JSX */
+let filterButton = (label: string, value: filter, current: filter) =>
+  <button
+    class={value === current ? "active" : "idle"}
+    onClick={_ => Signal.set(filter, value)}>
+    {label}
+  </button>
+```
+
+A file with **no** `@xote.component` anywhere is left completely untouched, so a
+project that mixes `@jsx.component` code with explicit thunks keeps its current
+semantics. That is the opt-in boundary: per file, by annotation.
 
 ### Bare value children
 
@@ -205,7 +243,7 @@ from the alias environment and its attribute is left as a plain, once-evaluated
 string).
 
 Only *eager* reads trigger a thunk. A read deferred inside a nested lambda — a
-`() => …` you wrote yourself, a `Computed`, a `Prop.reactive(Computed.make(…))`,
+`() => …` you wrote yourself, a `Computed`, a `MaybeSignal.reactive(Computed.make(…))`,
 or a helper that merely *returns* a thunk — is already reactive and left as-is.
 Because of that, when detection can't see a read (below), the safe fix is always
 to wrap the value in `() =>` yourself: it will not be double-wrapped.

--- a/ppx/README.md
+++ b/ppx/README.md
@@ -1,0 +1,562 @@
+# xote-tracked-ppx
+
+A native ReScript PPX that expands an `@xote.component` annotation into a
+props-deriving component whose returned JSX is decomposed into **fine-grained
+reactive leaves** — the compile-time counterpart to the runtime
+[`View.tracked`](../src/View.res) helper.
+
+> **Status:** the recommended way to write components today — but the semantics
+> are not frozen yet, and a few are still expected to change (see
+> [Not settled yet](#not-settled-yet)). The npm package ships the PPX as a
+> prebuilt binary per platform, selected at install time (see
+> [Distribution](#distribution)), so enabling `@xote.component` is a single
+> `ppx-flags` line with no toolchain requirement. The PPX is exercised in CI
+> and used by the [docs site](../docs-website) itself. It grew out of the
+> [`rescript-signals` #34](https://github.com/brnrdog/rescript-signals/pull/34)
+> auto-tracking idea, targeting Xote's view layer *and* compiling away the
+> wholesale-replacement tradeoff of `View.tracked`. See
+> [`docs/proposals/tracked-blocks.md`](../docs/proposals/tracked-blocks.md) for
+> the motivation and the alternatives that were rejected, and
+> [RFC #141](https://github.com/brnrdog/xote/issues/141) for the decision to
+> distribute prebuilt binaries and make this the primary model.
+
+## What problem it solves
+
+`View.tracked(() => <block>)` is convenient — every signal read inside the
+block subscribes it automatically — but it lowers to a `SignalFragment` over a
+`Computed`, so **any** dependency change re-evaluates the whole block and
+replaces its children wholesale (no diffing; local DOM state like input focus
+is lost). Good for small blocks, a footgun on large ones.
+
+This PPX takes the same ergonomic surface — write plain JSX, read signals
+inline — but instead of one coarse computed it **decomposes the block at
+compile time**, pushing reactivity down to exactly the leaves that read
+signals. The element structure is emitted once and never rebuilt.
+
+## Example
+
+Input — one annotation replaces `@jsx.component` and makes the return
+fine-grained:
+
+```rescript
+@xote.component
+let make = (~label: string) => {
+  let count = Signal.make(0)
+  <div class={Signal.get(count) > 0 ? "on" : "off"} id="card">
+    <span class="static-label"> {label} </span>
+    {Signal.get(count)}
+  </div>
+}
+```
+
+Compiles to (abbreviated):
+
+```js
+function make(props) {
+  let label = props.label;                        // props derived (@jsx.component)
+  let count = Signal.make(0);
+  return Elements.jsxs("div", {
+    id: "card",                                   // static — untouched
+    class: () => Signal.get(count) > 0 ? "on" : "off", // → View.computedAttr (reactive leaf)
+    children: [
+      Elements.jsx("span", {                      // static subtree — untouched
+        class: "static-label",
+        children: View.child(label),              // static text (passthrough/coerce)
+      }),
+      View.child(() => Signal.get(count)),        // → reactive text node (leaf)
+    ],
+  });
+}
+```
+
+Props derive from the labeled args (`label` stays static); no `View.tracked`,
+no `SignalFragment`, no `<View.Int>` wrapper, no wholesale rebuild. The bare
+`{Signal.get(count)}` child is coerced by `View.child` into a reactive text
+leaf; the `<div>` and `<span>` keep their DOM identity across updates, and only
+the `class` attribute and the number re-run. (`example/verify.mjs` asserts
+exactly this by tagging the elements and checking the tags survive a signal
+change.)
+
+`@xote.component` is the single annotation. The PPX rewrites it to
+`@jsx.component` (so the JSX transform still derives the props record) and
+fine-grains the returned JSX — one attribute, no `@jsx.component` +
+tracking-annotation stacking. Because it emits `@jsx.component`, it inherits its
+rules: **one component per module** (each in its own file, or a submodule).
+
+## Decomposition rules
+
+Applied recursively to the component's returned JSX:
+
+| Position | Reads a signal? | Result |
+|---|---|---|
+| Attribute value (`class={…}`) | yes | thunked → `View.computedAttr` (reactive attribute leaf) |
+| Attribute value | no | left as-is (static attribute) |
+| `<View.Text/Int/Float/Bool>` child | yes | thunked → reactive text node (leaf) |
+| `<View.Text/…>` child | no | left as-is (static text) |
+| Any value leaf | can't tell — the expression contains a call the PPX cannot resolve | wrapped in `View.probe`, which decides at runtime and reports a read it finds — see [Hidden reads](#hidden-reads) |
+| Element / nested JSX | — | recurse into attributes and children |
+| Fragment (`<>…</>`) | — | recurse into each child independently (so nested reactive regions stay separate — not collapsed into one thunk) |
+| User-component prop (`<Card label={…}>`) | — | left untouched — see [User-component props](#user-component-props) |
+| User-component render callback (`render={row => <li>…</li>}`) | — | the callback body is node position: decomposed like any other node, so bare children are coerced and leaves stay fine-grained |
+| Bare child, control flow (`if`/`switch` selecting different nodes) | yes | branches decomposed fine-grained, then wrapped in `View.tracked` — see below. Signal reads in `when` guards count: they are evaluated with the scrutinee |
+| Bare child, control flow | no | branches decomposed fine-grained, **no** `View.tracked` — a condition that cannot change needs no reactive scope, but its branches are still node position, so their bare children are coerced and their leaves stay fine-grained |
+| Bare child, block expression (`{let x = …; <span/>}`) | — | recurse into the tail, threading `let`-bound aliases — the inner JSX keeps fine-grained leaves |
+| Bare child, anything containing JSX (`{View.tracked(() => …)}`, `{View.fragment([<p/>])}`, `{xs->Array.map(x => <li/>)}`, `{try {<p/>} catch {…}}`) | — | the whole expression is walked: JSX inside it, and functions returning JSX, are node position and get decomposed; the result is then wrapped in `View.child` |
+| Bare child, otherwise (`{Signal.get(x)}`, `{"lit"}`, `{someNode}`) | — | wrapped in `View.child` — see [Bare value children](#bare-value-children) |
+
+The result: reactivity lives at the leaves; `View.tracked` is emitted
+**surgically**, only around a child region whose node *structure* actually
+varies, and never around the stable elements that enclose it.
+
+### User-component props
+
+Props of a **user component** land in that component's typed props record, so
+the PPX never thunks them — `<Card label={Signal.get(name)} />` compiles as
+written and is a deliberate **one-shot read** (the component function runs
+once; a reactive-looking scalar prop cannot be reactive anyway). For a prop
+that should react, pass the signal itself (`<Card count={count} />`) or a
+thunk, and have the component read it.
+
+The node-shaped exceptions are still decomposed:
+
+- **children**;
+- any prop whose value is **itself JSX** (`<Layout header={<span
+  class={Signal.get(theme)} />} />` — the header's class stays a fine-grained
+  reactive leaf);
+- any prop whose value is a **function returning JSX** — a render callback such
+  as `View.For`'s `render={row => <li> {row.author} </li>}`. Its body is node
+  position once applied, so it is decomposed like any other node: bare children
+  are coerced and reactive leaves inside stay fine-grained. Function props whose
+  body is *not* JSX (`by={row => row.id}`, `onClick={…}`) are left alone.
+
+Intrinsic elements (`<div>`, …) are different: their attributes accept thunks
+at runtime, which is why *their* reactive attributes are thunked into
+`computedAttr`s.
+
+### Where the annotation reaches
+
+`@xote.component` marks a *file* as written in the fine-grained style, not just
+one binding. In a file containing at least one annotated component, JSX is
+decomposed wherever it appears:
+
+- the annotated component's returned markup, and everything nested in it;
+- JSX bound to a name (`let row = <p> {"x"} </p>`), including JSX sitting inside
+  a container the binding builds — `let rows = [<li/>, <li/>]`,
+  `let header = Some(<h1/>)`, `let build = xs => Array.map(xs, x => <li/>)`;
+- **plain helper functions that return markup**, at the top level or in a
+  sibling module:
+
+```rescript
+/* no annotation needed: helpers that return markup are components in all but
+   name, and are decomposed like inline JSX */
+let filterButton = (label: string, value: filter, current: filter) =>
+  <button
+    class={value === current ? "active" : "idle"}
+    onClick={_ => Signal.set(filter, value)}>
+    {label}
+  </button>
+```
+
+A file with **no** `@xote.component` anywhere is left completely untouched, so a
+project that mixes `@jsx.component` code with explicit thunks keeps its current
+semantics. That is the opt-in boundary: per file, by annotation.
+
+### Bare value children
+
+You don't need an explicit `<View.Int>`/`<View.Text>` value primitive under the
+annotation — a **bare `{…}` child** in element position works directly:
+
+```rescript
+@xote.component
+let make = () =>
+  <div>
+    {"Count: "}          // static text
+    {Signal.get(count)}  // reactive text leaf
+  </div>
+```
+
+Every bare non-control-flow child is wrapped in the runtime helper
+[`View.child`](../src/View.res), which coerces at runtime:
+
+- an eager signal read is thunked first, so it becomes a **reactive text** leaf;
+- a static scalar (`{"lit"}`, `{42}`) becomes a **static text** node — previously
+  a *compile error* (a scalar in node position), now it just works;
+- a value that is **already a node** (`{View.text(x)}`, a component call)
+  passes through untouched (detected by its runtime tag);
+- a bare **signal** (`{count}` where `count: Signal.t<_>`) becomes reactive
+  text — signals are detected positively by their runtime shape, so an
+  arbitrary record is never mistaken for one;
+- an **array** is coerced element-wise into a fragment (an array of nodes
+  renders each node; an array of scalars renders their text);
+- `null`/`undefined` render nothing;
+- any **other object** (a record, a dict) cannot be rendered as a node: it is
+  stringified with a console warning pointing at the value (development only —
+  see [Hidden reads](#hidden-reads) for the flag that gates it).
+
+This also covers control flow whose **branches are scalars** — the `switch` is
+still tracked for the structural swap, but each scalar branch is coerced by
+`View.child`, so `| Loading => "…"` no longer needs a value primitive either.
+
+The explicit `View.Text/Int/Float/Bool` primitives remain available (they are
+what non-PPX code uses, and give stronger `int`/`float` typing on the child);
+`View.child` is just the zero-ceremony default under `@xote.component`.
+
+### Control flow tracks only the condition
+
+When a branch body is decomposed *before* the `View.tracked` wrapper is applied,
+its leaves become thunks. So when the tracked scope runs the chosen branch to
+build its nodes, those thunks are not invoked — the scope ends up subscribed to
+only the **condition/scrutinee**, not to signals read by leaves inside the
+branches. Given:
+
+```rescript
+@xote.component
+let make = () =>
+  <div>
+    {switch Signal.get(status) {
+    | Loading => <span> {View.text("Loading...")} </span>
+    | Ready(msg) => <strong class={Signal.get(theme)}> {View.text(msg)} </strong>
+    }}
+  </div>
+```
+
+the `class={Signal.get(theme)}` becomes a `computedAttr` **inside** the
+`View.tracked`. Changing `theme` updates just that class and leaves the
+`<strong>` in place; only a change to `status` (the scrutinee) re-runs the
+switch and rebuilds the branch. `example/verify.mjs` asserts both:
+the `<strong>` keeps its identity across a `theme` change, and a `status`
+change still swaps the branch.
+
+## What counts as "reads a signal"
+
+Detection is more than a literal `Signal.get`. An alias environment threaded
+through the traversal (scoped: an alias is visible only *after* its binding, and
+shadowing it with a non-alias removes it) recognises all of these:
+
+| Form | Example | Detected via |
+|---|---|---|
+| Direct | `Signal.get(sig)` / `X.Signal.get(sig)` | literal match |
+| Through the wrapper | `MaybeSignal.get(v)`, `Prop.get(v)` | same — reading a `MaybeSignal` subscribes exactly like `Signal.get` |
+| Pipe | `sig->Signal.get` | desugars to `Signal.get(sig)` before the PPX |
+| Value alias | `let g = Signal.get` … `g(sig)` | binding tracked in scope |
+| Module alias | `module S = Signal` … `S.get(sig)` | binding tracked in scope |
+| Open | `open Signal` … `get(sig)` | bare `get` under an open |
+| Local reactive helper | `let cls = () => Signal.get(x) ? …` … `cls()` | function binding whose body eagerly reads a signal; its *call* counts |
+| Same-file module helper | `module Store = { let count = s => Signal.get(s) }` … `Store.count(s)` | the module body is walked, and its reactive names qualified |
+
+`Signal.peek` (and `MaybeSignal.peek`) is intentionally **not** a read — it is an
+untracked read, so a value that only peeks stays static (verified by the
+example's `PeekShadow` case, where a reactive helper rebound to a `peek`-based
+function is dropped from the alias environment and its attribute is left as a
+plain, once-evaluated string).
+
+Only *eager* reads trigger a thunk. A read deferred inside a nested lambda — a
+`() => …` you wrote yourself, a `Computed`, a `MaybeSignal.reactive(Computed.make(…))`,
+or a helper that merely *returns* a thunk — is already reactive and left as-is.
+Because of that, when detection can't see a read, the safe fix is always to wrap
+the value in `() =>` yourself: it will not be double-wrapped.
+
+### Hidden reads
+
+Everything above is *syntactic*: the PPX follows a read only as far as it can
+see the definition. One indirection it cannot follow is a call into **another
+module** — `Store.waitingCount(store)`, or a local closure that ends in one:
+
+```rescript
+@xote.component
+let make = (~store) =>
+  <p class={Store.tone(store)}>       /* reads a signal — invisible to the ppx */
+    {Store.waitingCount(store)}
+  </p>
+```
+
+Nothing here says "signal", so nothing is thunked, and the leaf renders its
+first value forever. That was the library's one genuinely silent failure — and
+it is worse than a frozen leaf when the markup sits inside a `tracked` block or
+a tracked branch: the hidden read is captured by *that* scope instead, quietly
+widening it, so one unrelated update re-renders the whole region. A screen can
+look like it works for exactly that reason while the screen next to it breaks.
+
+The PPX still cannot resolve the call — but it can see that a call it cannot
+resolve is *there*. An expression built only from constants, identifiers, field
+accesses, lambdas, operators and Xote's own constructors provably calls nothing;
+anything else might. Leaves in that second group are emitted wrapped in
+[`View.probe`](../src/View.res), which settles the question at runtime: the first
+time the leaf is evaluated it runs inside a throwaway computed, and what that
+computed subscribed to gives the answer.
+
+- **Nothing subscribed** — the leaf really is static. The computed is disposed
+  and the value returned: `probe` was the identity function, and there is no
+  warning. An unresolvable call is not evidence of a read, so a false positive
+  is impossible.
+- **Something subscribed** — the read was hidden. The value is read back
+  *through* the computed, so an enclosing tracked block subscribes exactly as it
+  did before (behaviour is unchanged), and a one-time warning naming the source
+  location is logged:
+
+```
+[Xote] Queue.res:42:19: this value reads a signal through a call @xote.component
+cannot see (a helper from another module, MaybeSignal.get, a read stored in a
+data structure), so it compiled to a one-shot value that will never update — and
+inside a tracked block it widens that block and re-renders it wholesale. Wrap it
+in a thunk (`{() => ...}`) or inline the Signal.get.
+```
+
+The fix at the call site is the same escape hatch as always — make the read
+deferred, and the PPX leaves your thunk alone:
+
+```rescript
+<p class={() => Store.tone(store)}>
+  {() => Store.waitingCount(store)}
+</p>
+```
+
+Untracked control flow is probed the same way, on its condition/scrutinee and
+`when` guards: a read hidden there does not just freeze a value, it freezes the
+whole branch.
+
+Each site is probed **once** — the answer belongs to the source expression, not
+to a particular render — so a probed leaf costs one throwaway computed the first
+time it is evaluated and a plain call every time after, and the report appears
+once however often the component renders. Probing is skipped altogether in
+production builds: `globalThis.__XOTE_DEV__` decides when set, otherwise
+`process.env.NODE_ENV` (which bundlers inline) does. With neither available the
+probe stays on — a silently stale UI is worse than an allocation.
+
+What is *not* probed, because it can never be a hidden scalar read: event
+handlers and the `attrs` escape-hatch array, values containing JSX, and calls
+into `View`/`Html`/`Signal`/`Computed`/`MaybeSignal` themselves.
+
+## How it works
+
+Same mechanism as `rescript-tracked-ppx` in PR #34: ReScript 12 hands an
+external PPX an OCaml **4.06** parsetree (marshal magic `Caml1999M022`).
+`ast.ml` vendors those exact AST types (so `Marshal` round-trips) and `ppx.ml`
+implements the `ppx <infile> <outfile>` protocol, and rewrites bindings carrying the
+`xote.component` attribute (swapping in `jsx.component` and decomposing the
+returned JSX).
+
+The PPX runs **before** ReScript's JSX transform, so it sees JSX as
+`Apply @[JSX]` nodes with attributes as labelled arguments — the ideal layer to
+redistribute reactivity across attributes and children before they are lowered
+into `XoteJSX` calls. Thunks are emitted as `Function$(fun () -> …)` with a
+`res.arity` attribute (the uncurried-function encoding); the same encoding is
+unwrapped to reach the component body inside `Function$(fun ~props -> …)`.
+
+## License
+
+The vendored AST modules in [`ast.ml`](./ast.ml) (`Location`, `Longident`,
+`Asttypes`, `Parsetree`) are copied verbatim from the OCaml 4.06 compiler,
+© 1996–2019 INRIA, distributed under **LGPL-2.1 with the OCaml linking
+exception**; they keep their original copyright headers. The
+`@xote.component` rewriter below them is the project's own code. The full third-party notice
+and license text is in [`LICENSE.OCaml`](./LICENSE.OCaml), which ships in the
+npm tarball alongside `ast.ml` and `ppx.ml`.
+
+Keeping them in a separate file is deliberate: `ast.ml` stays a byte-for-byte
+copy, so a future AST re-sync is a copy rather than a merge, and `ppx.ml` is
+exactly the code this project maintains.
+
+## Distribution
+
+The npm package ships the PPX **prebuilt** for the common platforms, under
+`ppx/bin/`:
+
+| Platform | Binary |
+|---|---|
+| Linux x64 | `ppx-linux-x64.exe` |
+| Linux arm64 | `ppx-linux-arm64.exe` |
+| macOS x64 (Intel) | `ppx-darwin-x64.exe` |
+| macOS arm64 (Apple Silicon) | `ppx-darwin-arm64.exe` |
+| Windows x64 | `ppx-win32-x64.exe` |
+
+The binaries are compiled in CI by
+[`.github/workflows/ppx-binaries.yml`](../.github/workflows/ppx-binaries.yml)
+and injected into the tarball by the release workflow. On install, Xote's
+`postinstall` script ([`postinstall.js`](./postinstall.js)) copies the binary
+matching `process.platform`-`process.arch` to `ppx/ppx` (`ppx/ppx.exe` on
+Windows), which is the path consumers reference:
+
+```json
+{ "ppx-flags": ["xote/ppx/ppx"] }
+```
+
+That one line in your `rescript.json` is the whole setup — no OCaml toolchain
+required. Two edge cases:
+
+- **Install scripts disabled.** Some package managers skip dependency install
+  scripts (pnpm does by default). Approve them for `xote`
+  (`pnpm approve-builds`) or run `node node_modules/xote/ppx/postinstall.js`
+  once. When nothing could be installed, the script leaves an executable stub
+  at `ppx/ppx` so the failure reports itself at build time with that fix,
+  instead of ReScript's `try_package_path: upward traversal did not find`,
+  which names neither xote nor the remedy. (Not on Windows, where the path is
+  `ppx.exe` and a shell stub would not execute.)
+- **Unsupported platform.** If no prebuilt binary matches — or the matching
+  one does not execute on the host (the install script smoke-runs it; the
+  Linux prebuilts are glibc-linked, so musl systems like Alpine fall through
+  here) — the script falls back to compiling `ppx.ml` from source when
+  `ocamlopt` is on the `PATH`, and otherwise prints instructions without
+  failing the install.
+
+A `ppx-flags` entry is deliberately **not** in Xote's own published
+`rescript.json`: a ReScript consumer recompiles a dependency's sources during
+its own build and applies that dependency's `ppx-flags`, and Xote's `src/`
+carries no `@xote.component` annotations, so listing the PPX there would make
+every build depend on the binary for no benefit. The annotation applies to
+*your* components, which is why the flag lives in *your* `rescript.json` —
+exactly like the `jsx` configuration you already mirror.
+
+## Build from source
+
+```sh
+sh build.sh   # produces ./ppx (needs ocamlopt; any recent OCaml, tested 4.14)
+```
+
+`build.sh` also accepts an output path relative to `ppx/`
+(`sh build.sh bin/ppx-linux-x64.exe`), which is how the CI matrix produces
+the prebuilt binaries.
+
+## In this repo
+
+The PPX is developed and exercised in-repo without touching the published
+library config:
+
+- **`npm run ppx:build`** / **`npm run ppx:test`** (repo root) build the binary
+  and run both example suites: `verify.mjs` (jsdom, behaviour) and `golden.mjs`
+  (assertions on the emitted JavaScript).
+- The two suites cover different failure modes, and the second exists because
+  the first cannot see the bug that has now shipped three times. `verify.mjs`
+  proves leaves are fine-grained by mutating signals and checking elements keep
+  their identity — but JSX the traversal never *visits* still compiles and still
+  renders correct initial output, so a runtime test passes while the leaf is
+  frozen (and gets no `View.probe` either, because probes are only emitted at
+  visited sites). `golden.mjs` asserts on the emitted code, where that is
+  visible. Every positive assertion there has a matching negative, since
+  "reaches the leaf" and "rewrites indiscriminately" both satisfy a positive.
+- **`ppx:test` runs `rescript clean` first, and needs to.** ReScript does not
+  treat the ppx binary as a build input, so editing `ppx.ml` and re-running the
+  suites without a clean silently re-tests the *previously* emitted JavaScript —
+  green, and meaningless. Do not drop the clean to speed the loop up.
+- **CI** (`.github/workflows/ci.yml`) installs `ocaml-nox`, builds the PPX, and
+  runs `ppx:test` on every push/PR, so it can't silently rot.
+- The **docs site** (`docs-website/`) is a real consumer: its own
+  `rescript.json` carries the `ppx-flags`, its `res:build` builds the PPX first,
+  and the Counter demo is authored with `@xote.component`. The published Xote
+  library (`src/`, root `rescript.json`) stays PPX-free.
+
+## Run the example
+
+The example is a standalone mini-project. The whole flow is wrapped in a single
+script — from the repo root:
+
+```sh
+npm run ppx:test        # setup + build ppx + compile Demo.res + jsdom verify
+```
+
+Or step by step from `example/`:
+
+```sh
+sh setup.sh             # link toolchain + Xote from the repo root (idempotent)
+sh ../build.sh          # build the ppx
+npx rescript clean      # required after a ppx change — see "In this repo" above
+npm run build           # compile Demo.res / Golden.res through the ppx
+npm run verify          # jsdom runtime check (every case above, asserted on real DOM)
+npm run golden          # assertions on the emitted JavaScript (traversal reach)
+```
+
+## Not settled yet
+
+These are decisions rather than defects, and each is one real codebase's worth
+of experience away from possibly being made differently. They are listed
+separately from the limitations below because they may change in a way that
+requires edits to your components — worth knowing before the annotation is
+load-bearing for you.
+
+- **The opt-in is per file, but the annotation is per binding.** A file with at
+  least one `@xote.component` has *all* its JSX decomposed, including plain
+  helper functions (which is the point — see
+  [Where the annotation reaches](#where-the-annotation-reaches)). The
+  consequence is action at a distance: a byte-identical helper is reactive in
+  one file and static in another, moving it between files silently changes its
+  behaviour, and deleting the last annotation in a file silently de-reactivates
+  every helper in it — or breaks the build, depending on whether those helpers
+  happen to use bare children. An explicit file-level marker
+  (`@@xote.fineGrained`) would put the opt-in where its effect is; that is the
+  most likely change here.
+- **`View.child` accepts anything.** Its signature is `'a => node`, so under the
+  annotation a value that is neither a node nor a scalar type-checks in child
+  position and fails at runtime instead:
+
+  ```rescript
+  {user}                 /* a record  -> renders "[object Object]" (+ dev warning) */
+  {Signal.get(status)}   /* a variant -> renders "[object Object]" (+ dev warning) */
+  ```
+
+  Both are compile errors without the annotation. This is the same trade the
+  untyped JSX element props already make, extended from attributes (where a
+  wrong value renders a wrong string) to children (where it renders
+  `[object Object]`). It buys the zero-ceremony bare child, which is a large
+  part of the annotation's value, so the trade is deliberate — but a narrower
+  accepted type is the other place this may move.
+- **User-component props are never thunked.** A deliberate one-shot read today
+  (see [User-component props](#user-component-props)). Defensible, but it is the
+  rule people are most likely to trip over.
+
+## Known limitations
+
+- **Signal detection is syntactic** (though alias- and helper-aware — see the
+  table above). It follows `let`/`module`/`open` aliases, local reactive helpers
+  and same-file module helpers, but not indirection it cannot see the definition
+  of: a signal read behind an **imported / cross-module** helper, or reached
+  through a data structure, is not detected, and such a value still compiles to a
+  **static, once-evaluated attribute/text**. It is no longer *silent*:
+  [`View.probe`](#hidden-reads) reports it at runtime, once, with its source
+  location. The escape hatch is unchanged — wrap it in `() =>` yourself and it
+  becomes reactive (the eager check leaves your thunk alone, so it is never
+  double-wrapped). An over-eager match only produces a harmless extra
+  `computedAttr`.
+- **The probe reports, it does not repair.** It cannot: by the time the value
+  exists, the leaf has already been emitted as a static one. It also only fires
+  on the *first* evaluation of a site, and only for a *scalar* result — the shape
+  that silently renders a stale number or class name. A hidden read behind a
+  branch you never render in development is not reported, and neither is one
+  that a leaf only performs on a later evaluation.
+- **Hoisting a read into a `let` makes it a one-shot read.** Reactivity follows
+  the *expression in JSX position*: `<div> {Signal.get(count)} </div>` is a
+  reactive leaf, but
+
+  ```rescript
+  let label = Signal.get(count)->Int.toString
+  <div> {label} </div>
+  ```
+
+  reads `count` once, at component setup, and renders a static value — the
+  binding is an ordinary eager evaluation, exactly as it would be in any
+  signals library without a compiler. When extracting a reactive expression
+  into a binding, bind a *thunk* instead: `let label = () =>
+  Signal.get(count)->Int.toString` and use `{label()}` (a tracked reactive
+  helper) or `{label}` (coerced by `View.child`).
+- **Value-component detection is hard-coded** to the qualified
+  `View.Text/Int/Float/Bool`. An aliased or opened `View` (`module V = View` →
+  `<V.Text>`, `open View` → bare `<Text>`) is not recognized as a value
+  component. This is **not silent** — the value child lands in node position and
+  is a **compile error** (`string` where `View.node` is expected), so it fails
+  loudly at build time. Simplest fix: drop the wrapper and use a **bare `{…}`
+  child** (`View.child` coerces it), or use the qualified `View.Text` form.
+- **Coupled to ReScript's ppx ABI.** The vendored OCaml 4.06 parsetree, the
+  `Caml1999M022` marshal magic, and the uncurried `Function$` construct name are
+  compiler internals. A ReScript release that bumps the ppx AST version makes
+  the ppx **fail the build immediately** with an error naming the mismatched
+  magic (interface ASTs still pass through untouched); a release that renamed
+  `Function$` could fail *quietly*. Validated against ReScript 12; CI building
+  the docs site through the PPX is the early warning on upgrade.
+- **A branch swap still rebuilds that branch's subtree.** Control flow tracks
+  only the condition (leaves inside branches stay fine-grained, see above), but
+  when the condition *does* change, the selected branch is built fresh — there
+  is no keyed diffing between the old and new branch. This matches Xote's own
+  `View.Show`/`View.tracked`; use `View.For` with `by` for lists.
+- **Separate from the library build.** The PPX is never needed to build or use
+  Xote itself (`npm run build`/`npm run test` don't involve it). It is compiled
+  per platform in CI, shipped prebuilt in the npm tarball, and exercised
+  end-to-end by `npm run ppx:test` on every push.

--- a/ppx/README.md
+++ b/ppx/README.md
@@ -1,0 +1,272 @@
+# xote-tracked-ppx
+
+A native ReScript PPX that expands an `@xote.component` annotation into a
+props-deriving component whose returned JSX is decomposed into **fine-grained
+reactive leaves** — the compile-time counterpart to the runtime
+[`View.tracked`](../src/View.res) helper.
+
+> **Status:** experimental, opt-in. The PPX is exercised in CI and used by the
+> [docs site](../docs-website) itself (the Counter demo), but it is **not part
+> of the published npm package** — consumers who want it build it themselves
+> (see [Opt-in for consumers](#opt-in-for-consumers)). It demonstrates that the
+> [`rescript-signals` #34](https://github.com/brnrdog/rescript-signals/pull/34)
+> auto-tracking idea can target Xote's view layer *and* compile away the
+> wholesale-replacement tradeoff of `View.tracked`. See
+> [`docs/proposals/tracked-blocks.md`](../docs/proposals/tracked-blocks.md) for
+> the full design context (this is "Phase 2, fine-grained variant").
+
+## What problem it solves
+
+`View.tracked(() => <block>)` is convenient — every signal read inside the
+block subscribes it automatically — but it lowers to a `SignalFragment` over a
+`Computed`, so **any** dependency change re-evaluates the whole block and
+replaces its children wholesale (no diffing; local DOM state like input focus
+is lost). Good for small blocks, a footgun on large ones.
+
+This PPX takes the same ergonomic surface — write plain JSX, read signals
+inline — but instead of one coarse computed it **decomposes the block at
+compile time**, pushing reactivity down to exactly the leaves that read
+signals. The element structure is emitted once and never rebuilt.
+
+## Example
+
+Input — one annotation replaces `@jsx.component` and makes the return
+fine-grained:
+
+```rescript
+@xote.component
+let make = (~label: string) => {
+  let count = Signal.make(0)
+  <div class={Signal.get(count) > 0 ? "on" : "off"} id="card">
+    <span class="static-label"> {View.text(label)} </span>
+    <View.Int> {Signal.get(count)} </View.Int>
+  </div>
+}
+```
+
+Compiles to (abbreviated):
+
+```js
+function make(props) {
+  let label = props.label;                        // props derived (@jsx.component)
+  let count = Signal.make(0);
+  return Elements.jsxs("div", {
+    id: "card",                                   // static — untouched
+    class: () => Signal.get(count) > 0 ? "on" : "off", // → View.computedAttr (reactive leaf)
+    children: [
+      Elements.jsx("span", {                      // static subtree — untouched
+        class: "static-label",
+        children: View.text(label),
+      }),
+      jsx(View.Int.make, {
+        children: () => Signal.get(count),        // → reactive text node (leaf)
+      }),
+    ],
+  });
+}
+```
+
+Props derive from the labeled args (`label` stays static); no `View.tracked`,
+no `SignalFragment`, no wholesale rebuild. The `<div>` and `<span>` keep their
+DOM identity across updates; only the `class` attribute and the number re-run.
+(`example/verify.mjs` asserts exactly this by tagging the elements and checking
+the tags survive a signal change.)
+
+`@xote.component` is the single annotation. The PPX rewrites it to
+`@jsx.component` (so the JSX transform still derives the props record) and
+fine-grains the returned JSX — one attribute, no `@jsx.component` +
+tracking-annotation stacking. Because it emits `@jsx.component`, it inherits its
+rules: **one component per module** (each in its own file, or a submodule).
+
+## Decomposition rules
+
+Applied recursively to the component's returned JSX:
+
+| Position | Reads a signal? | Result |
+|---|---|---|
+| Attribute value (`class={…}`) | yes | thunked → `View.computedAttr` (reactive attribute leaf) |
+| Attribute value | no | left as-is (static attribute) |
+| `<View.Text/Int/Float/Bool>` child | yes | thunked → reactive text node (leaf) |
+| `<View.Text/…>` child | no | left as-is (static text) |
+| Element / nested JSX | — | recurse into attributes and children |
+| Bare child in node position (an `if`/`switch` selecting different nodes) | yes | branches decomposed fine-grained, then wrapped in `View.tracked` — see below |
+
+The result: reactivity lives at the leaves; `View.tracked` is emitted
+**surgically**, only around a child region whose node *structure* actually
+varies, and never around the stable elements that enclose it.
+
+### Control flow tracks only the condition
+
+When a branch body is decomposed *before* the `View.tracked` wrapper is applied,
+its leaves become thunks. So when the tracked scope runs the chosen branch to
+build its nodes, those thunks are not invoked — the scope ends up subscribed to
+only the **condition/scrutinee**, not to signals read by leaves inside the
+branches. Given:
+
+```rescript
+@xote.component
+let make = () =>
+  <div>
+    {switch Signal.get(status) {
+    | Loading => <span> {View.text("Loading...")} </span>
+    | Ready(msg) => <strong class={Signal.get(theme)}> {View.text(msg)} </strong>
+    }}
+  </div>
+```
+
+the `class={Signal.get(theme)}` becomes a `computedAttr` **inside** the
+`View.tracked`. Changing `theme` updates just that class and leaves the
+`<strong>` in place; only a change to `status` (the scrutinee) re-runs the
+switch and rebuilds the branch. `example/verify.mjs` asserts both:
+the `<strong>` keeps its identity across a `theme` change, and a `status`
+change still swaps the branch.
+
+## What counts as "reads a signal"
+
+Detection is more than a literal `Signal.get`. An alias environment threaded
+through the traversal (scoped: an alias is visible only *after* its binding, and
+shadowing it with a non-alias removes it) recognises all of these:
+
+| Form | Example | Detected via |
+|---|---|---|
+| Direct | `Signal.get(sig)` / `X.Signal.get(sig)` | literal match |
+| Pipe | `sig->Signal.get` | desugars to `Signal.get(sig)` before the PPX |
+| Value alias | `let g = Signal.get` … `g(sig)` | binding tracked in scope |
+| Module alias | `module S = Signal` … `S.get(sig)` | binding tracked in scope |
+| Open | `open Signal` … `get(sig)` | bare `get` under an open |
+| Local reactive helper | `let cls = () => Signal.get(x) ? …` … `cls()` | function binding whose body eagerly reads a signal; its *call* counts |
+
+`Signal.peek` is intentionally **not** a read — it is an untracked read, so a
+value that only peeks stays static (verified by the shadowing case, where an
+alias rebound to a `peek`-based function is dropped and its attribute is left
+as a plain string).
+
+Only *eager* reads trigger a thunk. A read deferred inside a nested lambda — a
+`() => …` you wrote yourself, a `Computed`, a `Prop.reactive(Computed.make(…))`,
+or a helper that merely *returns* a thunk — is already reactive and left as-is.
+Because of that, when detection can't see a read (below), the safe fix is always
+to wrap the value in `() =>` yourself: it will not be double-wrapped.
+
+## How it works
+
+Same mechanism as `rescript-tracked-ppx` in PR #34: ReScript 12 hands an
+external PPX an OCaml **4.06** parsetree (marshal magic `Caml1999M022`).
+`ppx.ml` vendors those exact AST types (so `Marshal` round-trips), implements
+the `ppx <infile> <outfile>` protocol, and rewrites bindings carrying the
+`xote.component` attribute (swapping in `jsx.component` and decomposing the
+returned JSX).
+
+The PPX runs **before** ReScript's JSX transform, so it sees JSX as
+`Apply @[JSX]` nodes with attributes as labelled arguments — the ideal layer to
+redistribute reactivity across attributes and children before they are lowered
+into `XoteJSX` calls. Thunks are emitted as `Function$(fun () -> …)` with a
+`res.arity` attribute (the uncurried-function encoding); the same encoding is
+unwrapped to reach the component body inside `Function$(fun ~props -> …)`.
+
+## License
+
+The vendored AST modules at the top of `ppx.ml` (`Location`, `Longident`,
+`Asttypes`, `Parsetree`) are copied verbatim from the OCaml 4.06 compiler,
+© 1996–2019 INRIA, distributed under **LGPL-2.1 with the OCaml linking
+exception**; they keep their original copyright headers. The
+`@xote.component` rewriter below them is the project's own code. The full third-party notice
+and license text is in [`LICENSE.OCaml`](./LICENSE.OCaml), which ships in the
+npm tarball alongside `ppx.ml`.
+
+## Build
+
+```sh
+sh build.sh   # produces ./ppx (needs ocamlopt; any recent OCaml, tested 4.14)
+```
+
+Wire it into a project's `rescript.json`:
+
+```json
+{ "ppx-flags": ["xote-tracked-ppx/ppx"] }
+```
+
+## Opt-in for consumers
+
+The compiled binary is platform-specific and is **not** shipped in the npm
+package, and — deliberately — neither is a `ppx-flags` entry in Xote's own
+published `rescript.json`. That last point matters: a ReScript consumer
+recompiles a dependency's sources during its own build and applies that
+dependency's `ppx-flags`, so a PPX listed in Xote's published config would
+force `ocamlopt` on **every** Xote user. Instead the PPX is strictly opt-in.
+
+The `ppx.ml` source *is* published, so a consumer who wants `@xote.component`
+can build it from the installed package and reference it from **their own**
+`rescript.json`:
+
+```sh
+npm install xote
+sh node_modules/xote/ppx/build.sh      # needs ocamlopt
+```
+
+```json
+{ "ppx-flags": ["xote/ppx/ppx"] }
+```
+
+Consumers who don't do this are entirely unaffected.
+
+## In this repo
+
+The PPX is developed and exercised in-repo without touching the published
+library config:
+
+- **`npm run ppx:build`** / **`npm run ppx:test`** (repo root) build the binary
+  and run the end-to-end example verification.
+- **CI** (`.github/workflows/ci.yml`) installs `ocaml-nox`, builds the PPX, and
+  runs `ppx:test` on every push/PR, so it can't silently rot.
+- The **docs site** (`docs-website/`) is a real consumer: its own
+  `rescript.json` carries the `ppx-flags`, its `res:build` builds the PPX first,
+  and the Counter demo is authored with `@xote.component`. The published Xote
+  library (`src/`, root `rescript.json`) stays PPX-free.
+
+## Run the example
+
+The example is a standalone mini-project. The whole flow is wrapped in a single
+script — from the repo root:
+
+```sh
+npm run ppx:test        # setup + build ppx + compile Demo.res + jsdom verify
+```
+
+Or step by step from `example/`:
+
+```sh
+sh setup.sh             # link toolchain + Xote from the repo root (idempotent)
+sh ../build.sh          # build the ppx
+npm run build           # compile Demo.res through the ppx
+npm run verify          # jsdom runtime check (41 assertions)
+```
+
+## Known limitations (it's a prototype)
+
+- **Signal detection is syntactic** (though alias- and helper-aware — see the
+  table above). It follows `let`/`module`/`open` aliases and *local* reactive
+  helpers, but not indirection it cannot see the definition of: a signal read
+  behind an **imported / cross-module** helper, or reached through a data
+  structure, is not detected. Such a value compiles to a **static, once-evaluated
+  attribute/text with no error** — the one genuinely silent failure. The escape
+  hatch is reliable: wrap it in `() =>` yourself and it becomes reactive (the
+  eager check leaves your thunk alone, so it is never double-wrapped). An
+  over-eager match only produces a harmless extra `computedAttr`.
+- **Value-component set is hard-coded** to `View.Text/Int/Float/Bool`. An
+  aliased or opened `View` (`module V = View` → `<V.Text>`, `open View` → bare
+  `<Text>`) is treated as an ordinary element, so a bare value child is put in
+  node position — which is a **compile error** (`string` where `View.node` is
+  expected), not a silent bug. Use the qualified `View.Text` form.
+- **Coupled to ReScript's ppx ABI.** The vendored OCaml 4.06 parsetree, the
+  `Caml1999M022` marshal magic, and the uncurried `Function$` construct name are
+  compiler internals. A ReScript release that bumps the ppx AST version fails
+  loudly (magic mismatch); one that renamed `Function$` could fail *quietly*.
+  Validated against ReScript 12; CI building the docs site through the PPX is the
+  canary on upgrade.
+- **A branch swap still rebuilds that branch's subtree.** Control flow tracks
+  only the condition (leaves inside branches stay fine-grained, see above), but
+  when the condition *does* change, the selected branch is built fresh — there
+  is no keyed diffing between the old and new branch. This matches Xote's own
+  `View.Show`/`View.tracked`; use `View.For` with `by` for lists.
+- **Not wired into the main build.** This lives outside `src/` and is not part
+  of `npm run build`/`test`; it is a standalone proof of concept.

--- a/ppx/README.md
+++ b/ppx/README.md
@@ -91,6 +91,7 @@ Applied recursively to the component's returned JSX:
 | Attribute value | no | left as-is (static attribute) |
 | `<View.Text/Int/Float/Bool>` child | yes | thunked → reactive text node (leaf) |
 | `<View.Text/…>` child | no | left as-is (static text) |
+| Any value leaf | can't tell — the expression contains a call the PPX cannot resolve | wrapped in `View.probe`, which decides at runtime and reports a read it finds — see [Hidden reads](#hidden-reads) |
 | Element / nested JSX | — | recurse into attributes and children |
 | Fragment (`<>…</>`) | — | recurse into each child independently (so nested reactive regions stay separate — not collapsed into one thunk) |
 | User-component prop (`<Card label={…}>`) | — | left untouched — see [User-component props](#user-component-props) |
@@ -230,23 +231,96 @@ shadowing it with a non-alias removes it) recognises all of these:
 | Form | Example | Detected via |
 |---|---|---|
 | Direct | `Signal.get(sig)` / `X.Signal.get(sig)` | literal match |
+| Through the wrapper | `MaybeSignal.get(v)`, `Prop.get(v)` | same — reading a `MaybeSignal` subscribes exactly like `Signal.get` |
 | Pipe | `sig->Signal.get` | desugars to `Signal.get(sig)` before the PPX |
 | Value alias | `let g = Signal.get` … `g(sig)` | binding tracked in scope |
 | Module alias | `module S = Signal` … `S.get(sig)` | binding tracked in scope |
 | Open | `open Signal` … `get(sig)` | bare `get` under an open |
 | Local reactive helper | `let cls = () => Signal.get(x) ? …` … `cls()` | function binding whose body eagerly reads a signal; its *call* counts |
+| Same-file module helper | `module Store = { let count = s => Signal.get(s) }` … `Store.count(s)` | the module body is walked, and its reactive names qualified |
 
-`Signal.peek` is intentionally **not** a read — it is an untracked read, so a
-value that only peeks stays static (verified by the example's `PeekShadow`
-case, where a reactive helper rebound to a `peek`-based function is dropped
-from the alias environment and its attribute is left as a plain, once-evaluated
-string).
+`Signal.peek` (and `MaybeSignal.peek`) is intentionally **not** a read — it is an
+untracked read, so a value that only peeks stays static (verified by the
+example's `PeekShadow` case, where a reactive helper rebound to a `peek`-based
+function is dropped from the alias environment and its attribute is left as a
+plain, once-evaluated string).
 
 Only *eager* reads trigger a thunk. A read deferred inside a nested lambda — a
 `() => …` you wrote yourself, a `Computed`, a `MaybeSignal.reactive(Computed.make(…))`,
 or a helper that merely *returns* a thunk — is already reactive and left as-is.
-Because of that, when detection can't see a read (below), the safe fix is always
-to wrap the value in `() =>` yourself: it will not be double-wrapped.
+Because of that, when detection can't see a read, the safe fix is always to wrap
+the value in `() =>` yourself: it will not be double-wrapped.
+
+### Hidden reads
+
+Everything above is *syntactic*: the PPX follows a read only as far as it can
+see the definition. One indirection it cannot follow is a call into **another
+module** — `Store.waitingCount(store)`, or a local closure that ends in one:
+
+```rescript
+@xote.component
+let make = (~store) =>
+  <p class={Store.tone(store)}>       /* reads a signal — invisible to the ppx */
+    {Store.waitingCount(store)}
+  </p>
+```
+
+Nothing here says "signal", so nothing is thunked, and the leaf renders its
+first value forever. That was the library's one genuinely silent failure — and
+it is worse than a frozen leaf when the markup sits inside a `tracked` block or
+a tracked branch: the hidden read is captured by *that* scope instead, quietly
+widening it, so one unrelated update re-renders the whole region. A screen can
+look like it works for exactly that reason while the screen next to it breaks.
+
+The PPX still cannot resolve the call — but it can see that a call it cannot
+resolve is *there*. An expression built only from constants, identifiers, field
+accesses, lambdas, operators and Xote's own constructors provably calls nothing;
+anything else might. Leaves in that second group are emitted wrapped in
+[`View.probe`](../src/View.res), which settles the question at runtime: the first
+time the leaf is evaluated it runs inside a throwaway computed, and what that
+computed subscribed to gives the answer.
+
+- **Nothing subscribed** — the leaf really is static. The computed is disposed
+  and the value returned: `probe` was the identity function, and there is no
+  warning. An unresolvable call is not evidence of a read, so a false positive
+  is impossible.
+- **Something subscribed** — the read was hidden. The value is read back
+  *through* the computed, so an enclosing tracked block subscribes exactly as it
+  did before (behaviour is unchanged), and a one-time warning naming the source
+  location is logged:
+
+```
+[Xote] Queue.res:42:19: this value reads a signal through a call @xote.component
+cannot see (a helper from another module, MaybeSignal.get, a read stored in a
+data structure), so it compiled to a one-shot value that will never update — and
+inside a tracked block it widens that block and re-renders it wholesale. Wrap it
+in a thunk (`{() => ...}`) or inline the Signal.get.
+```
+
+The fix at the call site is the same escape hatch as always — make the read
+deferred, and the PPX leaves your thunk alone:
+
+```rescript
+<p class={() => Store.tone(store)}>
+  {() => Store.waitingCount(store)}
+</p>
+```
+
+Untracked control flow is probed the same way, on its condition/scrutinee and
+`when` guards: a read hidden there does not just freeze a value, it freezes the
+whole branch.
+
+Each site is probed **once** — the answer belongs to the source expression, not
+to a particular render — so a probed leaf costs one throwaway computed the first
+time it is evaluated and a plain call every time after, and the report appears
+once however often the component renders. Probing is skipped altogether in
+production builds: `globalThis.__XOTE_DEV__` decides when set, otherwise
+`process.env.NODE_ENV` (which bundlers inline) does. With neither available the
+probe stays on — a silently stale UI is worse than an allocation.
+
+What is *not* probed, because it can never be a hidden scalar read: event
+handlers and the `attrs` escape-hatch array, values containing JSX, and calls
+into `View`/`Html`/`Signal`/`Computed`/`MaybeSignal` themselves.
 
 ## How it works
 
@@ -365,14 +439,22 @@ npm run verify          # jsdom runtime check (every case above, asserted on rea
 ## Known limitations
 
 - **Signal detection is syntactic** (though alias- and helper-aware — see the
-  table above). It follows `let`/`module`/`open` aliases and *local* reactive
-  helpers, but not indirection it cannot see the definition of: a signal read
-  behind an **imported / cross-module** helper, or reached through a data
-  structure, is not detected. Such a value compiles to a **static, once-evaluated
-  attribute/text with no error** — the one genuinely silent failure. The escape
-  hatch is reliable: wrap it in `() =>` yourself and it becomes reactive (the
-  eager check leaves your thunk alone, so it is never double-wrapped). An
-  over-eager match only produces a harmless extra `computedAttr`.
+  table above). It follows `let`/`module`/`open` aliases, local reactive helpers
+  and same-file module helpers, but not indirection it cannot see the definition
+  of: a signal read behind an **imported / cross-module** helper, or reached
+  through a data structure, is not detected, and such a value still compiles to a
+  **static, once-evaluated attribute/text**. It is no longer *silent*:
+  [`View.probe`](#hidden-reads) reports it at runtime, once, with its source
+  location. The escape hatch is unchanged — wrap it in `() =>` yourself and it
+  becomes reactive (the eager check leaves your thunk alone, so it is never
+  double-wrapped). An over-eager match only produces a harmless extra
+  `computedAttr`.
+- **The probe reports, it does not repair.** It cannot: by the time the value
+  exists, the leaf has already been emitted as a static one. It also only fires
+  on the *first* evaluation of a site, and only for a *scalar* result — the shape
+  that silently renders a stale number or class name. A hidden read behind a
+  branch you never render in development is not reported, and neither is one
+  that a leaf only performs on a later evaluation.
 - **Hoisting a read into a `let` makes it a one-shot read.** Reactivity follows
   the *expression in JSX position*: `<div> {Signal.get(count)} </div>` is a
   reactive leaf, but

--- a/ppx/ast.ml
+++ b/ppx/ast.ml
@@ -1,0 +1,946 @@
+(* Vendored OCaml 4.06 AST (ReScript 12's ppx parsetree is Caml1999M022 = 4.06).
+   Types are copied verbatim from ocaml/ocaml@4.06 so Marshal round-trips exactly. *)
+module Location = struct
+  type t = { loc_start : Lexing.position; loc_end : Lexing.position; loc_ghost : bool }
+  type 'a loc = { txt : 'a; loc : t }
+end
+module Longident = struct
+  type t = Lident of string | Ldot of t * string | Lapply of t * t
+end
+module Asttypes = struct
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Auxiliary AST types used by parsetree and typedtree. *)
+
+type constant =
+    Const_int of int
+  | Const_char of char
+  | Const_string of string * string option
+  | Const_float of string
+  | Const_int32 of int32
+  | Const_int64 of int64
+  | Const_nativeint of nativeint
+
+type rec_flag = Nonrecursive | Recursive
+
+type direction_flag = Upto | Downto
+
+(* Order matters, used in polymorphic comparison *)
+type private_flag = Private | Public
+
+type mutable_flag = Immutable | Mutable
+
+type virtual_flag = Virtual | Concrete
+
+type override_flag = Override | Fresh
+
+type closed_flag = Closed | Open
+
+type label = string
+
+type arg_label =
+    Nolabel
+  | Labelled of string (*  label:T -> ... *)
+  | Optional of string (* ?label:T -> ... *)
+
+type 'a loc = 'a Location.loc = {
+  txt : 'a;
+  loc : Location.t;
+}
+
+
+type variance =
+  | Covariant
+  | Contravariant
+  | Invariant
+end
+module Parsetree = struct
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Abstract syntax tree produced by parsing *)
+
+open Asttypes
+
+type constant =
+    Pconst_integer of string * char option
+  (* 3 3l 3L 3n
+
+     Suffixes [g-z][G-Z] are accepted by the parser.
+     Suffixes except 'l', 'L' and 'n' are rejected by the typechecker
+  *)
+  | Pconst_char of char
+  (* 'c' *)
+  | Pconst_string of string * string option
+  (* "constant"
+     {delim|other constant|delim}
+  *)
+  | Pconst_float of string * char option
+  (* 3.4 2e5 1.4e-4
+
+     Suffixes [g-z][G-Z] are accepted by the parser.
+     Suffixes are rejected by the typechecker.
+  *)
+
+(** {1 Extension points} *)
+
+type attribute = string loc * payload
+       (* [@id ARG]
+          [@@id ARG]
+
+          Metadata containers passed around within the AST.
+          The compiler ignores unknown attributes.
+       *)
+
+and extension = string loc * payload
+      (* [%id ARG]
+         [%%id ARG]
+
+         Sub-language placeholder -- rejected by the typechecker.
+      *)
+
+and attributes = attribute list
+
+and payload =
+  | PStr of structure
+  | PSig of signature (* : SIG *)
+  | PTyp of core_type  (* : T *)
+  | PPat of pattern * expression option  (* ? P  or  ? P when E *)
+
+(** {1 Core language} *)
+
+(* Type expressions *)
+
+and core_type =
+    {
+     ptyp_desc: core_type_desc;
+     ptyp_loc: Location.t;
+     ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and core_type_desc =
+  | Ptyp_any
+        (*  _ *)
+  | Ptyp_var of string
+        (* 'a *)
+  | Ptyp_arrow of arg_label * core_type * core_type
+        (* T1 -> T2       Simple
+           ~l:T1 -> T2    Labelled
+           ?l:T1 -> T2    Optional
+         *)
+  | Ptyp_tuple of core_type list
+        (* T1 * ... * Tn
+
+           Invariant: n >= 2
+        *)
+  | Ptyp_constr of Longident.t loc * core_type list
+        (* tconstr
+           T tconstr
+           (T1, ..., Tn) tconstr
+         *)
+  | Ptyp_object of object_field list * closed_flag
+        (* < l1:T1; ...; ln:Tn >     (flag = Closed)
+           < l1:T1; ...; ln:Tn; .. > (flag = Open)
+         *)
+  | Ptyp_class of Longident.t loc * core_type list
+        (* #tconstr
+           T #tconstr
+           (T1, ..., Tn) #tconstr
+         *)
+  | Ptyp_alias of core_type * string
+        (* T as 'a *)
+  | Ptyp_variant of row_field list * closed_flag * label list option
+        (* [ `A|`B ]         (flag = Closed; labels = None)
+           [> `A|`B ]        (flag = Open;   labels = None)
+           [< `A|`B ]        (flag = Closed; labels = Some [])
+           [< `A|`B > `X `Y ](flag = Closed; labels = Some ["X";"Y"])
+         *)
+  | Ptyp_poly of string loc list * core_type
+        (* 'a1 ... 'an. T
+
+           Can only appear in the following context:
+
+           - As the core_type of a Ppat_constraint node corresponding
+             to a constraint on a let-binding: let x : 'a1 ... 'an. T
+             = e ...
+
+           - Under Cfk_virtual for methods (not values).
+
+           - As the core_type of a Pctf_method node.
+
+           - As the core_type of a Pexp_poly node.
+
+           - As the pld_type field of a label_declaration.
+
+           - As a core_type of a Ptyp_object node.
+         *)
+
+  | Ptyp_package of package_type
+        (* (module S) *)
+  | Ptyp_extension of extension
+        (* [%id] *)
+
+and package_type = Longident.t loc * (Longident.t loc * core_type) list
+      (*
+        (module S)
+        (module S with type t1 = T1 and ... and tn = Tn)
+       *)
+
+and row_field =
+  | Rtag of label loc * attributes * bool * core_type list
+        (* [`A]                   ( true,  [] )
+           [`A of T]              ( false, [T] )
+           [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
+           [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
+
+          - The 2nd field is true if the tag contains a
+            constant (empty) constructor.
+          - '&' occurs when several types are used for the same constructor
+            (see 4.2 in the manual)
+
+          - TODO: switch to a record representation, and keep location
+        *)
+  | Rinherit of core_type
+        (* [ T ] *)
+
+and object_field =
+  | Otag of label loc * attributes * core_type
+  | Oinherit of core_type
+
+(* Patterns *)
+
+and pattern =
+    {
+     ppat_desc: pattern_desc;
+     ppat_loc: Location.t;
+     ppat_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and pattern_desc =
+  | Ppat_any
+        (* _ *)
+  | Ppat_var of string loc
+        (* x *)
+  | Ppat_alias of pattern * string loc
+        (* P as 'a *)
+  | Ppat_constant of constant
+        (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+  | Ppat_interval of constant * constant
+        (* 'a'..'z'
+
+           Other forms of interval are recognized by the parser
+           but rejected by the type-checker. *)
+  | Ppat_tuple of pattern list
+        (* (P1, ..., Pn)
+
+           Invariant: n >= 2
+        *)
+  | Ppat_construct of Longident.t loc * pattern option
+        (* C                None
+           C P              Some P
+           C (P1, ..., Pn)  Some (Ppat_tuple [P1; ...; Pn])
+         *)
+  | Ppat_variant of label * pattern option
+        (* `A             (None)
+           `A P           (Some P)
+         *)
+  | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+        (* { l1=P1; ...; ln=Pn }     (flag = Closed)
+           { l1=P1; ...; ln=Pn; _}   (flag = Open)
+
+           Invariant: n > 0
+         *)
+  | Ppat_array of pattern list
+        (* [| P1; ...; Pn |] *)
+  | Ppat_or of pattern * pattern
+        (* P1 | P2 *)
+  | Ppat_constraint of pattern * core_type
+        (* (P : T) *)
+  | Ppat_type of Longident.t loc
+        (* #tconst *)
+  | Ppat_lazy of pattern
+        (* lazy P *)
+  | Ppat_unpack of string loc
+        (* (module P)
+           Note: (module P : S) is represented as
+           Ppat_constraint(Ppat_unpack, Ptyp_package)
+         *)
+  | Ppat_exception of pattern
+        (* exception P *)
+  | Ppat_extension of extension
+        (* [%id] *)
+  | Ppat_open of Longident.t loc * pattern
+        (* M.(P) *)
+
+(* Value expressions *)
+
+and expression =
+    {
+     pexp_desc: expression_desc;
+     pexp_loc: Location.t;
+     pexp_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and expression_desc =
+  | Pexp_ident of Longident.t loc
+        (* x
+           M.x
+         *)
+  | Pexp_constant of constant
+        (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+  | Pexp_let of rec_flag * value_binding list * expression
+        (* let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
+         *)
+  | Pexp_function of case list
+        (* function P1 -> E1 | ... | Pn -> En *)
+  | Pexp_fun of arg_label * expression option * pattern * expression
+        (* fun P -> E1                          (Simple, None)
+           fun ~l:P -> E1                       (Labelled l, None)
+           fun ?l:P -> E1                       (Optional l, None)
+           fun ?l:(P = E0) -> E1                (Optional l, Some E0)
+
+           Notes:
+           - If E0 is provided, only Optional is allowed.
+           - "fun P1 P2 .. Pn -> E1" is represented as nested Pexp_fun.
+           - "let f P = E" is represented using Pexp_fun.
+         *)
+  | Pexp_apply of expression * (arg_label * expression) list
+        (* E0 ~l1:E1 ... ~ln:En
+           li can be empty (non labeled argument) or start with '?'
+           (optional argument).
+
+           Invariant: n > 0
+         *)
+  | Pexp_match of expression * case list
+        (* match E0 with P1 -> E1 | ... | Pn -> En *)
+  | Pexp_try of expression * case list
+        (* try E0 with P1 -> E1 | ... | Pn -> En *)
+  | Pexp_tuple of expression list
+        (* (E1, ..., En)
+
+           Invariant: n >= 2
+        *)
+  | Pexp_construct of Longident.t loc * expression option
+        (* C                None
+           C E              Some E
+           C (E1, ..., En)  Some (Pexp_tuple[E1;...;En])
+        *)
+  | Pexp_variant of label * expression option
+        (* `A             (None)
+           `A E           (Some E)
+         *)
+  | Pexp_record of (Longident.t loc * expression) list * expression option
+        (* { l1=P1; ...; ln=Pn }     (None)
+           { E0 with l1=P1; ...; ln=Pn }   (Some E0)
+
+           Invariant: n > 0
+         *)
+  | Pexp_field of expression * Longident.t loc
+        (* E.l *)
+  | Pexp_setfield of expression * Longident.t loc * expression
+        (* E1.l <- E2 *)
+  | Pexp_array of expression list
+        (* [| E1; ...; En |] *)
+  | Pexp_ifthenelse of expression * expression * expression option
+        (* if E1 then E2 else E3 *)
+  | Pexp_sequence of expression * expression
+        (* E1; E2 *)
+  | Pexp_while of expression * expression
+        (* while E1 do E2 done *)
+  | Pexp_for of
+      pattern *  expression * expression * direction_flag * expression
+        (* for i = E1 to E2 do E3 done      (flag = Upto)
+           for i = E1 downto E2 do E3 done  (flag = Downto)
+         *)
+  | Pexp_constraint of expression * core_type
+        (* (E : T) *)
+  | Pexp_coerce of expression * core_type option * core_type
+        (* (E :> T)        (None, T)
+           (E : T0 :> T)   (Some T0, T)
+         *)
+  | Pexp_send of expression * label loc
+        (*  E # m *)
+  | Pexp_new of Longident.t loc
+        (* new M.c *)
+  | Pexp_setinstvar of label loc * expression
+        (* x <- 2 *)
+  | Pexp_override of (label loc * expression) list
+        (* {< x1 = E1; ...; Xn = En >} *)
+  | Pexp_letmodule of string loc * module_expr * expression
+        (* let module M = ME in E *)
+  | Pexp_letexception of extension_constructor * expression
+        (* let exception C in E *)
+  | Pexp_assert of expression
+        (* assert E
+           Note: "assert false" is treated in a special way by the
+           type-checker. *)
+  | Pexp_lazy of expression
+        (* lazy E *)
+  | Pexp_poly of expression * core_type option
+        (* Used for method bodies.
+
+           Can only be used as the expression under Cfk_concrete
+           for methods (not values). *)
+  | Pexp_object of class_structure
+        (* object ... end *)
+  | Pexp_newtype of string loc * expression
+        (* fun (type t) -> E *)
+  | Pexp_pack of module_expr
+        (* (module ME)
+
+           (module ME : S) is represented as
+           Pexp_constraint(Pexp_pack, Ptyp_package S) *)
+  | Pexp_open of override_flag * Longident.t loc * expression
+        (* M.(E)
+           let open M in E
+           let! open M in E *)
+  | Pexp_extension of extension
+        (* [%id] *)
+  | Pexp_unreachable
+        (* . *)
+
+and case =   (* (P -> E) or (P when E0 -> E) *)
+    {
+     pc_lhs: pattern;
+     pc_guard: expression option;
+     pc_rhs: expression;
+    }
+
+(* Value descriptions *)
+
+and value_description =
+    {
+     pval_name: string loc;
+     pval_type: core_type;
+     pval_prim: string list;
+     pval_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+     pval_loc: Location.t;
+    }
+
+(*
+  val x: T                            (prim = [])
+  external x: T = "s1" ... "sn"       (prim = ["s1";..."sn"])
+*)
+
+(* Type declarations *)
+
+and type_declaration =
+    {
+     ptype_name: string loc;
+     ptype_params: (core_type * variance) list;
+           (* ('a1,...'an) t; None represents  _*)
+     ptype_cstrs: (core_type * core_type * Location.t) list;
+           (* ... constraint T1=T1'  ... constraint Tn=Tn' *)
+     ptype_kind: type_kind;
+     ptype_private: private_flag;   (* = private ... *)
+     ptype_manifest: core_type option;  (* = T *)
+     ptype_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+     ptype_loc: Location.t;
+    }
+
+(*
+  type t                     (abstract, no manifest)
+  type t = T0                (abstract, manifest=T0)
+  type t = C of T | ...      (variant,  no manifest)
+  type t = T0 = C of T | ... (variant,  manifest=T0)
+  type t = {l: T; ...}       (record,   no manifest)
+  type t = T0 = {l : T; ...} (record,   manifest=T0)
+  type t = ..                (open,     no manifest)
+*)
+
+and type_kind =
+  | Ptype_abstract
+  | Ptype_variant of constructor_declaration list
+        (* Invariant: non-empty list *)
+  | Ptype_record of label_declaration list
+        (* Invariant: non-empty list *)
+  | Ptype_open
+
+and label_declaration =
+    {
+     pld_name: string loc;
+     pld_mutable: mutable_flag;
+     pld_type: core_type;
+     pld_loc: Location.t;
+     pld_attributes: attributes; (* l : T [@id1] [@id2] *)
+    }
+
+(*  { ...; l: T; ... }            (mutable=Immutable)
+    { ...; mutable l: T; ... }    (mutable=Mutable)
+
+    Note: T can be a Ptyp_poly.
+*)
+
+and constructor_declaration =
+    {
+     pcd_name: string loc;
+     pcd_args: constructor_arguments;
+     pcd_res: core_type option;
+     pcd_loc: Location.t;
+     pcd_attributes: attributes; (* C of ... [@id1] [@id2] *)
+    }
+
+and constructor_arguments =
+  | Pcstr_tuple of core_type list
+  | Pcstr_record of label_declaration list
+
+(*
+  | C of T1 * ... * Tn     (res = None,    args = Pcstr_tuple [])
+  | C: T0                  (res = Some T0, args = [])
+  | C: T1 * ... * Tn -> T0 (res = Some T0, args = Pcstr_tuple)
+  | C of {...}             (res = None,    args = Pcstr_record)
+  | C: {...} -> T0         (res = Some T0, args = Pcstr_record)
+  | C of {...} as t        (res = None,    args = Pcstr_record)
+*)
+
+and type_extension =
+    {
+     ptyext_path: Longident.t loc;
+     ptyext_params: (core_type * variance) list;
+     ptyext_constructors: extension_constructor list;
+     ptyext_private: private_flag;
+     ptyext_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+    }
+(*
+  type t += ...
+*)
+
+and extension_constructor =
+    {
+     pext_name: string loc;
+     pext_kind : extension_constructor_kind;
+     pext_loc : Location.t;
+     pext_attributes: attributes; (* C of ... [@id1] [@id2] *)
+    }
+
+and extension_constructor_kind =
+    Pext_decl of constructor_arguments * core_type option
+      (*
+         | C of T1 * ... * Tn     ([T1; ...; Tn], None)
+         | C: T0                  ([], Some T0)
+         | C: T1 * ... * Tn -> T0 ([T1; ...; Tn], Some T0)
+       *)
+  | Pext_rebind of Longident.t loc
+      (*
+         | C = D
+       *)
+
+(** {1 Class language} *)
+
+(* Type expressions for the class language *)
+
+and class_type =
+    {
+     pcty_desc: class_type_desc;
+     pcty_loc: Location.t;
+     pcty_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and class_type_desc =
+  | Pcty_constr of Longident.t loc * core_type list
+        (* c
+           ['a1, ..., 'an] c *)
+  | Pcty_signature of class_signature
+        (* object ... end *)
+  | Pcty_arrow of arg_label * core_type * class_type
+        (* T -> CT       Simple
+           ~l:T -> CT    Labelled l
+           ?l:T -> CT    Optional l
+         *)
+  | Pcty_extension of extension
+        (* [%id] *)
+  | Pcty_open of override_flag * Longident.t loc * class_type
+        (* let open M in CT *)
+
+and class_signature =
+    {
+     pcsig_self: core_type;
+     pcsig_fields: class_type_field list;
+    }
+(* object('selfpat) ... end
+   object ... end             (self = Ptyp_any)
+ *)
+
+and class_type_field =
+    {
+     pctf_desc: class_type_field_desc;
+     pctf_loc: Location.t;
+     pctf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+and class_type_field_desc =
+  | Pctf_inherit of class_type
+        (* inherit CT *)
+  | Pctf_val of (label loc * mutable_flag * virtual_flag * core_type)
+        (* val x: T *)
+  | Pctf_method  of (label loc * private_flag * virtual_flag * core_type)
+        (* method x: T
+
+           Note: T can be a Ptyp_poly.
+         *)
+  | Pctf_constraint  of (core_type * core_type)
+        (* constraint T1 = T2 *)
+  | Pctf_attribute of attribute
+        (* [@@@id] *)
+  | Pctf_extension of extension
+        (* [%%id] *)
+
+and 'a class_infos =
+    {
+     pci_virt: virtual_flag;
+     pci_params: (core_type * variance) list;
+     pci_name: string loc;
+     pci_expr: 'a;
+     pci_loc: Location.t;
+     pci_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+    }
+(* class c = ...
+   class ['a1,...,'an] c = ...
+   class virtual c = ...
+
+   Also used for "class type" declaration.
+*)
+
+and class_description = class_type class_infos
+
+and class_type_declaration = class_type class_infos
+
+(* Value expressions for the class language *)
+
+and class_expr =
+    {
+     pcl_desc: class_expr_desc;
+     pcl_loc: Location.t;
+     pcl_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and class_expr_desc =
+  | Pcl_constr of Longident.t loc * core_type list
+        (* c
+           ['a1, ..., 'an] c *)
+  | Pcl_structure of class_structure
+        (* object ... end *)
+  | Pcl_fun of arg_label * expression option * pattern * class_expr
+        (* fun P -> CE                          (Simple, None)
+           fun ~l:P -> CE                       (Labelled l, None)
+           fun ?l:P -> CE                       (Optional l, None)
+           fun ?l:(P = E0) -> CE                (Optional l, Some E0)
+         *)
+  | Pcl_apply of class_expr * (arg_label * expression) list
+        (* CE ~l1:E1 ... ~ln:En
+           li can be empty (non labeled argument) or start with '?'
+           (optional argument).
+
+           Invariant: n > 0
+         *)
+  | Pcl_let of rec_flag * value_binding list * class_expr
+        (* let P1 = E1 and ... and Pn = EN in CE      (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN in CE  (flag = Recursive)
+         *)
+  | Pcl_constraint of class_expr * class_type
+        (* (CE : CT) *)
+  | Pcl_extension of extension
+  (* [%id] *)
+  | Pcl_open of override_flag * Longident.t loc * class_expr
+  (* let open M in CE *)
+
+
+and class_structure =
+    {
+     pcstr_self: pattern;
+     pcstr_fields: class_field list;
+    }
+(* object(selfpat) ... end
+   object ... end           (self = Ppat_any)
+ *)
+
+and class_field =
+    {
+     pcf_desc: class_field_desc;
+     pcf_loc: Location.t;
+     pcf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+and class_field_desc =
+  | Pcf_inherit of override_flag * class_expr * string loc option
+        (* inherit CE
+           inherit CE as x
+           inherit! CE
+           inherit! CE as x
+         *)
+  | Pcf_val of (label loc * mutable_flag * class_field_kind)
+        (* val x = E
+           val virtual x: T
+         *)
+  | Pcf_method of (label loc * private_flag * class_field_kind)
+        (* method x = E            (E can be a Pexp_poly)
+           method virtual x: T     (T can be a Ptyp_poly)
+         *)
+  | Pcf_constraint of (core_type * core_type)
+        (* constraint T1 = T2 *)
+  | Pcf_initializer of expression
+        (* initializer E *)
+  | Pcf_attribute of attribute
+        (* [@@@id] *)
+  | Pcf_extension of extension
+        (* [%%id] *)
+
+and class_field_kind =
+  | Cfk_virtual of core_type
+  | Cfk_concrete of override_flag * expression
+
+and class_declaration = class_expr class_infos
+
+(** {1 Module language} *)
+
+(* Type expressions for the module language *)
+
+and module_type =
+    {
+     pmty_desc: module_type_desc;
+     pmty_loc: Location.t;
+     pmty_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and module_type_desc =
+  | Pmty_ident of Longident.t loc
+        (* S *)
+  | Pmty_signature of signature
+        (* sig ... end *)
+  | Pmty_functor of string loc * module_type option * module_type
+        (* functor(X : MT1) -> MT2 *)
+  | Pmty_with of module_type * with_constraint list
+        (* MT with ... *)
+  | Pmty_typeof of module_expr
+        (* module type of ME *)
+  | Pmty_extension of extension
+        (* [%id] *)
+  | Pmty_alias of Longident.t loc
+        (* (module M) *)
+
+and signature = signature_item list
+
+and signature_item =
+    {
+     psig_desc: signature_item_desc;
+     psig_loc: Location.t;
+    }
+
+and signature_item_desc =
+  | Psig_value of value_description
+        (*
+          val x: T
+          external x: T = "s1" ... "sn"
+         *)
+  | Psig_type of rec_flag * type_declaration list
+        (* type t1 = ... and ... and tn = ... *)
+  | Psig_typext of type_extension
+        (* type t1 += ... *)
+  | Psig_exception of extension_constructor
+        (* exception C of T *)
+  | Psig_module of module_declaration
+        (* module X : MT *)
+  | Psig_recmodule of module_declaration list
+        (* module rec X1 : MT1 and ... and Xn : MTn *)
+  | Psig_modtype of module_type_declaration
+        (* module type S = MT
+           module type S *)
+  | Psig_open of open_description
+        (* open X *)
+  | Psig_include of include_description
+        (* include MT *)
+  | Psig_class of class_description list
+        (* class c1 : ... and ... and cn : ... *)
+  | Psig_class_type of class_type_declaration list
+        (* class type ct1 = ... and ... and ctn = ... *)
+  | Psig_attribute of attribute
+        (* [@@@id] *)
+  | Psig_extension of extension * attributes
+        (* [%%id] *)
+
+and module_declaration =
+    {
+     pmd_name: string loc;
+     pmd_type: module_type;
+     pmd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pmd_loc: Location.t;
+    }
+(* S : MT *)
+
+and module_type_declaration =
+    {
+     pmtd_name: string loc;
+     pmtd_type: module_type option;
+     pmtd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pmtd_loc: Location.t;
+    }
+(* S = MT
+   S       (abstract module type declaration, pmtd_type = None)
+*)
+
+and open_description =
+    {
+     popen_lid: Longident.t loc;
+     popen_override: override_flag;
+     popen_loc: Location.t;
+     popen_attributes: attributes;
+    }
+(* open! X - popen_override = Override (silences the 'used identifier
+                              shadowing' warning)
+   open  X - popen_override = Fresh
+ *)
+
+and 'a include_infos =
+    {
+     pincl_mod: 'a;
+     pincl_loc: Location.t;
+     pincl_attributes: attributes;
+    }
+
+and include_description = module_type include_infos
+(* include MT *)
+
+and include_declaration = module_expr include_infos
+(* include ME *)
+
+and with_constraint =
+  | Pwith_type of Longident.t loc * type_declaration
+        (* with type X.t = ...
+
+           Note: the last component of the longident must match
+           the name of the type_declaration. *)
+  | Pwith_module of Longident.t loc * Longident.t loc
+        (* with module X.Y = Z *)
+  | Pwith_typesubst of Longident.t loc * type_declaration
+        (* with type X.t := ..., same format as [Pwith_type] *)
+  | Pwith_modsubst of Longident.t loc * Longident.t loc
+        (* with module X.Y := Z *)
+
+(* Value expressions for the module language *)
+
+and module_expr =
+    {
+     pmod_desc: module_expr_desc;
+     pmod_loc: Location.t;
+     pmod_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and module_expr_desc =
+  | Pmod_ident of Longident.t loc
+        (* X *)
+  | Pmod_structure of structure
+        (* struct ... end *)
+  | Pmod_functor of string loc * module_type option * module_expr
+        (* functor(X : MT1) -> ME *)
+  | Pmod_apply of module_expr * module_expr
+        (* ME1(ME2) *)
+  | Pmod_constraint of module_expr * module_type
+        (* (ME : MT) *)
+  | Pmod_unpack of expression
+        (* (val E) *)
+  | Pmod_extension of extension
+        (* [%id] *)
+
+and structure = structure_item list
+
+and structure_item =
+    {
+     pstr_desc: structure_item_desc;
+     pstr_loc: Location.t;
+    }
+
+and structure_item_desc =
+  | Pstr_eval of expression * attributes
+        (* E *)
+  | Pstr_value of rec_flag * value_binding list
+        (* let P1 = E1 and ... and Pn = EN       (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN   (flag = Recursive)
+         *)
+  | Pstr_primitive of value_description
+        (*  val x: T
+            external x: T = "s1" ... "sn" *)
+  | Pstr_type of rec_flag * type_declaration list
+        (* type t1 = ... and ... and tn = ... *)
+  | Pstr_typext of type_extension
+        (* type t1 += ... *)
+  | Pstr_exception of extension_constructor
+        (* exception C of T
+           exception C = M.X *)
+  | Pstr_module of module_binding
+        (* module X = ME *)
+  | Pstr_recmodule of module_binding list
+        (* module rec X1 = ME1 and ... and Xn = MEn *)
+  | Pstr_modtype of module_type_declaration
+        (* module type S = MT *)
+  | Pstr_open of open_description
+        (* open X *)
+  | Pstr_class of class_declaration list
+        (* class c1 = ... and ... and cn = ... *)
+  | Pstr_class_type of class_type_declaration list
+        (* class type ct1 = ... and ... and ctn = ... *)
+  | Pstr_include of include_declaration
+        (* include ME *)
+  | Pstr_attribute of attribute
+        (* [@@@id] *)
+  | Pstr_extension of extension * attributes
+        (* [%%id] *)
+
+and value_binding =
+  {
+    pvb_pat: pattern;
+    pvb_expr: expression;
+    pvb_attributes: attributes;
+    pvb_loc: Location.t;
+  }
+
+and module_binding =
+    {
+     pmb_name: string loc;
+     pmb_expr: module_expr;
+     pmb_attributes: attributes;
+     pmb_loc: Location.t;
+    }
+(* X = ME *)
+
+(** {1 Toplevel} *)
+
+(* Toplevel phrases *)
+
+type toplevel_phrase =
+  | Ptop_def of structure
+  | Ptop_dir of string * directive_argument
+     (* #use, #load ... *)
+
+and directive_argument =
+  | Pdir_none
+  | Pdir_string of string
+  | Pdir_int of string * char option
+  | Pdir_ident of Longident.t
+  | Pdir_bool of bool
+end

--- a/ppx/build.sh
+++ b/ppx/build.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
-# Compiles the fine-grained @tracked ppx to a native binary using the system
-# OCaml compiler. ReScript 12 hands a ppx an OCaml 4.06 parsetree; ppx.ml
-# vendors those exact AST types, so the only build dependency is ocamlopt
-# (any recent OCaml works — tested with 4.14).
+# Compiles the fine-grained @xote.component ppx to a native binary using the
+# system OCaml compiler. ReScript 12 hands a ppx an OCaml 4.06 parsetree;
+# ppx.ml vendors those exact AST types, so the only build dependency is
+# ocamlopt (any recent OCaml works — tested with 4.14).
+#
+# Usage: build.sh [output-path]
+#   output-path is relative to this directory and defaults to ./ppx.
+#   CI passes bin/ppx-<platform>-<arch>.exe to produce the prebuilt binaries
+#   shipped in the npm package.
 set -e
 cd "$(dirname "$0")"
-ocamlopt -w -a-31 ppx.ml -o ppx
+out="${1:-ppx}"
+mkdir -p "$(dirname "$out")"
+ocamlopt -w -a-31 ppx.ml -o "$out"
 rm -f ppx.cmi ppx.cmx ppx.o
-echo "built $(pwd)/ppx"
+echo "built $(pwd)/$out"

--- a/ppx/build.sh
+++ b/ppx/build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Compiles the fine-grained @tracked ppx to a native binary using the system
+# OCaml compiler. ReScript 12 hands a ppx an OCaml 4.06 parsetree; ppx.ml
+# vendors those exact AST types, so the only build dependency is ocamlopt
+# (any recent OCaml works — tested with 4.14).
+set -e
+cd "$(dirname "$0")"
+ocamlopt -w -a-31 ppx.ml -o ppx
+rm -f ppx.cmi ppx.cmx ppx.o
+echo "built $(pwd)/ppx"

--- a/ppx/build.sh
+++ b/ppx/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Compiles the fine-grained @xote.component ppx to a native binary using the
+# system OCaml compiler. ReScript 12 hands a ppx an OCaml 4.06 parsetree;
+# ppx.ml vendors those exact AST types, so the only build dependency is
+# ocamlopt (any recent OCaml works — tested with 4.14).
+#
+# Usage: build.sh [output-path]
+#   output-path is relative to this directory and defaults to ./ppx.
+#   CI passes bin/ppx-<platform>-<arch>.exe to produce the prebuilt binaries
+#   shipped in the npm package.
+set -e
+cd "$(dirname "$0")"
+out="${1:-ppx}"
+mkdir -p "$(dirname "$out")"
+ocamlopt -w -a-31 ast.ml ppx.ml -o "$out"
+rm -f ast.cmi ast.cmx ast.o ppx.cmi ppx.cmx ppx.o
+echo "built $(pwd)/$out"

--- a/ppx/example/golden.mjs
+++ b/ppx/example/golden.mjs
@@ -1,0 +1,142 @@
+// Golden assertions on the JavaScript the ppx makes ReScript emit.
+//
+// verify.mjs proves *behaviour*: leaves are fine-grained, elements keep their
+// identity across a signal change. What it structurally cannot prove is
+// *reach* — JSX the traversal never visits still compiles and still renders,
+// only statically, and without even a `View.probe` to report it. A runtime test
+// mounts that markup and sees correct initial output, so it passes.
+//
+// That blind spot is how the same bug shipped three times: "an expression that
+// ends up in node position was not reached by the traversal" (untracked
+// control-flow branches, then render callbacks, then container-bound
+// bindings). These assertions look at the emitted code instead, so a leaf that
+// silently stayed static fails the build.
+//
+// Deliberately *not* full-file snapshots: those churn on every ReScript codegen
+// change and teach you nothing when they break. Each assertion below names one
+// binding and one property, and every positive has a matching negative — that a
+// leaf became reactive is only half the claim; the other half is that static
+// things stayed static.
+//
+//   npm run build && npm run golden
+import { readFileSync } from 'node:fs';
+
+/* A missing emitted file means the ReScript build did not produce it — usually
+   because it failed to compile. Say that, rather than dying in readFileSync
+   with an ENOENT stack that points at this script instead of at the build. */
+const emitted = (name) => {
+  try {
+    return readFileSync(new URL(`./src/${name}.res.mjs`, import.meta.url), 'utf8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    console.error(
+      `\ngolden: src/${name}.res.mjs was not emitted, so there is nothing to assert on.\n` +
+      `Run \`npm run build\` in ppx/example and fix the compile error first.\n` +
+      `(A bare {…} child failing with "This has type: string" is the traversal\n` +
+      ` not reaching that position — the loud half of the bug these tests guard.)`,
+    );
+    process.exit(1);
+  }
+};
+
+const golden = emitted('Golden');
+const demo = emitted('Demo');
+
+let pass = 0;
+const failures = [];
+
+/* `why` is printed on failure: a golden test nobody can interpret is worse than
+   no golden test, because the tempting fix is to update the expectation. */
+const has = (name, src, needle, why) => {
+  if (src.includes(needle)) { pass++; console.log('  ✓', name); }
+  else { failures.push({ name, why, expected: `to contain: ${needle}` }); console.log('  ✗', name); }
+};
+
+const lacks = (name, src, needle, why) => {
+  if (!src.includes(needle)) { pass++; console.log('  ✓', name); }
+  else { failures.push({ name, why, expected: `NOT to contain: ${needle}` }); console.log('  ✗', name); }
+};
+
+console.log('\ntraversal reach: JSX one container down from its binding');
+console.log('(each of these compiled to a frozen attribute, with no probe, before the fix)');
+
+has('array-bound JSX gets a reactive attribute', golden,
+  'class: () => Signal$Xote.get(themeArray)',
+  'JSX inside `let rows = [<li …/>]` is node position. If this is a bare ' +
+  '`Signal$Xote.get(themeArray)` the traversal stopped at the binding again.');
+
+has('option-bound JSX gets a reactive attribute', golden,
+  'class: () => Signal$Xote.get(themeOption)',
+  'JSX inside `Some(<h1 …/>)` is node position, same as an array element.');
+
+has('tuple-bound JSX gets a reactive attribute', golden,
+  'class: () => Signal$Xote.get(themeTuple)',
+  'JSX inside a tuple is node position too.');
+
+has('JSX in a nested non-render lambda gets a reactive attribute', golden,
+  'class: () => Signal$Xote.get(themeLambda)',
+  'The binding body is `Array.map(…)`, not JSX, so is_render_callback does not ' +
+  'fire — the walker still has to descend into the inner lambda.');
+
+has('directly-bound JSX stays reactive', golden,
+  'class: () => Signal$Xote.get(themeDirect)',
+  'The case that always worked. If this breaks, the fix regressed the base case ' +
+  'rather than extending it.');
+
+console.log('\nnegative controls: what must NOT be rewritten');
+
+has('a static attribute stays a plain string', golden,
+  'class: "static-class"',
+  'Nothing reads a signal here, so thunking it would allocate a computed ' +
+  'attribute for a constant.');
+
+lacks('a static attribute is not thunked', golden,
+  'class: () => "static-class"',
+  'An over-eager walker that thunks everything would still pass every positive ' +
+  'assertion above. This is what distinguishes "reaches the leaf" from ' +
+  '"rewrites indiscriminately".');
+
+lacks('an existing thunk is not double-wrapped', golden,
+  '() => () => Signal$Xote.get(themeThunked)',
+  '`class={() => Signal.get(x)}` is already reactive. Double-wrapping would ' +
+  'make the attribute a function-returning-function and render "() => …" as ' +
+  'the attribute value. This is what keeps @xote.component a safe drop-in.');
+
+console.log('\ncore contract (regression guards on the existing behaviour)');
+
+has('bare children are coerced through View.child', golden,
+  'View$Xote.child("open")',
+  'A bare `{"open"}` child in element position is coerced at runtime rather ' +
+  'than needing a <View.Text> wrapper.');
+
+has('control flow lowers to View.tracked', golden,
+  'View$Xote.tracked(',
+  'An if/switch in node position whose condition reads a signal is the one ' +
+  'place a structural swap needs a tracked scope.');
+
+lacks('a tracked branch does not thunk its own static leaf', golden,
+  'class: () => "open"',
+  'Leaves inside a branch are decomposed on their own merits; a static class ' +
+  'inside a tracked branch stays static.');
+
+has('an unresolvable call is wrapped in View.probe with its source location', demo,
+  'View$Xote.probe("Demo.res:525:32", () => Store.themeClass())',
+  'The hidden-read safety net. If the site string loses its line:col the ' +
+  'warning stops naming where to look, which is most of its value.');
+
+has('a user-component scalar prop is left as a one-shot read', demo,
+  'label: Signal$Xote.get(name)',
+  'Props land in the component\'s typed props record; thunking one would ' +
+  'change its type and fail to compile with a baffling error.');
+
+console.log(`\n${pass} passed, ${failures.length} failed`);
+
+if (failures.length > 0) {
+  console.log('\nfailures:');
+  for (const f of failures) {
+    console.log(`\n  ✗ ${f.name}`);
+    console.log(`    expected ${f.expected}`);
+    console.log(`    why this matters: ${f.why}`);
+  }
+  process.exit(1);
+}

--- a/ppx/example/package.json
+++ b/ppx/example/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "xote-tracked-ppx-example",
+  "private": true,
+  "description": "Demonstrates the fine-grained @tracked ppx. See ../README.md.",
+  "scripts": {
+    "build": "rescript build",
+    "verify": "node verify.mjs"
+  }
+}

--- a/ppx/example/package.json
+++ b/ppx/example/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "xote-tracked-ppx-example",
+  "private": true,
+  "description": "Demonstrates the fine-grained @xote.component ppx. See ../README.md.",
+  "scripts": {
+    "build": "rescript build",
+    "verify": "node verify.mjs",
+    "golden": "node golden.mjs"
+  }
+}

--- a/ppx/example/package.json
+++ b/ppx/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xote-tracked-ppx-example",
   "private": true,
-  "description": "Demonstrates the fine-grained @tracked ppx. See ../README.md.",
+  "description": "Demonstrates the fine-grained @xote.component ppx. See ../README.md.",
   "scripts": {
     "build": "rescript build",
     "verify": "node verify.mjs"

--- a/ppx/example/rescript.json
+++ b/ppx/example/rescript.json
@@ -1,0 +1,10 @@
+{
+  "name": "xote-tracked-ppx-example",
+  "sources": [{ "dir": "src", "subdirs": false }],
+  "package-specs": { "module": "esmodule", "in-source": true },
+  "suffix": ".res.mjs",
+  "dependencies": ["@rescript/core", "rescript-signals", "xote"],
+  "jsx": { "version": 4, "module": "XoteJSX" },
+  "compiler-flags": ["-open Xote"],
+  "ppx-flags": ["xote-tracked-ppx/ppx"]
+}

--- a/ppx/example/rescript.json
+++ b/ppx/example/rescript.json
@@ -1,0 +1,10 @@
+{
+  "name": "xote-tracked-ppx-example",
+  "sources": [{ "dir": "src", "subdirs": false }],
+  "package-specs": { "module": "esmodule", "in-source": true },
+  "suffix": ".res.mjs",
+  "dependencies": ["rescript-signals", "xote"],
+  "jsx": { "version": 4, "module": "XoteJSX" },
+  "compiler-flags": ["-open Xote"],
+  "ppx-flags": ["xote-tracked-ppx/ppx"]
+}

--- a/ppx/example/setup.sh
+++ b/ppx/example/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Links the toolchain and Xote from the repo root into this standalone example
+# so `npm run build` / `npm run verify` can resolve them. Idempotent.
+set -e
+cd "$(dirname "$0")"
+mkdir -p node_modules node_modules/@rescript
+
+link() {
+  # link <target> <name>  (relative to example/node_modules)
+  ln -sfn "$1" "node_modules/$2"
+}
+
+link ../../..                         xote
+link ../..                            xote-tracked-ppx
+link ../../../node_modules/rescript   rescript
+link ../../../node_modules/rescript-signals rescript-signals
+link ../../../node_modules/jsdom      jsdom
+# @rescript/core and the platform binaries live under the @rescript scope
+ln -sfn ../../../../node_modules/@rescript/core          node_modules/@rescript/core
+ln -sfn ../../../../node_modules/@rescript/linux-x64     node_modules/@rescript/linux-x64 2>/dev/null || true
+
+echo "example/ linked. Now: sh ../build.sh && npm run build && npm run verify"

--- a/ppx/example/setup.sh
+++ b/ppx/example/setup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Links the toolchain and Xote from the repo root into this standalone example
+# so `npm run build` / `npm run verify` can resolve them. Idempotent.
+set -e
+cd "$(dirname "$0")"
+mkdir -p node_modules node_modules/@rescript
+
+link() {
+  # link <target> <name>  (relative to example/node_modules)
+  ln -sfn "$1" "node_modules/$2"
+}
+
+link ../../..                         xote
+link ../..                            xote-tracked-ppx
+link ../../../node_modules/rescript   rescript
+link ../../../node_modules/rescript-signals rescript-signals
+link ../../../node_modules/jsdom      jsdom
+# the platform binaries live under the @rescript scope
+ln -sfn ../../../../node_modules/@rescript/linux-x64     node_modules/@rescript/linux-x64 2>/dev/null || true
+
+echo "example/ linked. Now: sh ../build.sh && npm run build && npm run verify"

--- a/ppx/example/src/Demo.res
+++ b/ppx/example/src/Demo.res
@@ -6,6 +6,7 @@ let status = Signal.make(Loading)
 let theme = Signal.make("light")
 let count = Signal.make(0)
 let mobileOpen = Signal.make(false)
+let labels = Signal.make(["one", "two"])
 let canvas = Signal.make("canvas-a")
 let items = Signal.make(["a", "b"])
 module S = Signal
@@ -120,14 +121,14 @@ module PreThunked = {
   }
 }
 
-/* Case 9: a value already reactive on its own — `Prop.reactive(Computed…)` —
+/* Case 9: a value already reactive on its own — `MaybeSignal.reactive(Computed…)` —
    reads a signal only inside a nested lambda, so it must NOT be thunked (that
-   would wrap a Prop.t in a function and break attribute rendering). */
+   would wrap a MaybeSignal.t in a function and break attribute rendering). */
 module PropWrapped = {
   @xote.component
   let make = () => {
     <div
-      class={Prop.reactive(Computed.make(() => Signal.get(active) ? "on" : "off"))}
+      class={MaybeSignal.reactive(Computed.make(() => Signal.get(active) ? "on" : "off"))}
       id="prop-wrapped">
       <View.Text> {"x"} </View.Text>
     </div>
@@ -367,4 +368,121 @@ module MappedList = {
       {Signal.get(items)->Array.map(item => <li class="ml-item"> {View.text(item)} </li>)}
     </ul>
   }
+}
+
+/* Case 20: control flow on a *plain* condition (a bool prop or local, no signal
+   read anywhere in the condition). No View.tracked is needed since the
+   structure cannot change, but the branches are still node position: their bare
+   children must be coerced. Before the branches were decomposed on this path,
+   `{if flag { <b> {"yes"} </b> } else { … }}` failed to compile with
+   "This has type: string", pointing at the literal rather than the
+   conditional. */
+module StaticBranch = {
+  @xote.component
+  let make = (~flag: bool) =>
+    <div id="static-branch">
+      {if flag {
+        <b id="sb-yes"> {"yes"} </b>
+      } else {
+        <i id="sb-no"> {"no"} </i>
+      }}
+      {flag ? "on" : "off"}
+    </div>
+}
+
+/* Case 21: a plain-condition branch that also holds a reactive leaf. The
+   conditional itself is built once; the leaf inside keeps its own reactive
+   scope, so changing the signal updates the class without rebuilding. */
+module StaticBranchReactiveLeaf = {
+  @xote.component
+  let make = (~flag: bool) =>
+    <div id="sbrl">
+      {if flag {
+        <b id="sbrl-tag" class={Signal.get(theme)}> {Signal.get(name)} </b>
+      } else {
+        <i> {"none"} </i>
+      }}
+    </div>
+}
+
+/* Case 22: bare children inside a *render callback*. A prop whose value is a
+   function returning JSX (View.For/Value/Maybe's `render`, or any user
+   component's callback) is node position once applied, but it is not itself
+   JSX, so the traversal used to stop at the callback boundary: nothing inside
+   was decomposed and `<span> {item.author} </span>` failed to compile with
+   "This has type: string". List rendering is written this way, so the shape is
+   everywhere. The reactive leaf below also proves decomposition really happens
+   inside the callback rather than the body being left alone. */
+type row = {id: string, author: string}
+let rows = Signal.make([{id: "r1", author: "Ada"}, {id: "r2", author: "Bo"}])
+
+module CallbackRows = {
+  @xote.component
+  let make = () =>
+    <ul id="cb-rows">
+      <View.For
+        each={MaybeSignal.reactive(rows)}
+        by={row => row.id}
+        render={row =>
+          <li class={Signal.get(theme)}>
+            <span class="author"> {row.author} </span>
+            <span> {" · "} </span>
+            {Signal.get(count)}
+          </li>}
+      />
+    </ul>
+}
+
+/* Case 23: node-taking runtime helpers called as plain functions. An explicit
+   `View.tracked(() => …)` or `View.each(xs, x => …)` is an ordinary
+   application, not JSX, so the traversal used to stop at the call: bare
+   children inside the callback were never coerced, even though the identical
+   markup works when the ppx emits `View.tracked` itself for an `if`/`switch`.
+   The callback body is node position, so it is decomposed like any other. */
+module HelperCallbacks = {
+  @xote.component
+  let make = () =>
+    <div id="helper-callbacks">
+      {View.tracked(() =>
+        if Signal.get(active) {
+          <p id="hc-on" class={Signal.get(theme)}> {Signal.get(name)} </p>
+        } else {
+          <p id="hc-off"> {"inactive"} </p>
+        }
+      )}
+      {View.each(labels, label => <span class="hc-item"> {label} </span>)}
+    </div>
+}
+
+/* Case 24: JSX reached through something other than a child slot. Any JSX the
+   component's markup contains is node position, however it is nested: inside an
+   array, an application (including the pipe form), a `try`, or bound to a local
+   name. Special-casing containers one at a time kept missing the next one, so
+   the traversal now walks the whole expression. */
+module NestedShapes = {
+  @xote.component
+  let make = () => {
+    /* JSX bound to a local name, and a local helper returning JSX */
+    let heading = <h4 id="ns-heading"> {"Nested"} </h4>
+    let item = (label: string) => <li class={Signal.get(theme)}> {label} </li>
+
+    <div id="nested-shapes">
+      {heading}
+      {View.fragment([<span id="ns-arr"> {"array"} </span>])}
+      {View.fragment(["a", "b"]->Array.map(a => <em class="ns-map"> {a} </em>))}
+      <ul> {View.fragment([item("one"), item("two")])} </ul>
+    </div>
+  }
+}
+
+/* Case 25: a plain helper function that returns markup — a component in all but
+   name. In a file that opts in (it contains an @xote.component), helper bodies
+   are decomposed like inline markup: bare children are coerced and reads become
+   leaves, so a helper needs no value primitives and no manual thunks. */
+let helperButton = (label: string) =>
+  <button id="helper-btn" class={Signal.get(theme)}> {label} </button>
+
+module HelperHost = {
+  @xote.component
+  let make = () => <div id="helper-host"> {helperButton("Press")} </div>
 }

--- a/ppx/example/src/Demo.res
+++ b/ppx/example/src/Demo.res
@@ -1,0 +1,142 @@
+type status = Loading | Ready(string)
+
+let name = Signal.make("Ada")
+let active = Signal.make(false)
+let status = Signal.make(Loading)
+let theme = Signal.make("light")
+module S = Signal
+
+/* Every case is an @xote.component: one annotation derives props (it emits
+   @jsx.component) and fine-grains the returned JSX into reactive leaves.
+   @jsx.component allows only one component per module, so each lives in its
+   own submodule (in real code, one per file). */
+
+/* Case 1: attribute + text leaves become fine-grained, static parts untouched */
+module Card = {
+  @xote.component
+  let make = () => {
+    <div class={Signal.get(active) ? "on" : "off"} id="card">
+      <span class="static-label"> {View.text("Name:")} </span>
+      <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 2: control flow in node position -> View.tracked (structural swap) */
+module Panel = {
+  @xote.component
+  let make = () => {
+    <div>
+      {switch Signal.get(status) {
+      | Loading => <span> {View.text("Loading...")} </span>
+      | Ready(msg) => <strong> {View.text(msg)} </strong>
+      }}
+    </div>
+  }
+}
+
+/* Case 2b: a branch whose leaf reads a *different* signal (theme) than the
+   scrutinee (status). Branch decomposition keeps that leaf fine-grained, so
+   the switch tracks only `status`: changing `theme` updates just the class and
+   leaves the <strong> element in place (no branch rebuild). */
+module SwitchLeaf = {
+  @xote.component
+  let make = () => {
+    <div id="switch-leaf">
+      {switch Signal.get(status) {
+      | Loading => <span> {View.text("Loading...")} </span>
+      | Ready(msg) =>
+        <strong id="ready-strong" class={Signal.get(theme)}> {View.text(msg)} </strong>
+      }}
+    </div>
+  }
+}
+
+/* Case 3: indirect read via a value alias — `let g = Signal.get` */
+module Aliased = {
+  @xote.component
+  let make = () => {
+    let g = Signal.get
+    <div class={g(active) ? "on" : "off"} id="aliased">
+      <View.Text> {`Hi, ${g(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 4: indirect read via a module alias — `module S = Signal` (top level) */
+module ModAliased = {
+  @xote.component
+  let make = () => {
+    <div class={S.get(active) ? "on" : "off"} id="mod-aliased">
+      <View.Text> {`Yo, ${S.get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 5: indirect read via `open Signal` then a bare `get` */
+module OpenAliased = {
+  @xote.component
+  let make = () => {
+    open Signal
+    <div class={get(active) ? "on" : "off"} id="open-aliased">
+      <View.Text> {`Hey, ${get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 6: pipe form — `active->Signal.get` (desugars to Signal.get(active)) */
+module Piped = {
+  @xote.component
+  let make = () => {
+    <div class={active->Signal.get ? "on" : "off"} id="piped">
+      <View.Text> {`Pipe, ${name->Signal.get}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 7: a component with a prop — `label` (a prop) stays static while the
+   signal reads become reactive leaves. */
+module Labeled = {
+  @xote.component
+  let make = (~label: string) => {
+    <div class={Signal.get(active) ? "on" : "off"} id="labeled">
+      <View.Text> {`${label}: ${Signal.get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 8: pre-existing `() => …` thunks are left alone (not double-wrapped), so
+   @xote.component is a safe drop-in on components already written that way. */
+module PreThunked = {
+  @xote.component
+  let make = () => {
+    <div class={() => Signal.get(active) ? "on" : "off"} id="pre-thunked">
+      <View.Text> {() => `T: ${Signal.get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 9: a value already reactive on its own — `Prop.reactive(Computed…)` —
+   reads a signal only inside a nested lambda, so it must NOT be thunked (that
+   would wrap a Prop.t in a function and break attribute rendering). */
+module PropWrapped = {
+  @xote.component
+  let make = () => {
+    <div
+      class={Prop.reactive(Computed.make(() => Signal.get(active) ? "on" : "off"))}
+      id="prop-wrapped">
+      <View.Text> {"x"} </View.Text>
+    </div>
+  }
+}
+
+/* Case 10: a read hidden behind a local helper. The helper's body eagerly reads
+   a signal, so it is tracked as reactive and calling it inline stays fine-grained
+   (rather than silently compiling to a static, once-evaluated attribute). */
+let statusClass = () => Signal.get(active) ? "on" : "off"
+module HelperHidden = {
+  @xote.component
+  let make = () => {
+    <div class={statusClass()} id="helper-hidden"> <View.Text> {"hh"} </View.Text> </div>
+  }
+}

--- a/ppx/example/src/Demo.res
+++ b/ppx/example/src/Demo.res
@@ -486,3 +486,64 @@ module HelperHost = {
   @xote.component
   let make = () => <div id="helper-host"> {helperButton("Press")} </div>
 }
+
+/* Case 26: `MaybeSignal.get` is a tracked read exactly like `Signal.get`, and
+   so is `Prop.get` (its deprecated alias). Reading through the static-or-
+   reactive wrapper subscribes just the same, so these leaves must be thunked. */
+let maybeName: MaybeSignal.t<string> = MaybeSignal.reactive(name)
+let maybeTheme: MaybeSignal.t<string> = MaybeSignal.reactive(theme)
+
+module MaybeSignalRead = {
+  @xote.component
+  let make = () =>
+    <p id="maybe-signal" class={MaybeSignal.get(maybeTheme)}> {MaybeSignal.get(maybeName)} </p>
+}
+
+/* Case 27: a reactive helper reached through a module *in this file*. The ppx
+   walks the module body, so `Counter.doubled()` is a read; `Counter.plain(…)`
+   is not, and stays a plain static value. */
+module Counter = {
+  let doubled = () => Signal.get(count) * 2
+  let plain = (n: int) => n + 1
+}
+
+module ModuleHelper = {
+  @xote.component
+  let make = () =>
+    <p id="module-helper" class={Counter.doubled() > 0 ? "positive" : "zero"}>
+      {Counter.doubled()}
+    </p>
+}
+
+/* Case 28: the hidden read. `Store` lives in another file, so the ppx sees only
+   a call it cannot resolve and cannot know a signal is read behind it. Both
+   leaves are wrapped in `View.probe`, which reports them at runtime instead of
+   rendering a frozen value in silence. */
+module Hidden = {
+  @xote.component
+  let make = () =>
+    <p id="hidden-read" class={Store.themeClass()}> {Store.waitingCount()} </p>
+}
+
+/* Case 28b: the same indirection in a *condition*. A read hidden in the
+   scrutinee freezes the whole branch, so untracked control flow probes it. */
+module HiddenBranch = {
+  @xote.component
+  let make = () =>
+    <div id="hidden-branch">
+      {if Store.isBusy() {
+        <span id="hb-busy"> {"busy"} </span>
+      } else {
+        <span id="hb-idle"> {"idle"} </span>
+      }}
+    </div>
+}
+
+/* Case 29: the probe must not cry wolf. An unresolvable call that reads no
+   signal is a perfectly ordinary static value — no warning, no reactivity, and
+   `View.probe` returns it untouched. */
+module HiddenClean = {
+  @xote.component
+  let make = () =>
+    <p id="hidden-clean" class={Store.title("row")}> {Counter.plain(41)} </p>
+}

--- a/ppx/example/src/Demo.res
+++ b/ppx/example/src/Demo.res
@@ -4,6 +4,9 @@ let name = Signal.make("Ada")
 let active = Signal.make(false)
 let status = Signal.make(Loading)
 let theme = Signal.make("light")
+let count = Signal.make(0)
+let mobileOpen = Signal.make(false)
+let canvas = Signal.make("canvas-a")
 module S = Signal
 
 /* Every case is an @xote.component: one annotation derives props (it emits
@@ -138,5 +141,115 @@ module HelperHidden = {
   @xote.component
   let make = () => {
     <div class={statusClass()} id="helper-hidden"> <View.Text> {"hh"} </View.Text> </div>
+  }
+}
+
+/* Case 11: a *bare* reactive scalar child — no <View.Int>/<View.Text> wrapper.
+   The ppx wraps it in View.child, which coerces the eager signal read into a
+   reactive text node. This is the value-primitive-free ergonomic default. */
+module BareInt = {
+  @xote.component
+  let make = () => {
+    <div id="bare-int"> {Signal.get(count)} </div>
+  }
+}
+
+/* Case 12: a bare reactive *string* child alongside a static sibling — only the
+   text leaf is reactive, the <span> and surrounding element keep their identity. */
+module BareString = {
+  @xote.component
+  let make = () => {
+    <div id="bare-string"> <span class="lbl"> {View.text("n: ")} </span> {Signal.get(name)} </div>
+  }
+}
+
+/* Case 13: a bare *static* scalar child — previously a type error (string in node
+   position); View.child now makes it a static text node. */
+module BareStatic = {
+  @xote.component
+  let make = () => {
+    <div id="bare-static"> {"literal"} </div>
+  }
+}
+
+/* Case 14: a bare child that is *already a node* — View.child detects it at
+   runtime and passes it through untouched (no double wrapping). */
+module BareNode = {
+  @xote.component
+  let make = () => {
+    <div id="bare-node"> {View.text("noded")} </div>
+  }
+}
+
+/* Case 15: control flow whose branches are bare *scalars* (not nodes). The switch
+   is still tracked (structural swap on `status`), but each branch is coerced by
+   View.child, so scalar branches no longer need a value primitive. */
+module ScalarSwitch = {
+  @xote.component
+  let make = () => {
+    <div id="scalar-switch">
+      {switch Signal.get(status) {
+      | Loading => "…loading"
+      | Ready(msg) => msg
+      }}
+    </div>
+  }
+}
+
+/* Case 16: a make whose body is a *fragment* holding two independent reactive
+   regions — a canvas element (reads `canvas`) and a nested mobile-backdrop `if`
+   (reads `mobileOpen`). Each fragment child is decomposed on its own, so the
+   backdrop toggle re-runs only its own View.tracked and leaves the canvas (and
+   its content leaf) in place. A regression guard: before fragments were recursed
+   into, the whole fragment collapsed into one coarse thunk and toggling the panel
+   rebuilt every sibling. */
+module Workspace = {
+  @xote.component
+  let make = () => {
+    <>
+      <div id="ws-canvas"> {Signal.get(canvas)} </div>
+      {if Signal.get(mobileOpen) {
+        <div id="ws-backdrop" />
+      } else {
+        View.null()
+      }}
+    </>
+  }
+}
+
+/* Case 17: bare children *directly* in a fragment return (no wrapping element).
+   A dropdown-style component whose labels sit next to a static anchor at the
+   fragment's top level — each bare read is coerced by View.child in place, so
+   the component needs no display:contents root just to make them type. */
+module DropdownFragment = {
+  @xote.component
+  let make = () => {
+    <>
+      <span id="df-anchor" />
+      {Signal.get(name)}
+      {() => `#${Signal.get(count)->Int.toString}`}
+    </>
+  }
+}
+
+/* Case 18: a control-flow *branch body* that is itself a fragment of bare labels
+   (a dropdown inlined into an `if`, not extracted into its own component). The
+   switch is tracked on the toggle, and the fragment branch is decomposed so its
+   bare labels are coerced — the anchor outside the `if` keeps its identity. */
+module MenuBranch = {
+  @xote.component
+  let make = () => {
+    <div id="mb-host">
+      <span id="mb-anchor" />
+      {if Signal.get(active) {
+        <>
+          {Signal.get(name)}
+          {View.text(" / ")}
+          {Signal.get(count)}
+        </>
+      } else {
+        View.null()
+      }}
+    </div>
   }
 }

--- a/ppx/example/src/Demo.res
+++ b/ppx/example/src/Demo.res
@@ -1,0 +1,549 @@
+type status = Loading | Ready(string)
+
+let name = Signal.make("Ada")
+let active = Signal.make(false)
+let status = Signal.make(Loading)
+let theme = Signal.make("light")
+let count = Signal.make(0)
+let mobileOpen = Signal.make(false)
+let labels = Signal.make(["one", "two"])
+let canvas = Signal.make("canvas-a")
+let items = Signal.make(["a", "b"])
+module S = Signal
+
+/* Every case is an @xote.component: one annotation derives props (it emits
+   @jsx.component) and fine-grains the returned JSX into reactive leaves.
+   @jsx.component allows only one component per module, so each lives in its
+   own submodule (in real code, one per file). */
+
+/* Case 1: attribute + text leaves become fine-grained, static parts untouched */
+module Card = {
+  @xote.component
+  let make = () => {
+    <div class={Signal.get(active) ? "on" : "off"} id="card">
+      <span class="static-label"> {View.text("Name:")} </span>
+      <View.Text> {`Hello, ${Signal.get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 2: control flow in node position -> View.tracked (structural swap) */
+module Panel = {
+  @xote.component
+  let make = () => {
+    <div>
+      {switch Signal.get(status) {
+      | Loading => <span> {View.text("Loading...")} </span>
+      | Ready(msg) => <strong> {View.text(msg)} </strong>
+      }}
+    </div>
+  }
+}
+
+/* Case 2b: a branch whose leaf reads a *different* signal (theme) than the
+   scrutinee (status). Branch decomposition keeps that leaf fine-grained, so
+   the switch tracks only `status`: changing `theme` updates just the class and
+   leaves the <strong> element in place (no branch rebuild). */
+module SwitchLeaf = {
+  @xote.component
+  let make = () => {
+    <div id="switch-leaf">
+      {switch Signal.get(status) {
+      | Loading => <span> {View.text("Loading...")} </span>
+      | Ready(msg) =>
+        <strong id="ready-strong" class={Signal.get(theme)}> {View.text(msg)} </strong>
+      }}
+    </div>
+  }
+}
+
+/* Case 3: indirect read via a value alias — `let g = Signal.get` */
+module Aliased = {
+  @xote.component
+  let make = () => {
+    let g = Signal.get
+    <div class={g(active) ? "on" : "off"} id="aliased">
+      <View.Text> {`Hi, ${g(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 4: indirect read via a module alias — `module S = Signal` (top level) */
+module ModAliased = {
+  @xote.component
+  let make = () => {
+    <div class={S.get(active) ? "on" : "off"} id="mod-aliased">
+      <View.Text> {`Yo, ${S.get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 5: indirect read via `open Signal` then a bare `get` */
+module OpenAliased = {
+  @xote.component
+  let make = () => {
+    open Signal
+    <div class={get(active) ? "on" : "off"} id="open-aliased">
+      <View.Text> {`Hey, ${get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 6: pipe form — `active->Signal.get` (desugars to Signal.get(active)) */
+module Piped = {
+  @xote.component
+  let make = () => {
+    <div class={active->Signal.get ? "on" : "off"} id="piped">
+      <View.Text> {`Pipe, ${name->Signal.get}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 7: a component with a prop — `label` (a prop) stays static while the
+   signal reads become reactive leaves. */
+module Labeled = {
+  @xote.component
+  let make = (~label: string) => {
+    <div class={Signal.get(active) ? "on" : "off"} id="labeled">
+      <View.Text> {`${label}: ${Signal.get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 8: pre-existing `() => …` thunks are left alone (not double-wrapped), so
+   @xote.component is a safe drop-in on components already written that way. */
+module PreThunked = {
+  @xote.component
+  let make = () => {
+    <div class={() => Signal.get(active) ? "on" : "off"} id="pre-thunked">
+      <View.Text> {() => `T: ${Signal.get(name)}`} </View.Text>
+    </div>
+  }
+}
+
+/* Case 9: a value already reactive on its own — `MaybeSignal.reactive(Computed…)` —
+   reads a signal only inside a nested lambda, so it must NOT be thunked (that
+   would wrap a MaybeSignal.t in a function and break attribute rendering). */
+module PropWrapped = {
+  @xote.component
+  let make = () => {
+    <div
+      class={MaybeSignal.reactive(Computed.make(() => Signal.get(active) ? "on" : "off"))}
+      id="prop-wrapped">
+      <View.Text> {"x"} </View.Text>
+    </div>
+  }
+}
+
+/* Case 10: a read hidden behind a local helper. The helper's body eagerly reads
+   a signal, so it is tracked as reactive and calling it inline stays fine-grained
+   (rather than silently compiling to a static, once-evaluated attribute). */
+let statusClass = () => Signal.get(active) ? "on" : "off"
+module HelperHidden = {
+  @xote.component
+  let make = () => {
+    <div class={statusClass()} id="helper-hidden"> <View.Text> {"hh"} </View.Text> </div>
+  }
+}
+
+/* Case 11: a *bare* reactive scalar child — no <View.Int>/<View.Text> wrapper.
+   The ppx wraps it in View.child, which coerces the eager signal read into a
+   reactive text node. This is the value-primitive-free ergonomic default. */
+module BareInt = {
+  @xote.component
+  let make = () => {
+    <div id="bare-int"> {Signal.get(count)} </div>
+  }
+}
+
+/* Case 12: a bare reactive *string* child alongside a static sibling — only the
+   text leaf is reactive, the <span> and surrounding element keep their identity. */
+module BareString = {
+  @xote.component
+  let make = () => {
+    <div id="bare-string"> <span class="lbl"> {View.text("n: ")} </span> {Signal.get(name)} </div>
+  }
+}
+
+/* Case 13: a bare *static* scalar child — previously a type error (string in node
+   position); View.child now makes it a static text node. */
+module BareStatic = {
+  @xote.component
+  let make = () => {
+    <div id="bare-static"> {"literal"} </div>
+  }
+}
+
+/* Case 14: a bare child that is *already a node* — View.child detects it at
+   runtime and passes it through untouched (no double wrapping). */
+module BareNode = {
+  @xote.component
+  let make = () => {
+    <div id="bare-node"> {View.text("noded")} </div>
+  }
+}
+
+/* Case 15: control flow whose branches are bare *scalars* (not nodes). The switch
+   is still tracked (structural swap on `status`), but each branch is coerced by
+   View.child, so scalar branches no longer need a value primitive. */
+module ScalarSwitch = {
+  @xote.component
+  let make = () => {
+    <div id="scalar-switch">
+      {switch Signal.get(status) {
+      | Loading => "…loading"
+      | Ready(msg) => msg
+      }}
+    </div>
+  }
+}
+
+/* Case 16: a make whose body is a *fragment* holding two independent reactive
+   regions — a canvas element (reads `canvas`) and a nested mobile-backdrop `if`
+   (reads `mobileOpen`). Each fragment child is decomposed on its own, so the
+   backdrop toggle re-runs only its own View.tracked and leaves the canvas (and
+   its content leaf) in place. A regression guard: before fragments were recursed
+   into, the whole fragment collapsed into one coarse thunk and toggling the panel
+   rebuilt every sibling. */
+module Workspace = {
+  @xote.component
+  let make = () => {
+    <>
+      <div id="ws-canvas"> {Signal.get(canvas)} </div>
+      {if Signal.get(mobileOpen) {
+        <div id="ws-backdrop" />
+      } else {
+        View.null()
+      }}
+    </>
+  }
+}
+
+/* Case 17: bare children *directly* in a fragment return (no wrapping element).
+   A dropdown-style component whose labels sit next to a static anchor at the
+   fragment's top level — each bare read is coerced by View.child in place, so
+   the component needs no display:contents root just to make them type. */
+module DropdownFragment = {
+  @xote.component
+  let make = () => {
+    <>
+      <span id="df-anchor" />
+      {Signal.get(name)}
+      {() => `#${Signal.get(count)->Int.toString}`}
+    </>
+  }
+}
+
+/* Case 18: a control-flow *branch body* that is itself a fragment of bare labels
+   (a dropdown inlined into an `if`, not extracted into its own component). The
+   switch is tracked on the toggle, and the fragment branch is decomposed so its
+   bare labels are coerced — the anchor outside the `if` keeps its identity. */
+module MenuBranch = {
+  @xote.component
+  let make = () => {
+    <div id="mb-host">
+      <span id="mb-anchor" />
+      {if Signal.get(active) {
+        <>
+          {Signal.get(name)}
+          {View.text(" / ")}
+          {Signal.get(count)}
+        </>
+      } else {
+        View.null()
+      }}
+    </div>
+  }
+}
+
+/* Case 19: a signal read inside a *polymorphic variant* payload in attribute
+   position — `#tone(Signal.get(theme))`. Exercises the Pexp_variant case of
+   the eager-read traversal: before it was added, this class compiled to a
+   static, once-evaluated attribute with no error. */
+module VariantAttr = {
+  @xote.component
+  let make = () => {
+    <div
+      id="variant-attr"
+      class={switch #tone(Signal.get(theme)) {
+      | #tone(t) => "tone-" ++ t
+      }}>
+      <span id="va-anchor" />
+    </div>
+  }
+}
+
+/* Case 20: a switch whose ONLY signal read sits in a `when` guard. Guards are
+   evaluated eagerly alongside the scrutinee, so the switch must still become a
+   View.tracked region — before guards were visited by the eager-read traversal,
+   this compiled to a once-evaluated static branch with no error. */
+module GuardSwitch = {
+  @xote.component
+  let make = () => {
+    let v = 1
+    <div id="guard-switch">
+      {switch v {
+      | _ if Signal.get(active) => <span id="gs-on"> {View.text("on")} </span>
+      | _ => <span id="gs-off"> {View.text("off")} </span>
+      }}
+    </div>
+  }
+}
+
+/* Case 21: a component inside a signature-constrained module. The structure
+   traversal must descend through `module X: Sig = { … }` (Pmod_constraint) —
+   before it did, @xote.component was silently left unexpanded there. */
+module ConstrainedPanel: {
+  @res.jsxComponentProps
+  type props = {}
+  let make: props => View.node
+} = {
+  @xote.component
+  let make = () => {
+    <div id="constrained" class={Signal.get(theme)}> {Signal.get(count)} </div>
+  }
+}
+
+/* Case 22: a block expression (`{let … ; <span/>}`) in node position. The tail
+   JSX must keep fine-grained leaves — before blocks were recursed into, the
+   whole block collapsed into one coarse View.child thunk that rebuilt the
+   subtree (and lost element identity) on every dependency change. */
+module LetBlockChild = {
+  @xote.component
+  let make = () => {
+    <div id="lb-host">
+      {
+        let label = "L"
+        <span id="lb-span" class={Signal.get(theme)}> {View.text(label)} </span>
+      }
+    </div>
+  }
+}
+
+/* Cases 23/24: user-component props. A scalar prop that eagerly reads a signal
+   is passed through untouched — a deliberate one-shot read into the component's
+   typed props record (thunking it would be a type error; pass the signal itself
+   for a reactive prop). A prop whose value is itself JSX is node position, so
+   its own reactive leaves are decomposed and stay fine-grained. */
+module TitleCard = {
+  @xote.component
+  let make = (~label: string, ~header: View.node) => {
+    <div id="title-card">
+      <em id="tc-label"> {View.text(label)} </em>
+      {header}
+    </div>
+  }
+}
+
+module UseTitleCard = {
+  @xote.component
+  let make = () => {
+    <TitleCard
+      label={Signal.get(name)}
+      header={<span id="tc-header" class={Signal.get(theme)} />}
+    />
+  }
+}
+
+/* Case 25: shadowing removes a reactive helper. `toneClass` (top level) eagerly
+   reads a signal, but the local rebind below is peek-based — the rebind drops
+   the name from the reactive-helper set, so `class={toneClass()}` is left as a
+   plain, intentionally-static one-shot string. */
+let toneClass = () => Signal.get(active) ? "on" : "off"
+module PeekShadow = {
+  @xote.component
+  let make = () => {
+    let toneClass = () => Signal.peek(active) ? "peek-on" : "peek-off"
+    <div id="peek-shadow" class={toneClass()}> <span id="ps-anchor" /> </div>
+  }
+}
+
+/* Case 26: a bare mapped-list child — `{Signal.get(items)->Array.map(…)}`. The
+   eager read is thunked and View.child re-coerces the *array* result on every
+   run (an array-returning thunk must not lock into reactive-text mode). */
+module MappedList = {
+  @xote.component
+  let make = () => {
+    <ul id="mapped-list">
+      {Signal.get(items)->Array.map(item => <li class="ml-item"> {View.text(item)} </li>)}
+    </ul>
+  }
+}
+
+/* Case 20: control flow on a *plain* condition (a bool prop or local, no signal
+   read anywhere in the condition). No View.tracked is needed since the
+   structure cannot change, but the branches are still node position: their bare
+   children must be coerced. Before the branches were decomposed on this path,
+   `{if flag { <b> {"yes"} </b> } else { … }}` failed to compile with
+   "This has type: string", pointing at the literal rather than the
+   conditional. */
+module StaticBranch = {
+  @xote.component
+  let make = (~flag: bool) =>
+    <div id="static-branch">
+      {if flag {
+        <b id="sb-yes"> {"yes"} </b>
+      } else {
+        <i id="sb-no"> {"no"} </i>
+      }}
+      {flag ? "on" : "off"}
+    </div>
+}
+
+/* Case 21: a plain-condition branch that also holds a reactive leaf. The
+   conditional itself is built once; the leaf inside keeps its own reactive
+   scope, so changing the signal updates the class without rebuilding. */
+module StaticBranchReactiveLeaf = {
+  @xote.component
+  let make = (~flag: bool) =>
+    <div id="sbrl">
+      {if flag {
+        <b id="sbrl-tag" class={Signal.get(theme)}> {Signal.get(name)} </b>
+      } else {
+        <i> {"none"} </i>
+      }}
+    </div>
+}
+
+/* Case 22: bare children inside a *render callback*. A prop whose value is a
+   function returning JSX (View.For/Value/Maybe's `render`, or any user
+   component's callback) is node position once applied, but it is not itself
+   JSX, so the traversal used to stop at the callback boundary: nothing inside
+   was decomposed and `<span> {item.author} </span>` failed to compile with
+   "This has type: string". List rendering is written this way, so the shape is
+   everywhere. The reactive leaf below also proves decomposition really happens
+   inside the callback rather than the body being left alone. */
+type row = {id: string, author: string}
+let rows = Signal.make([{id: "r1", author: "Ada"}, {id: "r2", author: "Bo"}])
+
+module CallbackRows = {
+  @xote.component
+  let make = () =>
+    <ul id="cb-rows">
+      <View.For
+        each={MaybeSignal.reactive(rows)}
+        by={row => row.id}
+        render={row =>
+          <li class={Signal.get(theme)}>
+            <span class="author"> {row.author} </span>
+            <span> {" · "} </span>
+            {Signal.get(count)}
+          </li>}
+      />
+    </ul>
+}
+
+/* Case 23: node-taking runtime helpers called as plain functions. An explicit
+   `View.tracked(() => …)` or `View.each(xs, x => …)` is an ordinary
+   application, not JSX, so the traversal used to stop at the call: bare
+   children inside the callback were never coerced, even though the identical
+   markup works when the ppx emits `View.tracked` itself for an `if`/`switch`.
+   The callback body is node position, so it is decomposed like any other. */
+module HelperCallbacks = {
+  @xote.component
+  let make = () =>
+    <div id="helper-callbacks">
+      {View.tracked(() =>
+        if Signal.get(active) {
+          <p id="hc-on" class={Signal.get(theme)}> {Signal.get(name)} </p>
+        } else {
+          <p id="hc-off"> {"inactive"} </p>
+        }
+      )}
+      {View.each(labels, label => <span class="hc-item"> {label} </span>)}
+    </div>
+}
+
+/* Case 24: JSX reached through something other than a child slot. Any JSX the
+   component's markup contains is node position, however it is nested: inside an
+   array, an application (including the pipe form), a `try`, or bound to a local
+   name. Special-casing containers one at a time kept missing the next one, so
+   the traversal now walks the whole expression. */
+module NestedShapes = {
+  @xote.component
+  let make = () => {
+    /* JSX bound to a local name, and a local helper returning JSX */
+    let heading = <h4 id="ns-heading"> {"Nested"} </h4>
+    let item = (label: string) => <li class={Signal.get(theme)}> {label} </li>
+
+    <div id="nested-shapes">
+      {heading}
+      {View.fragment([<span id="ns-arr"> {"array"} </span>])}
+      {View.fragment(["a", "b"]->Array.map(a => <em class="ns-map"> {a} </em>))}
+      <ul> {View.fragment([item("one"), item("two")])} </ul>
+    </div>
+  }
+}
+
+/* Case 25: a plain helper function that returns markup — a component in all but
+   name. In a file that opts in (it contains an @xote.component), helper bodies
+   are decomposed like inline markup: bare children are coerced and reads become
+   leaves, so a helper needs no value primitives and no manual thunks. */
+let helperButton = (label: string) =>
+  <button id="helper-btn" class={Signal.get(theme)}> {label} </button>
+
+module HelperHost = {
+  @xote.component
+  let make = () => <div id="helper-host"> {helperButton("Press")} </div>
+}
+
+/* Case 26: `MaybeSignal.get` is a tracked read exactly like `Signal.get`, and
+   so is `Prop.get` (its deprecated alias). Reading through the static-or-
+   reactive wrapper subscribes just the same, so these leaves must be thunked. */
+let maybeName: MaybeSignal.t<string> = MaybeSignal.reactive(name)
+let maybeTheme: MaybeSignal.t<string> = MaybeSignal.reactive(theme)
+
+module MaybeSignalRead = {
+  @xote.component
+  let make = () =>
+    <p id="maybe-signal" class={MaybeSignal.get(maybeTheme)}> {MaybeSignal.get(maybeName)} </p>
+}
+
+/* Case 27: a reactive helper reached through a module *in this file*. The ppx
+   walks the module body, so `Counter.doubled()` is a read; `Counter.plain(…)`
+   is not, and stays a plain static value. */
+module Counter = {
+  let doubled = () => Signal.get(count) * 2
+  let plain = (n: int) => n + 1
+}
+
+module ModuleHelper = {
+  @xote.component
+  let make = () =>
+    <p id="module-helper" class={Counter.doubled() > 0 ? "positive" : "zero"}>
+      {Counter.doubled()}
+    </p>
+}
+
+/* Case 28: the hidden read. `Store` lives in another file, so the ppx sees only
+   a call it cannot resolve and cannot know a signal is read behind it. Both
+   leaves are wrapped in `View.probe`, which reports them at runtime instead of
+   rendering a frozen value in silence. */
+module Hidden = {
+  @xote.component
+  let make = () =>
+    <p id="hidden-read" class={Store.themeClass()}> {Store.waitingCount()} </p>
+}
+
+/* Case 28b: the same indirection in a *condition*. A read hidden in the
+   scrutinee freezes the whole branch, so untracked control flow probes it. */
+module HiddenBranch = {
+  @xote.component
+  let make = () =>
+    <div id="hidden-branch">
+      {if Store.isBusy() {
+        <span id="hb-busy"> {"busy"} </span>
+      } else {
+        <span id="hb-idle"> {"idle"} </span>
+      }}
+    </div>
+}
+
+/* Case 29: the probe must not cry wolf. An unresolvable call that reads no
+   signal is a perfectly ordinary static value — no warning, no reactivity, and
+   `View.probe` returns it untouched. */
+module HiddenClean = {
+  @xote.component
+  let make = () =>
+    <p id="hidden-clean" class={Store.title("row")}> {Counter.plain(41)} </p>
+}

--- a/ppx/example/src/Demo.res
+++ b/ppx/example/src/Demo.res
@@ -7,6 +7,7 @@ let theme = Signal.make("light")
 let count = Signal.make(0)
 let mobileOpen = Signal.make(false)
 let canvas = Signal.make("canvas-a")
+let items = Signal.make(["a", "b"])
 module S = Signal
 
 /* Every case is an @xote.component: one annotation derives props (it emits
@@ -251,5 +252,119 @@ module MenuBranch = {
         View.null()
       }}
     </div>
+  }
+}
+
+/* Case 19: a signal read inside a *polymorphic variant* payload in attribute
+   position — `#tone(Signal.get(theme))`. Exercises the Pexp_variant case of
+   the eager-read traversal: before it was added, this class compiled to a
+   static, once-evaluated attribute with no error. */
+module VariantAttr = {
+  @xote.component
+  let make = () => {
+    <div
+      id="variant-attr"
+      class={switch #tone(Signal.get(theme)) {
+      | #tone(t) => "tone-" ++ t
+      }}>
+      <span id="va-anchor" />
+    </div>
+  }
+}
+
+/* Case 20: a switch whose ONLY signal read sits in a `when` guard. Guards are
+   evaluated eagerly alongside the scrutinee, so the switch must still become a
+   View.tracked region — before guards were visited by the eager-read traversal,
+   this compiled to a once-evaluated static branch with no error. */
+module GuardSwitch = {
+  @xote.component
+  let make = () => {
+    let v = 1
+    <div id="guard-switch">
+      {switch v {
+      | _ if Signal.get(active) => <span id="gs-on"> {View.text("on")} </span>
+      | _ => <span id="gs-off"> {View.text("off")} </span>
+      }}
+    </div>
+  }
+}
+
+/* Case 21: a component inside a signature-constrained module. The structure
+   traversal must descend through `module X: Sig = { … }` (Pmod_constraint) —
+   before it did, @xote.component was silently left unexpanded there. */
+module ConstrainedPanel: {
+  @res.jsxComponentProps
+  type props = {}
+  let make: props => View.node
+} = {
+  @xote.component
+  let make = () => {
+    <div id="constrained" class={Signal.get(theme)}> {Signal.get(count)} </div>
+  }
+}
+
+/* Case 22: a block expression (`{let … ; <span/>}`) in node position. The tail
+   JSX must keep fine-grained leaves — before blocks were recursed into, the
+   whole block collapsed into one coarse View.child thunk that rebuilt the
+   subtree (and lost element identity) on every dependency change. */
+module LetBlockChild = {
+  @xote.component
+  let make = () => {
+    <div id="lb-host">
+      {
+        let label = "L"
+        <span id="lb-span" class={Signal.get(theme)}> {View.text(label)} </span>
+      }
+    </div>
+  }
+}
+
+/* Cases 23/24: user-component props. A scalar prop that eagerly reads a signal
+   is passed through untouched — a deliberate one-shot read into the component's
+   typed props record (thunking it would be a type error; pass the signal itself
+   for a reactive prop). A prop whose value is itself JSX is node position, so
+   its own reactive leaves are decomposed and stay fine-grained. */
+module TitleCard = {
+  @xote.component
+  let make = (~label: string, ~header: View.node) => {
+    <div id="title-card">
+      <em id="tc-label"> {View.text(label)} </em>
+      {header}
+    </div>
+  }
+}
+
+module UseTitleCard = {
+  @xote.component
+  let make = () => {
+    <TitleCard
+      label={Signal.get(name)}
+      header={<span id="tc-header" class={Signal.get(theme)} />}
+    />
+  }
+}
+
+/* Case 25: shadowing removes a reactive helper. `toneClass` (top level) eagerly
+   reads a signal, but the local rebind below is peek-based — the rebind drops
+   the name from the reactive-helper set, so `class={toneClass()}` is left as a
+   plain, intentionally-static one-shot string. */
+let toneClass = () => Signal.get(active) ? "on" : "off"
+module PeekShadow = {
+  @xote.component
+  let make = () => {
+    let toneClass = () => Signal.peek(active) ? "peek-on" : "peek-off"
+    <div id="peek-shadow" class={toneClass()}> <span id="ps-anchor" /> </div>
+  }
+}
+
+/* Case 26: a bare mapped-list child — `{Signal.get(items)->Array.map(…)}`. The
+   eager read is thunked and View.child re-coerces the *array* result on every
+   run (an array-returning thunk must not lock into reactive-text mode). */
+module MappedList = {
+  @xote.component
+  let make = () => {
+    <ul id="mapped-list">
+      {Signal.get(items)->Array.map(item => <li class="ml-item"> {View.text(item)} </li>)}
+    </ul>
   }
 }

--- a/ppx/example/src/Golden.res
+++ b/ppx/example/src/Golden.res
@@ -1,0 +1,72 @@
+/* Traversal-reach cases for the golden assertions in ../golden.mjs.
+
+   Demo.res + verify.mjs prove *behaviour* (leaves are fine-grained, elements
+   keep identity). They cannot prove *reach*: JSX the traversal never visits
+   still compiles and still renders — just statically, and without even a
+   `View.probe` to report it. That is invisible to a runtime test and is how the
+   same bug shipped three times ("an expression that ends up in node position
+   was not reached by the traversal").
+
+   So these cases are asserted on the *emitted JavaScript* instead. Each uses its
+   own signal so an assertion can name exactly one binding, and every case has a
+   matching negative assertion — proving the leaf is reactive is only half the
+   claim, the other half is that static things stayed static. */
+
+let themeArray = Signal.make("light")
+let themeOption = Signal.make("light")
+let themeTuple = Signal.make("light")
+let themeLambda = Signal.make("light")
+let themeDirect = Signal.make("light")
+let themeThunked = Signal.make("light")
+let open_ = Signal.make(false)
+
+/* --- reach: JSX one container down from the binding ----------------------
+
+   These deliberately use `View.text` rather than a bare `{…}` child, so they
+   compile whether or not the traversal reaches them. That matters: a bare child
+   here would make an unreached binding a *compile error*, which would mask the
+   silent half of the bug behind the loud half. As written, an unreached binding
+   still builds and still renders — and the golden assertion is the only thing
+   that notices the attribute went static. That is the failure mode being
+   guarded. (The loud half is covered by the bare children further down.) */
+
+/* An array of nodes — the single most ordinary way to build a list of markup. */
+let rowsInArray = [<li class={Signal.get(themeArray)}> {View.text("row")} </li>]
+
+/* Optional markup. */
+let headerInOption = Some(<h1 class={Signal.get(themeOption)}> {View.text("title")} </h1>)
+
+/* A tuple of nodes. */
+let cellsInTuple = (
+  <th class={Signal.get(themeTuple)}> {View.text("a")} </th>,
+  <th> {View.text("b")} </th>,
+)
+
+/* JSX inside a nested lambda that is *not* itself a render callback: the
+   binding's own body is the `Array.map` call, not JSX. */
+let rowsFromLambda = xs =>
+  Array.map(xs, x => <li class={Signal.get(themeLambda)}> {View.text(x)} </li>)
+
+/* --- control: the binding that already worked ---------------------------- */
+
+let directJsx = <p class={Signal.get(themeDirect)}> {"direct"} </p>
+
+/* --- negative controls: things that must NOT be rewritten ---------------- */
+
+/* A static attribute stays a plain string — no spurious computed attribute. */
+let staticOnly = [<span class="static-class"> {View.text("plain")} </span>]
+
+/* An explicit thunk is already reactive and must not be double-wrapped. */
+let preThunked = [<span class={() => Signal.get(themeThunked)}> {View.text("thunked")} </span>]
+
+@xote.component
+let make = () =>
+  <div>
+    {View.fragment(rowsInArray)}
+    /* control flow still tracks only its condition */
+    {if Signal.get(open_) {
+      <span class="open"> {"open"} </span>
+    } else {
+      View.null()
+    }}
+  </div>

--- a/ppx/example/src/Store.res
+++ b/ppx/example/src/Store.res
@@ -1,0 +1,16 @@
+/* A plain module in *another file*. The ppx only ever sees the call at the use
+   site (`Store.waitingCount()`), never this body, so a signal read in here is
+   the one form detection cannot follow. Used by Demo's hidden-read cases:
+   `waitingCount`/`themeClass`/`isBusy` read signals; `title` does not, and must
+   not be reported. */
+
+let waiting = Signal.make(4)
+let busy = Signal.make(false)
+let tone = Signal.make("calm")
+
+let waitingCount = () => Signal.get(waiting)
+let themeClass = () => "tone-" ++ Signal.get(tone)
+let isBusy = () => Signal.get(busy)
+
+/* No signal read at all — the probe must stay silent on this one. */
+let title = (prefix: string) => prefix ++ "!"

--- a/ppx/example/verify.mjs
+++ b/ppx/example/verify.mjs
@@ -1,0 +1,548 @@
+// Runtime verification that the @xote.component fine-grained ppx produces
+// reactive *leaves* (not a wholesale rebuild). The key assertions tag DOM elements with
+// a marker property, mutate signals, then check the marker survives — proving
+// the element kept its identity and was not recreated.
+//
+//   sh ../build.sh && npm run build && npm run verify
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'https://xote.test/' });
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Node = dom.window.Node;
+
+const View = await import('xote/src/View.res.mjs');
+const Signal = await import('xote/src/Signal.res.mjs');
+const Demo = await import('./src/Demo.res.mjs');
+const Store = await import('./src/Store.res.mjs');
+
+// `View.probe` reports hidden reads through console.warn. Capture from the very
+// first mount so the hidden-read section can assert both what was reported and
+// what was not — a false positive is as much a failure as a missed read.
+const warnings = [];
+const realWarn = console.warn;
+console.warn = (...args) => { warnings.push(args.join(' ')); };
+
+let pass = 0, fail = 0;
+const check = (name, cond) => {
+  if (cond) { pass++; console.log('  ✓', name); }
+  else { fail++; console.log('  ✗', name); }
+};
+const mount = (factory) => {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  View.mount(factory(), host);
+  return host.firstElementChild;
+};
+
+// --- Fine-grained leaves: attribute + text update, structure preserved -----
+// Cases 1/3/4/5/6 all read `active` (class) and `name` (text), each via a
+// different read form. If the ppx failed to recognise the read, the leaf
+// would be static and the assertions below would fail.
+const c = (m) => () => m({}); // call a propless @xote.component
+const forms = [
+  ['card    (Signal.get direct)',       c(Demo.Card.make),        '#card',        'Hello, Grace'],
+  ['aliased (let g = Signal.get)',      c(Demo.Aliased.make),     '#aliased',     'Hi, Grace'],
+  ['modAlias(module S = Signal)',       c(Demo.ModAliased.make),  '#mod-aliased', 'Yo, Grace'],
+  ['open    (open Signal; get)',        c(Demo.OpenAliased.make), '#open-aliased','Hey, Grace'],
+  ['piped   (active->Signal.get)',      c(Demo.Piped.make),       '#piped',       'Pipe, Grace'],
+];
+
+console.log('fine-grained reactive leaves (each read form):');
+const mounted = forms.map(([, factory]) => mount(factory));
+mounted.forEach((el) => { el.__marker = 'ORIGINAL'; });
+check('all start class "off"', mounted.every((el) => el.className === 'off'));
+
+Signal.set(Demo.active, true);
+Signal.set(Demo.name, 'Grace');
+
+forms.forEach(([label, , sel, expectedText], i) => {
+  const el = document.querySelector(sel);
+  check(`${label}: class -> "on"`, el.className === 'on');
+  check(`${label}: text updated`, el.textContent.includes(expectedText));
+  check(`${label}: element kept identity (not rebuilt)`, mounted[i].__marker === 'ORIGINAL' && el === mounted[i]);
+});
+
+// Case 1 also has a static sibling span that must never be touched.
+check('card static <span> class intact', document.querySelector('#card .static-label') !== null);
+check('card static label text intact', document.querySelector('#card').textContent.includes('Name:'));
+
+// --- @xote.component: derives props AND fine-grains the returned JSX --------
+console.log('@xote.component (props derived + fine-grained):');
+const labeled = mount(() => Demo.Labeled.make({ label: 'Hits' }));
+labeled.__marker = 'ORIGINAL';
+check('prop rendered (label "Hits")', labeled.textContent.includes('Hits:'));
+check('reads current signal via props form', labeled.textContent.includes('Grace')); // name already Grace
+check('class is reactive ("on")', labeled.className === 'on');
+
+Signal.set(Demo.active, false);
+Signal.set(Demo.name, 'Ada');
+check('class leaf updated to "off"', document.querySelector('#labeled').className === 'off');
+check('text leaf updated (Ada)', document.querySelector('#labeled').textContent.includes('Hits: Ada'));
+check('component element kept identity (fine-grained, no rebuild)', document.querySelector('#labeled').__marker === 'ORIGINAL');
+
+// Pre-existing () => … thunks must not be double-wrapped: class stays a real
+// string ("off"/"on"), not a function. active is currently false, name "Ada".
+console.log('pre-existing thunks (not double-wrapped):');
+const pre = mount(() => Demo.PreThunked.make({}));
+check('class is a plain string, not double-thunked', pre.className === 'off');
+check('text thunk resolves', pre.textContent.includes('T: Ada'));
+Signal.set(Demo.active, true);
+Signal.set(Demo.name, 'Zoe');
+check('class thunk still reactive ("on")', pre.className === 'on');
+check('text thunk still reactive (Zoe)', pre.textContent.includes('T: Zoe'));
+
+// A Prop.reactive(Computed) class reads only inside a lambda -> not thunked;
+// the class must be a real string and stay reactive. active is currently true.
+console.log('already-reactive value (Prop.reactive not thunked):');
+const pw = mount(() => Demo.PropWrapped.make({}));
+check('Prop.reactive class is a real string ("on")', pw.className === 'on');
+Signal.set(Demo.active, false);
+check('Prop.reactive class still reactive ("off")', document.querySelector('#prop-wrapped').className === 'off');
+
+// A read hidden behind a local helper (statusClass) must still be reactive —
+// the helper is tracked, so class={statusClass()} is thunked, not static.
+// active is currently false.
+//
+// NOTE: only *local* helpers are covered. A read behind an imported /
+// cross-module helper is invisible to the (single-file) PPX and compiles to a
+// static attribute with no error — a limitation this jsdom suite cannot catch
+// structurally, since the missed read produces valid code that simply never
+// updates. See ppx/README.md "Known limitations"; the escape hatch is to wrap
+// the value in `() =>` yourself.
+console.log('helper-hidden read (local reactive helper tracked):');
+const hh = mount(() => Demo.HelperHidden.make({}));
+check('helper class reactive ("off")', hh.className === 'off');
+Signal.set(Demo.active, true);
+check('helper class updates ("on") — not a silent static bug', document.querySelector('#helper-hidden').className === 'on');
+
+// --- Structural swap via View.tracked, outer element preserved -------------
+console.log('panel (structural swap, outer element preserved):');
+const panel = mount(c(Demo.Panel.make));
+panel.__pmarker = 'PANEL';
+check('initial Loading <span>', panel.querySelector('span') !== null && panel.textContent.includes('Loading'));
+
+Signal.set(Demo.status, { TAG: 'Ready', _0: 'Done!' });
+check('swapped to <strong>', panel.querySelector('strong') !== null);
+check('shows "Done!"', panel.textContent.includes('Done!'));
+check('outer DIV kept identity (only inner region swapped)', panel.__pmarker === 'PANEL');
+
+// --- Branch leaf stays fine-grained (item 2) -------------------------------
+// The switch tracks only `status`; the Ready branch's class reads `theme`.
+// Changing `theme` must update the class leaf WITHOUT re-running the switch —
+// i.e. the <strong> keeps its identity. (Before branch decomposition, `theme`
+// was read eagerly during the tracked render, so the whole branch rebuilt.)
+console.log('switchLeaf (branch leaf reacts without re-running the switch):');
+Signal.set(Demo.status, { TAG: 'Ready', _0: 'Ready!' }); // select the Ready branch
+const outer = mount(c(Demo.SwitchLeaf.make));
+outer.__omarker = 'OUTER';
+const strong = outer.querySelector('#ready-strong');
+strong.__marker = 'STRONG';
+check('initial class = theme "light"', strong.className === 'light');
+
+Signal.set(Demo.theme, 'dark');
+check('class leaf updated to "dark"', outer.querySelector('#ready-strong').className === 'dark');
+check('<strong> kept identity (switch did NOT re-run)', outer.querySelector('#ready-strong').__marker === 'STRONG');
+check('outer div kept identity', outer.__omarker === 'OUTER');
+
+// Structural swap still works: changing the scrutinee rebuilds the branch.
+Signal.set(Demo.status, 'Loading');
+check('scrutinee change still swaps to <span>',
+  outer.querySelector('span') !== null && outer.querySelector('#ready-strong') === null);
+
+// --- Bare children coerced by View.child (no <View.Int>/<View.Text> needed) --
+// <div>{Signal.get(count)}</div> — a bare *reactive scalar* becomes reactive
+// text; the <div> keeps its identity across the change (fine-grained leaf).
+console.log('bare reactive int child (View.child):');
+Signal.set(Demo.count, 0);
+const bi = mount(() => Demo.BareInt.make({}));
+bi.__marker = 'BI';
+check('bare int renders "0"', bi.textContent === '0');
+Signal.set(Demo.count, 7);
+check('bare int updates to "7"', document.querySelector('#bare-int').textContent === '7');
+check('bare int <div> kept identity (reactive leaf, not rebuilt)', document.querySelector('#bare-int').__marker === 'BI');
+
+// <div><span>…</span>{Signal.get(name)}</div> — bare reactive string alongside a
+// static sibling; only the text leaf reacts, the <span> keeps its identity.
+console.log('bare reactive string child + static sibling:');
+Signal.set(Demo.name, 'Ada');
+const bs = mount(() => Demo.BareString.make({}));
+const bsSpan = bs.querySelector('.lbl');
+bsSpan.__marker = 'SPAN';
+check('bare string shows "n: Ada"', bs.textContent === 'n: Ada');
+Signal.set(Demo.name, 'Bo');
+check('bare string updates to "n: Bo"', document.querySelector('#bare-string').textContent === 'n: Bo');
+check('static <span> sibling kept identity', document.querySelector('#bare-string .lbl').__marker === 'SPAN');
+
+// <div>{"literal"}</div> — a bare *static* scalar (a type error before View.child)
+// becomes a static text node.
+console.log('bare static scalar child:');
+const bst = mount(() => Demo.BareStatic.make({}));
+check('bare static renders "literal"', bst.textContent === 'literal');
+
+// <div>{View.text("noded")}</div> — a bare child that is *already a node* passes
+// through View.child untouched.
+console.log('bare already-a-node child (passthrough):');
+const bn = mount(() => Demo.BareNode.make({}));
+check('bare node renders "noded"', bn.textContent === 'noded');
+
+// Control flow with *scalar* branches: still a tracked structural swap on
+// `status`, but each scalar branch is coerced by View.child (no value primitive).
+console.log('scalar switch branches (tracked + View.child):');
+Signal.set(Demo.status, 'Loading');
+const ss = mount(() => Demo.ScalarSwitch.make({}));
+ss.__marker = 'SS';
+check('scalar switch shows "…loading"', ss.textContent === '…loading');
+Signal.set(Demo.status, { TAG: 'Ready', _0: 'done' });
+check('scalar switch swaps to "done"', document.querySelector('#scalar-switch').textContent === 'done');
+check('scalar switch outer <div> kept identity', document.querySelector('#scalar-switch').__marker === 'SS');
+
+// --- Fragment body: nested regions stay independent ------------------------
+// A make whose body is a <>…</> fragment with two reactive regions: a canvas
+// element and a mobile-backdrop `if`. Each fragment child is decomposed on its
+// own, so toggling the backdrop must NOT rebuild the canvas. (Regression: before
+// fragments were recursed into, the whole fragment was one coarse thunk and a
+// panel toggle rebuilt every sibling, losing DOM state.)
+console.log('fragment body: independent reactive regions (no coarse collapse):');
+Signal.set(Demo.mobileOpen, false);
+Signal.set(Demo.canvas, 'canvas-a');
+const wsHost = document.createElement('div');
+document.body.appendChild(wsHost);
+View.mount(Demo.Workspace.make({}), wsHost);
+const canvasEl = wsHost.querySelector('#ws-canvas');
+canvasEl.__marker = 'CANVAS';
+check('canvas renders "canvas-a"', canvasEl.textContent === 'canvas-a');
+check('backdrop absent initially', wsHost.querySelector('#ws-backdrop') === null);
+
+Signal.set(Demo.mobileOpen, true);
+check('backdrop appears on panel toggle', wsHost.querySelector('#ws-backdrop') !== null);
+check('canvas kept identity across panel toggle (NOT rebuilt)', wsHost.querySelector('#ws-canvas').__marker === 'CANVAS');
+
+Signal.set(Demo.canvas, 'canvas-b');
+check('canvas content updates on its own', wsHost.querySelector('#ws-canvas').textContent === 'canvas-b');
+check('canvas still same element after its own update', wsHost.querySelector('#ws-canvas').__marker === 'CANVAS');
+
+Signal.set(Demo.mobileOpen, false);
+check('backdrop removed on toggle off', wsHost.querySelector('#ws-backdrop') === null);
+check('canvas kept identity across second toggle (regions independent)', wsHost.querySelector('#ws-canvas').__marker === 'CANVAS');
+
+// --- Bare children directly in a fragment return ---------------------------
+// A dropdown-style fragment whose labels sit at the top level next to a static
+// anchor. Each bare read must be coerced in place (no display:contents root).
+console.log('bare children directly in a fragment return:');
+Signal.set(Demo.name, 'Ada');
+Signal.set(Demo.count, 3);
+const dfHost = document.createElement('div');
+document.body.appendChild(dfHost);
+View.mount(Demo.DropdownFragment.make({}), dfHost);
+const dfAnchor = dfHost.querySelector('#df-anchor');
+dfAnchor.__marker = 'ANCHOR';
+check('fragment bare label renders (name)', dfHost.textContent.includes('Ada'));
+check('fragment bare thunk renders (#count)', dfHost.textContent.includes('#3'));
+Signal.set(Demo.name, 'Bo');
+Signal.set(Demo.count, 9);
+check('fragment bare label updates', dfHost.textContent.includes('Bo'));
+check('fragment bare thunk updates', dfHost.textContent.includes('#9'));
+check('fragment static anchor kept identity', dfHost.querySelector('#df-anchor').__marker === 'ANCHOR');
+
+// --- Fragment as a control-flow branch body --------------------------------
+// The dropdown's labels live inside CanvasMenu's `{if …}` as a fragment, not in
+// their own component. The branch is decomposed so its bare labels are coerced;
+// the anchor outside the `if` keeps its identity across toggles.
+console.log('fragment as a control-flow branch body:');
+Signal.set(Demo.active, false);
+Signal.set(Demo.name, 'Ada');
+Signal.set(Demo.count, 5);
+const mb = mount(() => Demo.MenuBranch.make({}));
+const mbAnchor = mb.querySelector('#mb-anchor');
+mbAnchor.__marker = 'MB';
+check('branch closed: no labels yet', !mb.textContent.includes('Ada'));
+Signal.set(Demo.active, true);
+check('branch open: bare label coerced (name)', document.querySelector('#mb-host').textContent.includes('Ada'));
+check('branch open: bare int coerced (count)', document.querySelector('#mb-host').textContent.includes('5'));
+check('anchor outside the if kept identity', document.querySelector('#mb-anchor').__marker === 'MB');
+Signal.set(Demo.active, false);
+check('branch closed again: labels gone', !document.querySelector('#mb-host').textContent.includes('Ada'));
+check('anchor still same element after toggle', document.querySelector('#mb-anchor').__marker === 'MB');
+
+// --- Poly-variant payload in attribute position -----------------------------
+// `class={switch #tone(Signal.get(theme)) { ... }}`: the read sits inside a
+// polymorphic variant payload (Pexp_variant), which the eager-read traversal
+// must descend into — previously this attribute silently stayed static.
+console.log('poly-variant payload in attribute position:');
+Signal.set(Demo.theme, 'light');
+const vaHost = document.createElement('div');
+document.body.appendChild(vaHost);
+View.mount(Demo.VariantAttr.make({}), vaHost);
+const vaEl = vaHost.querySelector('#variant-attr');
+vaEl.__marker = 'VA';
+check('variant payload read renders initial class', vaEl.className === 'tone-light');
+Signal.set(Demo.theme, 'dark');
+check('variant payload read is reactive (class updates)', vaHost.querySelector('#variant-attr').className === 'tone-dark');
+check('element kept identity across class update', vaHost.querySelector('#variant-attr').__marker === 'VA');
+
+// --- Guard-only reads make the switch tracked -------------------------------
+// `switch v { | _ if Signal.get(active) => … }`: the ONLY read is in the
+// `when` guard. Guards are evaluated eagerly, so the switch must be tracked —
+// previously the guard was invisible and the branch was static forever.
+console.log('switch guard read (tracked via when-guard):');
+Signal.set(Demo.active, true);
+const gs = mount(() => Demo.GuardSwitch.make({}));
+gs.__marker = 'GS';
+check('guard true renders "on" branch', gs.querySelector('#gs-on') !== null);
+Signal.set(Demo.active, false);
+check('guard read is tracked: swaps to "off" branch', document.querySelector('#guard-switch #gs-off') !== null);
+check('guard switch outer div kept identity', document.querySelector('#guard-switch').__marker === 'GS');
+
+// --- Signature-constrained module still transformed -------------------------
+// `module ConstrainedPanel: Sig = { @xote.component … }`: the traversal must
+// descend through Pmod_constraint — previously the annotation was silently
+// left unexpanded there (static attrs, or a type error on bare children).
+console.log('component inside `module X: Sig = { … }`:');
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.count, 1);
+const cp = mount(() => Demo.ConstrainedPanel.make({}));
+cp.__marker = 'CP';
+check('constrained: reactive class renders', cp.className === 'light');
+check('constrained: bare int child renders', cp.textContent === '1');
+Signal.set(Demo.theme, 'dark');
+Signal.set(Demo.count, 2);
+check('constrained: class updates (transform ran under the constraint)', document.querySelector('#constrained').className === 'dark');
+check('constrained: bare child updates', document.querySelector('#constrained').textContent === '2');
+check('constrained: element kept identity', document.querySelector('#constrained').__marker === 'CP');
+
+// --- let-block child stays fine-grained -------------------------------------
+// `{let label = …; <span class={Signal.get(theme)}/>}` in node position: the
+// tail JSX keeps fine-grained leaves. Previously the whole block collapsed
+// into one coarse View.child thunk that rebuilt the span on every change.
+console.log('let-block in node position (fine-grained, identity kept):');
+Signal.set(Demo.theme, 'light');
+const lb = mount(() => Demo.LetBlockChild.make({}));
+const lbSpan = lb.querySelector('#lb-span');
+lbSpan.__marker = 'LB';
+check('let-block span renders with initial class', lbSpan.className === 'light');
+Signal.set(Demo.theme, 'dark');
+check('let-block class updates', lb.querySelector('#lb-span').className === 'dark');
+check('let-block span kept identity (no coarse rebuild)', lb.querySelector('#lb-span').__marker === 'LB');
+
+// --- User-component props ----------------------------------------------------
+// A scalar prop that eagerly reads a signal passes through untouched (a
+// deliberate one-shot read — previously the ppx thunked it into a baffling
+// type error). A JSX-valued prop is node position: its own leaves stay
+// reactive and keep identity.
+console.log('user-component props (one-shot scalars, reactive JSX values):');
+Signal.set(Demo.name, 'Ada');
+Signal.set(Demo.theme, 'light');
+const tc = mount(() => Demo.UseTitleCard.make({}));
+check('scalar prop rendered from one-shot read', tc.querySelector('#tc-label').textContent === 'Ada');
+const tcHeader = tc.querySelector('#tc-header');
+tcHeader.__marker = 'TCH';
+check('JSX-valued prop rendered with its reactive class', tcHeader.className === 'light');
+Signal.set(Demo.name, 'Bo');
+Signal.set(Demo.theme, 'dark');
+check('scalar prop is a deliberate one-shot read (stays "Ada")', tc.querySelector('#tc-label').textContent === 'Ada');
+check('JSX prop class updates (leaves decomposed inside the prop)', tc.querySelector('#tc-header').className === 'dark');
+check('JSX prop element kept identity', tc.querySelector('#tc-header').__marker === 'TCH');
+
+// --- peek + shadowing: rebound helper is dropped -----------------------------
+// `toneClass` is a reactive helper at top level, but the component rebinds it
+// to a peek-based one — the rebind drops it from the reactive-helper set, so
+// the attribute is a plain, intentionally static string.
+console.log('peek-based rebind drops the reactive helper:');
+Signal.set(Demo.active, true);
+const ps = mount(() => Demo.PeekShadow.make({}));
+check('peek class evaluated once ("peek-on")', ps.className === 'peek-on');
+Signal.set(Demo.active, false);
+check('peek class intentionally static (no update)', document.querySelector('#peek-shadow').className === 'peek-on');
+
+// --- Bare mapped-list child (array-returning thunk) --------------------------
+// `{Signal.get(items)->Array.map(…)}`: the eager read is thunked and the
+// thunk returns an *array* — View.child must re-coerce it per run, not lock
+// into reactive-text mode from the first value.
+console.log('bare mapped list child (array thunk re-coerced per run):');
+Signal.set(Demo.items, ['a', 'b']);
+const ml = mount(() => Demo.MappedList.make({}));
+ml.__marker = 'ML';
+check('mapped list renders items', ml.textContent === 'ab');
+check('mapped list renders real <li> elements', ml.querySelectorAll('li.ml-item').length === 2);
+Signal.set(Demo.items, ['a', 'b', 'c']);
+check('mapped list updates', document.querySelector('#mapped-list').textContent === 'abc');
+check('mapped list outer <ul> kept identity', document.querySelector('#mapped-list').__marker === 'ML');
+
+
+// --- Control flow on a plain (non-signal) condition -------------------------
+// The conditional is built once, but its branches are node position: bare
+// children inside them must still be coerced by View.child. This is the shape
+// that failed to compile before the branches were decomposed on this path.
+console.log('control flow on a plain condition:');
+const sbTrue = document.createElement('div');
+document.body.appendChild(sbTrue);
+View.mount(Demo.StaticBranch.make({ flag: true }), sbTrue);
+check('plain-cond branch renders bare literal child', sbTrue.querySelector('#sb-yes').textContent === 'yes');
+check('plain-cond ternary over strings renders', sbTrue.textContent.includes('on'));
+
+const sbFalse = document.createElement('div');
+document.body.appendChild(sbFalse);
+View.mount(Demo.StaticBranch.make({ flag: false }), sbFalse);
+check('plain-cond else branch renders bare literal child', sbFalse.querySelector('#sb-no').textContent === 'no');
+check('plain-cond ternary takes the else value', sbFalse.textContent.includes('off'));
+
+// A reactive leaf inside a statically-chosen branch stays fine-grained: the
+// branch element keeps its identity while the leaf updates.
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.name, 'Ada');
+const sbrl = document.createElement('div');
+document.body.appendChild(sbrl);
+View.mount(Demo.StaticBranchReactiveLeaf.make({ flag: true }), sbrl);
+const sbrlTag = sbrl.querySelector('#sbrl-tag');
+sbrlTag.__marker = 'SBRL';
+check('plain-cond branch leaf renders initial class', sbrlTag.className === 'light');
+check('plain-cond branch leaf renders bare signal read', sbrlTag.textContent.includes('Ada'));
+Signal.set(Demo.theme, 'dark');
+Signal.set(Demo.name, 'Bo');
+check('leaf class updates inside a plain-cond branch', sbrl.querySelector('#sbrl-tag').className === 'dark');
+check('leaf text updates inside a plain-cond branch', sbrl.querySelector('#sbrl-tag').textContent.includes('Bo'));
+check('branch element kept identity (built once, not rebuilt)', sbrl.querySelector('#sbrl-tag').__marker === 'SBRL');
+
+
+// --- Bare children inside a render callback ---------------------------------
+// `render={row => …}` is a function returning JSX: node position once applied,
+// but not JSX itself, so the traversal used to stop at the callback boundary.
+console.log('bare children inside a render callback:');
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.count, 7);
+const cb = mount(() => Demo.CallbackRows.make({}));
+const cbFirst = cb.querySelector('#cb-rows li');
+cbFirst.__marker = 'ROW1';
+check('callback bare child renders (author)', cb.textContent.includes('Ada'));
+check('callback bare literal renders (separator)', cb.textContent.includes('·'));
+check('callback bare signal read renders (count)', cb.textContent.includes('7'));
+check('callback leaf attribute rendered', cbFirst.className === 'light');
+// The leaves inside the callback are fine-grained: updating a signal they read
+// changes them in place instead of rebuilding the row.
+Signal.set(Demo.count, 8);
+check('callback bare signal read updates', document.querySelector('#cb-rows').textContent.includes('8'));
+Signal.set(Demo.theme, 'dark');
+check('callback leaf attribute updates', document.querySelector('#cb-rows li').className === 'dark');
+check('row kept identity across leaf updates', document.querySelector('#cb-rows li').__marker === 'ROW1');
+
+
+// --- Node-taking helpers called as plain functions --------------------------
+// `View.tracked(() => …)` / `View.each(xs, x => …)` are applications, not JSX,
+// so the traversal used to stop at the call and leave their callback bodies
+// undecomposed.
+console.log('bare children inside node-taking helper callbacks:');
+Signal.set(Demo.active, false);
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.name, 'Ada');
+const hc = mount(() => Demo.HelperCallbacks.make({}));
+check('tracked callback: else branch bare literal', hc.textContent.includes('inactive'));
+check('each callback: bare item rendered', hc.textContent.includes('one') && hc.textContent.includes('two'));
+Signal.set(Demo.active, true);
+const hcOn = document.querySelector('#hc-on');
+hcOn.__marker = 'HC';
+check('tracked callback: branch bare signal read', hcOn.textContent.includes('Ada'));
+check('tracked callback: branch leaf attribute', hcOn.className === 'light');
+// Leaves inside the tracked callback stay fine-grained: the element survives.
+Signal.set(Demo.name, 'Bo');
+Signal.set(Demo.theme, 'dark');
+check('tracked callback: bare read updates', document.querySelector('#hc-on').textContent.includes('Bo'));
+check('tracked callback: leaf attribute updates', document.querySelector('#hc-on').className === 'dark');
+check('tracked callback: element kept identity', document.querySelector('#hc-on').__marker === 'HC');
+
+
+// --- Plain helper functions returning markup --------------------------------
+// The file opts in via its @xote.component bindings, so helper bodies are
+// decomposed too: bare child coerced, class a reactive leaf.
+console.log('helper function returning markup:');
+Signal.set(Demo.theme, 'light');
+const hb = mount(() => Demo.HelperHost.make({}));
+const hbBtn = hb.querySelector('#helper-btn');
+hbBtn.__marker = 'HB';
+check('helper bare child rendered', hbBtn.textContent.includes('Press'));
+check('helper leaf attribute rendered', hbBtn.className === 'light');
+Signal.set(Demo.theme, 'dark');
+check('helper leaf attribute updates (reactive, not static)', document.querySelector('#helper-btn').className === 'dark');
+check('helper element kept identity', document.querySelector('#helper-btn').__marker === 'HB');
+
+// --- JSX reached through arrays, applications, pipes, local bindings --------
+console.log('JSX nested in non-child positions:');
+const ns = mount(() => Demo.NestedShapes.make({}));
+check('let-bound JSX renders bare child', ns.querySelector('#ns-heading').textContent.includes('Nested'));
+check('array literal inside View.fragment', ns.querySelector('#ns-arr').textContent.includes('array'));
+check('pipe + map callback decomposed', ns.querySelectorAll('.ns-map').length === 2);
+check('local helper items rendered', ns.textContent.includes('one') && ns.textContent.includes('two'));
+
+// --- MaybeSignal.get is a tracked read --------------------------------------
+// Reading through the static-or-reactive wrapper subscribes exactly like
+// Signal.get, so both leaves below must be reactive, not one-shot.
+console.log('MaybeSignal.get is a tracked read:');
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.name, 'Ada');
+const ms = mount(() => Demo.MaybeSignalRead.make({}));
+ms.__marker = 'MS';
+check('MaybeSignal.get attribute rendered', ms.className === 'light');
+check('MaybeSignal.get bare child rendered', ms.textContent.includes('Ada'));
+Signal.set(Demo.theme, 'dark');
+Signal.set(Demo.name, 'Bo');
+check('MaybeSignal.get attribute updates', document.querySelector('#maybe-signal').className === 'dark');
+check('MaybeSignal.get bare child updates', document.querySelector('#maybe-signal').textContent.includes('Bo'));
+check('MaybeSignal leaf kept element identity', document.querySelector('#maybe-signal').__marker === 'MS');
+
+// --- A reactive helper behind a same-file module -----------------------------
+console.log('same-file module helper is a tracked read:');
+Signal.set(Demo.count, 2);
+const mh = mount(() => Demo.ModuleHelper.make({}));
+mh.__marker = 'MH';
+check('module helper bare child rendered', mh.textContent.includes('4'));
+check('module helper attribute rendered', mh.className === 'positive');
+Signal.set(Demo.count, 0);
+check('module helper bare child updates', document.querySelector('#module-helper').textContent.trim() === '0');
+check('module helper attribute updates', document.querySelector('#module-helper').className === 'zero');
+check('module helper kept element identity', document.querySelector('#module-helper').__marker === 'MH');
+
+// --- Hidden reads: what detection cannot follow, reported at runtime ---------
+// `Store` is another file, so the ppx sees only a call it cannot resolve. The
+// leaf is wrapped in `View.probe`, which evaluates it inside a throwaway
+// computed and reports it if that computed subscribed to anything.
+console.log('hidden reads (an unresolvable call that does read a signal):');
+const hidden = mount(() => Demo.Hidden.make({}));
+check('hidden read still renders its initial value', hidden.textContent.includes('4'));
+check('hidden read attribute still renders', hidden.className === 'tone-calm');
+check('hidden read reported with its source location', warnings.some((w) => w.includes('Demo.res:525:54')));
+check('hidden read attribute reported', warnings.some((w) => w.includes('Demo.res:525:32')));
+check('warning names the fix', warnings.some((w) => w.includes('() => ...')));
+
+// This is precisely what the warning is for: the leaf is frozen at its first
+// value. Detection cannot fix it, so it has to say so.
+Signal.set(Store.waiting, 9);
+check('hidden read is indeed frozen (the failure the warning describes)', document.querySelector('#hidden-read').textContent.includes('4'));
+
+const hiddenBranch = mount(() => Demo.HiddenBranch.make({}));
+check('hidden condition renders a branch', hiddenBranch.querySelector('#hb-idle') !== null);
+check('hidden condition reported', warnings.some((w) => w.includes('Demo.res:534:11')));
+
+// Only once per site, however many times the component mounts.
+const repeats = warnings.filter((w) => w.includes('Demo.res:525:54')).length;
+mount(() => Demo.Hidden.make({}));
+check('each site is reported once, not per render', warnings.filter((w) => w.includes('Demo.res:525:54')).length === repeats);
+
+// --- ...and silent when there is nothing to report ---------------------------
+// An unresolvable call is not evidence of a read. Probing decides by what the
+// evaluation actually subscribed to, so a false positive is impossible.
+console.log('probe stays silent when nothing is read:');
+const quiet = warnings.length;
+const clean = mount(() => Demo.HiddenClean.make({}));
+check('unresolvable-but-static bare child renders', clean.textContent.includes('42'));
+check('unresolvable-but-static attribute renders', clean.className === 'row!');
+check('no warning for a call that reads nothing', warnings.length === quiet);
+// Case 25 (PeekShadow) is probed too: `Signal.peek` registers no dependency, so
+// a deliberate one-shot peek must not be reported either.
+check('no warning for a deliberate peek-based helper', !warnings.some((w) => w.includes('Demo.res:357')));
+check('no warning from any other case', warnings.every((w) => /Demo\.res:(525|534):/.test(w)));
+
+console.warn = realWarn;
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/ppx/example/verify.mjs
+++ b/ppx/example/verify.mjs
@@ -1,5 +1,5 @@
-// Runtime verification that the @tracked fine-grained ppx produces reactive
-// *leaves* (not a wholesale rebuild). The key assertions tag DOM elements with
+// Runtime verification that the @xote.component fine-grained ppx produces
+// reactive *leaves* (not a wholesale rebuild). The key assertions tag DOM elements with
 // a marker property, mutate signals, then check the marker survives — proving
 // the element kept its identity and was not recreated.
 //
@@ -257,6 +257,110 @@ check('anchor outside the if kept identity', document.querySelector('#mb-anchor'
 Signal.set(Demo.active, false);
 check('branch closed again: labels gone', !document.querySelector('#mb-host').textContent.includes('Ada'));
 check('anchor still same element after toggle', document.querySelector('#mb-anchor').__marker === 'MB');
+
+// --- Poly-variant payload in attribute position -----------------------------
+// `class={switch #tone(Signal.get(theme)) { ... }}`: the read sits inside a
+// polymorphic variant payload (Pexp_variant), which the eager-read traversal
+// must descend into — previously this attribute silently stayed static.
+console.log('poly-variant payload in attribute position:');
+Signal.set(Demo.theme, 'light');
+const vaHost = document.createElement('div');
+document.body.appendChild(vaHost);
+View.mount(Demo.VariantAttr.make({}), vaHost);
+const vaEl = vaHost.querySelector('#variant-attr');
+vaEl.__marker = 'VA';
+check('variant payload read renders initial class', vaEl.className === 'tone-light');
+Signal.set(Demo.theme, 'dark');
+check('variant payload read is reactive (class updates)', vaHost.querySelector('#variant-attr').className === 'tone-dark');
+check('element kept identity across class update', vaHost.querySelector('#variant-attr').__marker === 'VA');
+
+// --- Guard-only reads make the switch tracked -------------------------------
+// `switch v { | _ if Signal.get(active) => … }`: the ONLY read is in the
+// `when` guard. Guards are evaluated eagerly, so the switch must be tracked —
+// previously the guard was invisible and the branch was static forever.
+console.log('switch guard read (tracked via when-guard):');
+Signal.set(Demo.active, true);
+const gs = mount(() => Demo.GuardSwitch.make({}));
+gs.__marker = 'GS';
+check('guard true renders "on" branch', gs.querySelector('#gs-on') !== null);
+Signal.set(Demo.active, false);
+check('guard read is tracked: swaps to "off" branch', document.querySelector('#guard-switch #gs-off') !== null);
+check('guard switch outer div kept identity', document.querySelector('#guard-switch').__marker === 'GS');
+
+// --- Signature-constrained module still transformed -------------------------
+// `module ConstrainedPanel: Sig = { @xote.component … }`: the traversal must
+// descend through Pmod_constraint — previously the annotation was silently
+// left unexpanded there (static attrs, or a type error on bare children).
+console.log('component inside `module X: Sig = { … }`:');
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.count, 1);
+const cp = mount(() => Demo.ConstrainedPanel.make({}));
+cp.__marker = 'CP';
+check('constrained: reactive class renders', cp.className === 'light');
+check('constrained: bare int child renders', cp.textContent === '1');
+Signal.set(Demo.theme, 'dark');
+Signal.set(Demo.count, 2);
+check('constrained: class updates (transform ran under the constraint)', document.querySelector('#constrained').className === 'dark');
+check('constrained: bare child updates', document.querySelector('#constrained').textContent === '2');
+check('constrained: element kept identity', document.querySelector('#constrained').__marker === 'CP');
+
+// --- let-block child stays fine-grained -------------------------------------
+// `{let label = …; <span class={Signal.get(theme)}/>}` in node position: the
+// tail JSX keeps fine-grained leaves. Previously the whole block collapsed
+// into one coarse View.child thunk that rebuilt the span on every change.
+console.log('let-block in node position (fine-grained, identity kept):');
+Signal.set(Demo.theme, 'light');
+const lb = mount(() => Demo.LetBlockChild.make({}));
+const lbSpan = lb.querySelector('#lb-span');
+lbSpan.__marker = 'LB';
+check('let-block span renders with initial class', lbSpan.className === 'light');
+Signal.set(Demo.theme, 'dark');
+check('let-block class updates', lb.querySelector('#lb-span').className === 'dark');
+check('let-block span kept identity (no coarse rebuild)', lb.querySelector('#lb-span').__marker === 'LB');
+
+// --- User-component props ----------------------------------------------------
+// A scalar prop that eagerly reads a signal passes through untouched (a
+// deliberate one-shot read — previously the ppx thunked it into a baffling
+// type error). A JSX-valued prop is node position: its own leaves stay
+// reactive and keep identity.
+console.log('user-component props (one-shot scalars, reactive JSX values):');
+Signal.set(Demo.name, 'Ada');
+Signal.set(Demo.theme, 'light');
+const tc = mount(() => Demo.UseTitleCard.make({}));
+check('scalar prop rendered from one-shot read', tc.querySelector('#tc-label').textContent === 'Ada');
+const tcHeader = tc.querySelector('#tc-header');
+tcHeader.__marker = 'TCH';
+check('JSX-valued prop rendered with its reactive class', tcHeader.className === 'light');
+Signal.set(Demo.name, 'Bo');
+Signal.set(Demo.theme, 'dark');
+check('scalar prop is a deliberate one-shot read (stays "Ada")', tc.querySelector('#tc-label').textContent === 'Ada');
+check('JSX prop class updates (leaves decomposed inside the prop)', tc.querySelector('#tc-header').className === 'dark');
+check('JSX prop element kept identity', tc.querySelector('#tc-header').__marker === 'TCH');
+
+// --- peek + shadowing: rebound helper is dropped -----------------------------
+// `toneClass` is a reactive helper at top level, but the component rebinds it
+// to a peek-based one — the rebind drops it from the reactive-helper set, so
+// the attribute is a plain, intentionally static string.
+console.log('peek-based rebind drops the reactive helper:');
+Signal.set(Demo.active, true);
+const ps = mount(() => Demo.PeekShadow.make({}));
+check('peek class evaluated once ("peek-on")', ps.className === 'peek-on');
+Signal.set(Demo.active, false);
+check('peek class intentionally static (no update)', document.querySelector('#peek-shadow').className === 'peek-on');
+
+// --- Bare mapped-list child (array-returning thunk) --------------------------
+// `{Signal.get(items)->Array.map(…)}`: the eager read is thunked and the
+// thunk returns an *array* — View.child must re-coerce it per run, not lock
+// into reactive-text mode from the first value.
+console.log('bare mapped list child (array thunk re-coerced per run):');
+Signal.set(Demo.items, ['a', 'b']);
+const ml = mount(() => Demo.MappedList.make({}));
+ml.__marker = 'ML';
+check('mapped list renders items', ml.textContent === 'ab');
+check('mapped list renders real <li> elements', ml.querySelectorAll('li.ml-item').length === 2);
+Signal.set(Demo.items, ['a', 'b', 'c']);
+check('mapped list updates', document.querySelector('#mapped-list').textContent === 'abc');
+check('mapped list outer <ul> kept identity', document.querySelector('#mapped-list').__marker === 'ML');
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/ppx/example/verify.mjs
+++ b/ppx/example/verify.mjs
@@ -1,0 +1,147 @@
+// Runtime verification that the @tracked fine-grained ppx produces reactive
+// *leaves* (not a wholesale rebuild). The key assertions tag DOM elements with
+// a marker property, mutate signals, then check the marker survives — proving
+// the element kept its identity and was not recreated.
+//
+//   sh ../build.sh && npm run build && npm run verify
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'https://xote.test/' });
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Node = dom.window.Node;
+
+const View = await import('xote/src/View.res.mjs');
+const Signal = await import('xote/src/Signal.res.mjs');
+const Demo = await import('./src/Demo.res.mjs');
+
+let pass = 0, fail = 0;
+const check = (name, cond) => {
+  if (cond) { pass++; console.log('  ✓', name); }
+  else { fail++; console.log('  ✗', name); }
+};
+const mount = (factory) => {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  View.mount(factory(), host);
+  return host.firstElementChild;
+};
+
+// --- Fine-grained leaves: attribute + text update, structure preserved -----
+// Cases 1/3/4/5/6 all read `active` (class) and `name` (text), each via a
+// different read form. If the ppx failed to recognise the read, the leaf
+// would be static and the assertions below would fail.
+const c = (m) => () => m({}); // call a propless @xote.component
+const forms = [
+  ['card    (Signal.get direct)',       c(Demo.Card.make),        '#card',        'Hello, Grace'],
+  ['aliased (let g = Signal.get)',      c(Demo.Aliased.make),     '#aliased',     'Hi, Grace'],
+  ['modAlias(module S = Signal)',       c(Demo.ModAliased.make),  '#mod-aliased', 'Yo, Grace'],
+  ['open    (open Signal; get)',        c(Demo.OpenAliased.make), '#open-aliased','Hey, Grace'],
+  ['piped   (active->Signal.get)',      c(Demo.Piped.make),       '#piped',       'Pipe, Grace'],
+];
+
+console.log('fine-grained reactive leaves (each read form):');
+const mounted = forms.map(([, factory]) => mount(factory));
+mounted.forEach((el) => { el.__marker = 'ORIGINAL'; });
+check('all start class "off"', mounted.every((el) => el.className === 'off'));
+
+Signal.set(Demo.active, true);
+Signal.set(Demo.name, 'Grace');
+
+forms.forEach(([label, , sel, expectedText], i) => {
+  const el = document.querySelector(sel);
+  check(`${label}: class -> "on"`, el.className === 'on');
+  check(`${label}: text updated`, el.textContent.includes(expectedText));
+  check(`${label}: element kept identity (not rebuilt)`, mounted[i].__marker === 'ORIGINAL' && el === mounted[i]);
+});
+
+// Case 1 also has a static sibling span that must never be touched.
+check('card static <span> class intact', document.querySelector('#card .static-label') !== null);
+check('card static label text intact', document.querySelector('#card').textContent.includes('Name:'));
+
+// --- @xote.component: derives props AND fine-grains the returned JSX --------
+console.log('@xote.component (props derived + fine-grained):');
+const labeled = mount(() => Demo.Labeled.make({ label: 'Hits' }));
+labeled.__marker = 'ORIGINAL';
+check('prop rendered (label "Hits")', labeled.textContent.includes('Hits:'));
+check('reads current signal via props form', labeled.textContent.includes('Grace')); // name already Grace
+check('class is reactive ("on")', labeled.className === 'on');
+
+Signal.set(Demo.active, false);
+Signal.set(Demo.name, 'Ada');
+check('class leaf updated to "off"', document.querySelector('#labeled').className === 'off');
+check('text leaf updated (Ada)', document.querySelector('#labeled').textContent.includes('Hits: Ada'));
+check('component element kept identity (fine-grained, no rebuild)', document.querySelector('#labeled').__marker === 'ORIGINAL');
+
+// Pre-existing () => … thunks must not be double-wrapped: class stays a real
+// string ("off"/"on"), not a function. active is currently false, name "Ada".
+console.log('pre-existing thunks (not double-wrapped):');
+const pre = mount(() => Demo.PreThunked.make({}));
+check('class is a plain string, not double-thunked', pre.className === 'off');
+check('text thunk resolves', pre.textContent.includes('T: Ada'));
+Signal.set(Demo.active, true);
+Signal.set(Demo.name, 'Zoe');
+check('class thunk still reactive ("on")', pre.className === 'on');
+check('text thunk still reactive (Zoe)', pre.textContent.includes('T: Zoe'));
+
+// A Prop.reactive(Computed) class reads only inside a lambda -> not thunked;
+// the class must be a real string and stay reactive. active is currently true.
+console.log('already-reactive value (Prop.reactive not thunked):');
+const pw = mount(() => Demo.PropWrapped.make({}));
+check('Prop.reactive class is a real string ("on")', pw.className === 'on');
+Signal.set(Demo.active, false);
+check('Prop.reactive class still reactive ("off")', document.querySelector('#prop-wrapped').className === 'off');
+
+// A read hidden behind a local helper (statusClass) must still be reactive —
+// the helper is tracked, so class={statusClass()} is thunked, not static.
+// active is currently false.
+//
+// NOTE: only *local* helpers are covered. A read behind an imported /
+// cross-module helper is invisible to the (single-file) PPX and compiles to a
+// static attribute with no error — a limitation this jsdom suite cannot catch
+// structurally, since the missed read produces valid code that simply never
+// updates. See ppx/README.md "Known limitations"; the escape hatch is to wrap
+// the value in `() =>` yourself.
+console.log('helper-hidden read (local reactive helper tracked):');
+const hh = mount(() => Demo.HelperHidden.make({}));
+check('helper class reactive ("off")', hh.className === 'off');
+Signal.set(Demo.active, true);
+check('helper class updates ("on") — not a silent static bug', document.querySelector('#helper-hidden').className === 'on');
+
+// --- Structural swap via View.tracked, outer element preserved -------------
+console.log('panel (structural swap, outer element preserved):');
+const panel = mount(c(Demo.Panel.make));
+panel.__pmarker = 'PANEL';
+check('initial Loading <span>', panel.querySelector('span') !== null && panel.textContent.includes('Loading'));
+
+Signal.set(Demo.status, { TAG: 'Ready', _0: 'Done!' });
+check('swapped to <strong>', panel.querySelector('strong') !== null);
+check('shows "Done!"', panel.textContent.includes('Done!'));
+check('outer DIV kept identity (only inner region swapped)', panel.__pmarker === 'PANEL');
+
+// --- Branch leaf stays fine-grained (item 2) -------------------------------
+// The switch tracks only `status`; the Ready branch's class reads `theme`.
+// Changing `theme` must update the class leaf WITHOUT re-running the switch —
+// i.e. the <strong> keeps its identity. (Before branch decomposition, `theme`
+// was read eagerly during the tracked render, so the whole branch rebuilt.)
+console.log('switchLeaf (branch leaf reacts without re-running the switch):');
+Signal.set(Demo.status, { TAG: 'Ready', _0: 'Ready!' }); // select the Ready branch
+const outer = mount(c(Demo.SwitchLeaf.make));
+outer.__omarker = 'OUTER';
+const strong = outer.querySelector('#ready-strong');
+strong.__marker = 'STRONG';
+check('initial class = theme "light"', strong.className === 'light');
+
+Signal.set(Demo.theme, 'dark');
+check('class leaf updated to "dark"', outer.querySelector('#ready-strong').className === 'dark');
+check('<strong> kept identity (switch did NOT re-run)', outer.querySelector('#ready-strong').__marker === 'STRONG');
+check('outer div kept identity', outer.__omarker === 'OUTER');
+
+// Structural swap still works: changing the scrutinee rebuilds the branch.
+Signal.set(Demo.status, 'Loading');
+check('scrutinee change still swaps to <span>',
+  outer.querySelector('span') !== null && outer.querySelector('#ready-strong') === null);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/ppx/example/verify.mjs
+++ b/ppx/example/verify.mjs
@@ -143,5 +143,120 @@ Signal.set(Demo.status, 'Loading');
 check('scrutinee change still swaps to <span>',
   outer.querySelector('span') !== null && outer.querySelector('#ready-strong') === null);
 
+// --- Bare children coerced by View.child (no <View.Int>/<View.Text> needed) --
+// <div>{Signal.get(count)}</div> — a bare *reactive scalar* becomes reactive
+// text; the <div> keeps its identity across the change (fine-grained leaf).
+console.log('bare reactive int child (View.child):');
+Signal.set(Demo.count, 0);
+const bi = mount(() => Demo.BareInt.make({}));
+bi.__marker = 'BI';
+check('bare int renders "0"', bi.textContent === '0');
+Signal.set(Demo.count, 7);
+check('bare int updates to "7"', document.querySelector('#bare-int').textContent === '7');
+check('bare int <div> kept identity (reactive leaf, not rebuilt)', document.querySelector('#bare-int').__marker === 'BI');
+
+// <div><span>…</span>{Signal.get(name)}</div> — bare reactive string alongside a
+// static sibling; only the text leaf reacts, the <span> keeps its identity.
+console.log('bare reactive string child + static sibling:');
+Signal.set(Demo.name, 'Ada');
+const bs = mount(() => Demo.BareString.make({}));
+const bsSpan = bs.querySelector('.lbl');
+bsSpan.__marker = 'SPAN';
+check('bare string shows "n: Ada"', bs.textContent === 'n: Ada');
+Signal.set(Demo.name, 'Bo');
+check('bare string updates to "n: Bo"', document.querySelector('#bare-string').textContent === 'n: Bo');
+check('static <span> sibling kept identity', document.querySelector('#bare-string .lbl').__marker === 'SPAN');
+
+// <div>{"literal"}</div> — a bare *static* scalar (a type error before View.child)
+// becomes a static text node.
+console.log('bare static scalar child:');
+const bst = mount(() => Demo.BareStatic.make({}));
+check('bare static renders "literal"', bst.textContent === 'literal');
+
+// <div>{View.text("noded")}</div> — a bare child that is *already a node* passes
+// through View.child untouched.
+console.log('bare already-a-node child (passthrough):');
+const bn = mount(() => Demo.BareNode.make({}));
+check('bare node renders "noded"', bn.textContent === 'noded');
+
+// Control flow with *scalar* branches: still a tracked structural swap on
+// `status`, but each scalar branch is coerced by View.child (no value primitive).
+console.log('scalar switch branches (tracked + View.child):');
+Signal.set(Demo.status, 'Loading');
+const ss = mount(() => Demo.ScalarSwitch.make({}));
+ss.__marker = 'SS';
+check('scalar switch shows "…loading"', ss.textContent === '…loading');
+Signal.set(Demo.status, { TAG: 'Ready', _0: 'done' });
+check('scalar switch swaps to "done"', document.querySelector('#scalar-switch').textContent === 'done');
+check('scalar switch outer <div> kept identity', document.querySelector('#scalar-switch').__marker === 'SS');
+
+// --- Fragment body: nested regions stay independent ------------------------
+// A make whose body is a <>…</> fragment with two reactive regions: a canvas
+// element and a mobile-backdrop `if`. Each fragment child is decomposed on its
+// own, so toggling the backdrop must NOT rebuild the canvas. (Regression: before
+// fragments were recursed into, the whole fragment was one coarse thunk and a
+// panel toggle rebuilt every sibling, losing DOM state.)
+console.log('fragment body: independent reactive regions (no coarse collapse):');
+Signal.set(Demo.mobileOpen, false);
+Signal.set(Demo.canvas, 'canvas-a');
+const wsHost = document.createElement('div');
+document.body.appendChild(wsHost);
+View.mount(Demo.Workspace.make({}), wsHost);
+const canvasEl = wsHost.querySelector('#ws-canvas');
+canvasEl.__marker = 'CANVAS';
+check('canvas renders "canvas-a"', canvasEl.textContent === 'canvas-a');
+check('backdrop absent initially', wsHost.querySelector('#ws-backdrop') === null);
+
+Signal.set(Demo.mobileOpen, true);
+check('backdrop appears on panel toggle', wsHost.querySelector('#ws-backdrop') !== null);
+check('canvas kept identity across panel toggle (NOT rebuilt)', wsHost.querySelector('#ws-canvas').__marker === 'CANVAS');
+
+Signal.set(Demo.canvas, 'canvas-b');
+check('canvas content updates on its own', wsHost.querySelector('#ws-canvas').textContent === 'canvas-b');
+check('canvas still same element after its own update', wsHost.querySelector('#ws-canvas').__marker === 'CANVAS');
+
+Signal.set(Demo.mobileOpen, false);
+check('backdrop removed on toggle off', wsHost.querySelector('#ws-backdrop') === null);
+check('canvas kept identity across second toggle (regions independent)', wsHost.querySelector('#ws-canvas').__marker === 'CANVAS');
+
+// --- Bare children directly in a fragment return ---------------------------
+// A dropdown-style fragment whose labels sit at the top level next to a static
+// anchor. Each bare read must be coerced in place (no display:contents root).
+console.log('bare children directly in a fragment return:');
+Signal.set(Demo.name, 'Ada');
+Signal.set(Demo.count, 3);
+const dfHost = document.createElement('div');
+document.body.appendChild(dfHost);
+View.mount(Demo.DropdownFragment.make({}), dfHost);
+const dfAnchor = dfHost.querySelector('#df-anchor');
+dfAnchor.__marker = 'ANCHOR';
+check('fragment bare label renders (name)', dfHost.textContent.includes('Ada'));
+check('fragment bare thunk renders (#count)', dfHost.textContent.includes('#3'));
+Signal.set(Demo.name, 'Bo');
+Signal.set(Demo.count, 9);
+check('fragment bare label updates', dfHost.textContent.includes('Bo'));
+check('fragment bare thunk updates', dfHost.textContent.includes('#9'));
+check('fragment static anchor kept identity', dfHost.querySelector('#df-anchor').__marker === 'ANCHOR');
+
+// --- Fragment as a control-flow branch body --------------------------------
+// The dropdown's labels live inside CanvasMenu's `{if …}` as a fragment, not in
+// their own component. The branch is decomposed so its bare labels are coerced;
+// the anchor outside the `if` keeps its identity across toggles.
+console.log('fragment as a control-flow branch body:');
+Signal.set(Demo.active, false);
+Signal.set(Demo.name, 'Ada');
+Signal.set(Demo.count, 5);
+const mb = mount(() => Demo.MenuBranch.make({}));
+const mbAnchor = mb.querySelector('#mb-anchor');
+mbAnchor.__marker = 'MB';
+check('branch closed: no labels yet', !mb.textContent.includes('Ada'));
+Signal.set(Demo.active, true);
+check('branch open: bare label coerced (name)', document.querySelector('#mb-host').textContent.includes('Ada'));
+check('branch open: bare int coerced (count)', document.querySelector('#mb-host').textContent.includes('5'));
+check('anchor outside the if kept identity', document.querySelector('#mb-anchor').__marker === 'MB');
+Signal.set(Demo.active, false);
+check('branch closed again: labels gone', !document.querySelector('#mb-host').textContent.includes('Ada'));
+check('anchor still same element after toggle', document.querySelector('#mb-anchor').__marker === 'MB');
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/ppx/example/verify.mjs
+++ b/ppx/example/verify.mjs
@@ -15,6 +15,14 @@ globalThis.Node = dom.window.Node;
 const View = await import('xote/src/View.res.mjs');
 const Signal = await import('xote/src/Signal.res.mjs');
 const Demo = await import('./src/Demo.res.mjs');
+const Store = await import('./src/Store.res.mjs');
+
+// `View.probe` reports hidden reads through console.warn. Capture from the very
+// first mount so the hidden-read section can assert both what was reported and
+// what was not — a false positive is as much a failure as a missed read.
+const warnings = [];
+const realWarn = console.warn;
+console.warn = (...args) => { warnings.push(args.join(' ')); };
 
 let pass = 0, fail = 0;
 const check = (name, cond) => {
@@ -465,6 +473,76 @@ check('let-bound JSX renders bare child', ns.querySelector('#ns-heading').textCo
 check('array literal inside View.fragment', ns.querySelector('#ns-arr').textContent.includes('array'));
 check('pipe + map callback decomposed', ns.querySelectorAll('.ns-map').length === 2);
 check('local helper items rendered', ns.textContent.includes('one') && ns.textContent.includes('two'));
+
+// --- MaybeSignal.get is a tracked read --------------------------------------
+// Reading through the static-or-reactive wrapper subscribes exactly like
+// Signal.get, so both leaves below must be reactive, not one-shot.
+console.log('MaybeSignal.get is a tracked read:');
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.name, 'Ada');
+const ms = mount(() => Demo.MaybeSignalRead.make({}));
+ms.__marker = 'MS';
+check('MaybeSignal.get attribute rendered', ms.className === 'light');
+check('MaybeSignal.get bare child rendered', ms.textContent.includes('Ada'));
+Signal.set(Demo.theme, 'dark');
+Signal.set(Demo.name, 'Bo');
+check('MaybeSignal.get attribute updates', document.querySelector('#maybe-signal').className === 'dark');
+check('MaybeSignal.get bare child updates', document.querySelector('#maybe-signal').textContent.includes('Bo'));
+check('MaybeSignal leaf kept element identity', document.querySelector('#maybe-signal').__marker === 'MS');
+
+// --- A reactive helper behind a same-file module -----------------------------
+console.log('same-file module helper is a tracked read:');
+Signal.set(Demo.count, 2);
+const mh = mount(() => Demo.ModuleHelper.make({}));
+mh.__marker = 'MH';
+check('module helper bare child rendered', mh.textContent.includes('4'));
+check('module helper attribute rendered', mh.className === 'positive');
+Signal.set(Demo.count, 0);
+check('module helper bare child updates', document.querySelector('#module-helper').textContent.trim() === '0');
+check('module helper attribute updates', document.querySelector('#module-helper').className === 'zero');
+check('module helper kept element identity', document.querySelector('#module-helper').__marker === 'MH');
+
+// --- Hidden reads: what detection cannot follow, reported at runtime ---------
+// `Store` is another file, so the ppx sees only a call it cannot resolve. The
+// leaf is wrapped in `View.probe`, which evaluates it inside a throwaway
+// computed and reports it if that computed subscribed to anything.
+console.log('hidden reads (an unresolvable call that does read a signal):');
+const hidden = mount(() => Demo.Hidden.make({}));
+check('hidden read still renders its initial value', hidden.textContent.includes('4'));
+check('hidden read attribute still renders', hidden.className === 'tone-calm');
+check('hidden read reported with its source location', warnings.some((w) => w.includes('Demo.res:525:54')));
+check('hidden read attribute reported', warnings.some((w) => w.includes('Demo.res:525:32')));
+check('warning names the fix', warnings.some((w) => w.includes('() => ...')));
+
+// This is precisely what the warning is for: the leaf is frozen at its first
+// value. Detection cannot fix it, so it has to say so.
+Signal.set(Store.waiting, 9);
+check('hidden read is indeed frozen (the failure the warning describes)', document.querySelector('#hidden-read').textContent.includes('4'));
+
+const hiddenBranch = mount(() => Demo.HiddenBranch.make({}));
+check('hidden condition renders a branch', hiddenBranch.querySelector('#hb-idle') !== null);
+check('hidden condition reported', warnings.some((w) => w.includes('Demo.res:534:11')));
+
+// Only once per site, however many times the component mounts.
+const repeats = warnings.filter((w) => w.includes('Demo.res:525:54')).length;
+mount(() => Demo.Hidden.make({}));
+check('each site is reported once, not per render', warnings.filter((w) => w.includes('Demo.res:525:54')).length === repeats);
+
+// --- ...and silent when there is nothing to report ---------------------------
+// An unresolvable call is not evidence of a read. Probing decides by what the
+// evaluation actually subscribed to, so a false positive is impossible.
+console.log('probe stays silent when nothing is read:');
+const quiet = warnings.length;
+const clean = mount(() => Demo.HiddenClean.make({}));
+check('unresolvable-but-static bare child renders', clean.textContent.includes('42'));
+check('unresolvable-but-static attribute renders', clean.className === 'row!');
+check('no warning for a call that reads nothing', warnings.length === quiet);
+// Case 25 (PeekShadow) is probed too: `Signal.peek` registers no dependency, so
+// a deliberate one-shot peek must not be reported either.
+check('no warning for a deliberate peek-based helper', !warnings.some((w) => w.includes('Demo.res:357')));
+check('no warning from any other case', warnings.every((w) => /Demo\.res:(525|534):/.test(w)));
+
+console.warn = realWarn;
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/ppx/example/verify.mjs
+++ b/ppx/example/verify.mjs
@@ -362,5 +362,109 @@ Signal.set(Demo.items, ['a', 'b', 'c']);
 check('mapped list updates', document.querySelector('#mapped-list').textContent === 'abc');
 check('mapped list outer <ul> kept identity', document.querySelector('#mapped-list').__marker === 'ML');
 
+
+// --- Control flow on a plain (non-signal) condition -------------------------
+// The conditional is built once, but its branches are node position: bare
+// children inside them must still be coerced by View.child. This is the shape
+// that failed to compile before the branches were decomposed on this path.
+console.log('control flow on a plain condition:');
+const sbTrue = document.createElement('div');
+document.body.appendChild(sbTrue);
+View.mount(Demo.StaticBranch.make({ flag: true }), sbTrue);
+check('plain-cond branch renders bare literal child', sbTrue.querySelector('#sb-yes').textContent === 'yes');
+check('plain-cond ternary over strings renders', sbTrue.textContent.includes('on'));
+
+const sbFalse = document.createElement('div');
+document.body.appendChild(sbFalse);
+View.mount(Demo.StaticBranch.make({ flag: false }), sbFalse);
+check('plain-cond else branch renders bare literal child', sbFalse.querySelector('#sb-no').textContent === 'no');
+check('plain-cond ternary takes the else value', sbFalse.textContent.includes('off'));
+
+// A reactive leaf inside a statically-chosen branch stays fine-grained: the
+// branch element keeps its identity while the leaf updates.
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.name, 'Ada');
+const sbrl = document.createElement('div');
+document.body.appendChild(sbrl);
+View.mount(Demo.StaticBranchReactiveLeaf.make({ flag: true }), sbrl);
+const sbrlTag = sbrl.querySelector('#sbrl-tag');
+sbrlTag.__marker = 'SBRL';
+check('plain-cond branch leaf renders initial class', sbrlTag.className === 'light');
+check('plain-cond branch leaf renders bare signal read', sbrlTag.textContent.includes('Ada'));
+Signal.set(Demo.theme, 'dark');
+Signal.set(Demo.name, 'Bo');
+check('leaf class updates inside a plain-cond branch', sbrl.querySelector('#sbrl-tag').className === 'dark');
+check('leaf text updates inside a plain-cond branch', sbrl.querySelector('#sbrl-tag').textContent.includes('Bo'));
+check('branch element kept identity (built once, not rebuilt)', sbrl.querySelector('#sbrl-tag').__marker === 'SBRL');
+
+
+// --- Bare children inside a render callback ---------------------------------
+// `render={row => …}` is a function returning JSX: node position once applied,
+// but not JSX itself, so the traversal used to stop at the callback boundary.
+console.log('bare children inside a render callback:');
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.count, 7);
+const cb = mount(() => Demo.CallbackRows.make({}));
+const cbFirst = cb.querySelector('#cb-rows li');
+cbFirst.__marker = 'ROW1';
+check('callback bare child renders (author)', cb.textContent.includes('Ada'));
+check('callback bare literal renders (separator)', cb.textContent.includes('·'));
+check('callback bare signal read renders (count)', cb.textContent.includes('7'));
+check('callback leaf attribute rendered', cbFirst.className === 'light');
+// The leaves inside the callback are fine-grained: updating a signal they read
+// changes them in place instead of rebuilding the row.
+Signal.set(Demo.count, 8);
+check('callback bare signal read updates', document.querySelector('#cb-rows').textContent.includes('8'));
+Signal.set(Demo.theme, 'dark');
+check('callback leaf attribute updates', document.querySelector('#cb-rows li').className === 'dark');
+check('row kept identity across leaf updates', document.querySelector('#cb-rows li').__marker === 'ROW1');
+
+
+// --- Node-taking helpers called as plain functions --------------------------
+// `View.tracked(() => …)` / `View.each(xs, x => …)` are applications, not JSX,
+// so the traversal used to stop at the call and leave their callback bodies
+// undecomposed.
+console.log('bare children inside node-taking helper callbacks:');
+Signal.set(Demo.active, false);
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.name, 'Ada');
+const hc = mount(() => Demo.HelperCallbacks.make({}));
+check('tracked callback: else branch bare literal', hc.textContent.includes('inactive'));
+check('each callback: bare item rendered', hc.textContent.includes('one') && hc.textContent.includes('two'));
+Signal.set(Demo.active, true);
+const hcOn = document.querySelector('#hc-on');
+hcOn.__marker = 'HC';
+check('tracked callback: branch bare signal read', hcOn.textContent.includes('Ada'));
+check('tracked callback: branch leaf attribute', hcOn.className === 'light');
+// Leaves inside the tracked callback stay fine-grained: the element survives.
+Signal.set(Demo.name, 'Bo');
+Signal.set(Demo.theme, 'dark');
+check('tracked callback: bare read updates', document.querySelector('#hc-on').textContent.includes('Bo'));
+check('tracked callback: leaf attribute updates', document.querySelector('#hc-on').className === 'dark');
+check('tracked callback: element kept identity', document.querySelector('#hc-on').__marker === 'HC');
+
+
+// --- Plain helper functions returning markup --------------------------------
+// The file opts in via its @xote.component bindings, so helper bodies are
+// decomposed too: bare child coerced, class a reactive leaf.
+console.log('helper function returning markup:');
+Signal.set(Demo.theme, 'light');
+const hb = mount(() => Demo.HelperHost.make({}));
+const hbBtn = hb.querySelector('#helper-btn');
+hbBtn.__marker = 'HB';
+check('helper bare child rendered', hbBtn.textContent.includes('Press'));
+check('helper leaf attribute rendered', hbBtn.className === 'light');
+Signal.set(Demo.theme, 'dark');
+check('helper leaf attribute updates (reactive, not static)', document.querySelector('#helper-btn').className === 'dark');
+check('helper element kept identity', document.querySelector('#helper-btn').__marker === 'HB');
+
+// --- JSX reached through arrays, applications, pipes, local bindings --------
+console.log('JSX nested in non-child positions:');
+const ns = mount(() => Demo.NestedShapes.make({}));
+check('let-bound JSX renders bare child', ns.querySelector('#ns-heading').textContent.includes('Nested'));
+check('array literal inside View.fragment', ns.querySelector('#ns-arr').textContent.includes('array'));
+check('pipe + map callback decomposed', ns.querySelectorAll('.ns-map').length === 2);
+check('local helper items rendered', ns.textContent.includes('one') && ns.textContent.includes('two'));
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/ppx/package.json
+++ b/ppx/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "xote-tracked-ppx",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Experimental native ReScript PPX that expands @tracked JSX blocks into fine-grained Xote reactive leaves. Opt-in; build with ./build.sh (needs ocamlopt).",
+  "bin": {
+    "xote-tracked-ppx": "./ppx"
+  },
+  "scripts": {
+    "build": "sh build.sh",
+    "example:setup": "sh example/setup.sh",
+    "example:verify": "sh build.sh && cd example && npm run build && npm run verify"
+  },
+  "files": [
+    "ppx.ml",
+    "build.sh",
+    "README.md",
+    "LICENSE.OCaml"
+  ]
+}

--- a/ppx/package.json
+++ b/ppx/package.json
@@ -2,7 +2,7 @@
   "name": "xote-tracked-ppx",
   "version": "0.1.0",
   "private": true,
-  "description": "Experimental native ReScript PPX that expands @tracked JSX blocks into fine-grained Xote reactive leaves. Opt-in; build with ./build.sh (needs ocamlopt).",
+  "description": "Native ReScript PPX that expands @xote.component into fine-grained Xote reactive leaves. Shipped prebuilt per platform in the xote npm package; build from source with ./build.sh (needs ocamlopt).",
   "bin": {
     "xote-tracked-ppx": "./ppx"
   },

--- a/ppx/package.json
+++ b/ppx/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "xote-tracked-ppx",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Native ReScript PPX that expands @xote.component into fine-grained Xote reactive leaves. Shipped prebuilt per platform in the xote npm package; build from source with ./build.sh (needs ocamlopt).",
+  "bin": {
+    "xote-tracked-ppx": "./ppx"
+  },
+  "scripts": {
+    "build": "sh build.sh",
+    "example:setup": "sh example/setup.sh",
+    "example:verify": "sh build.sh && cd example && npm run build && npm run verify"
+  },
+  "files": [
+    "ppx.ml",
+    "ast.ml",
+    "build.sh",
+    "README.md",
+    "LICENSE.OCaml"
+  ]
+}

--- a/ppx/postinstall.js
+++ b/ppx/postinstall.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/*
+ * Selects the prebuilt @xote.component ppx binary for the current platform.
+ *
+ * The npm package ships one native binary per supported platform under
+ * ppx/bin/ (built in CI, see .github/workflows/ppx-binaries.yml). This script
+ * copies the matching one to ppx/ppx (ppx/ppx.exe on Windows), which is the
+ * path consumers reference from their rescript.json:
+ *
+ *   "ppx-flags": ["xote/ppx/ppx"]
+ *
+ * Fallbacks, in order:
+ *   1. No prebuilt binary for this platform (or it does not run here — musl
+ *      libc, emulation, damaged file), but ocamlopt is available: compile
+ *      from the bundled ppx.ml source (build.sh).
+ *   2. Otherwise: print instructions and exit 0. The install never fails —
+ *      not even on an unexpected error, hence the top-level try/catch — since
+ *      the ppx is only needed by projects that list it in their own
+ *      ppx-flags, and Xote's published library sources compile without it.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ppxDir = __dirname;
+const isWindows = process.platform === 'win32';
+const target = `${process.platform}-${process.arch}`;
+const prebuilt = path.join(ppxDir, 'bin', `ppx-${target}.exe`);
+const dest = path.join(ppxDir, isWindows ? 'ppx.exe' : 'ppx');
+
+/* The linux prebuilts are glibc-linked; on musl (e.g. Alpine) they would copy
+ * fine and then die at exec time inside the ReScript build. Same probe
+ * esbuild uses: the report header only carries glibcVersionRuntime on glibc. */
+function isMuslLinux() {
+  if (process.platform !== 'linux') return false;
+  try {
+    const report = process.report && process.report.getReport();
+    return !(report && report.header && report.header.glibcVersionRuntime);
+  } catch (_err) {
+    return false;
+  }
+}
+
+/* `ppx --help` exits 0 without needing an AST: proves the binary actually
+ * loads and executes on this host (arch, libc, DLLs) — a copy can succeed
+ * where an exec cannot. */
+function runs(bin) {
+  const run = spawnSync(bin, ['--help'], { stdio: 'ignore' });
+  return !run.error && run.status === 0;
+}
+
+function installPrebuilt() {
+  if (!fs.existsSync(prebuilt)) return false;
+  if (isMuslLinux()) {
+    console.warn(
+      `xote: the prebuilt ${target} ppx binary is glibc-linked and this system uses musl; trying a source build instead.`,
+    );
+    return false;
+  }
+  fs.copyFileSync(prebuilt, dest);
+  if (!isWindows) fs.chmodSync(dest, 0o755);
+  if (!runs(dest)) {
+    console.warn(`xote: prebuilt ppx binary for ${target} does not execute on this system; trying a source build instead.`);
+    try {
+      fs.unlinkSync(dest);
+    } catch (_err) {
+      /* leave a non-executing copy behind rather than fail the install */
+    }
+    return false;
+  }
+  console.log(`xote: installed prebuilt ppx binary for ${target}`);
+  return true;
+}
+
+function buildFromSource() {
+  const probe = spawnSync('ocamlopt', ['-version'], { stdio: 'ignore', shell: isWindows });
+  if (probe.error || probe.status !== 0) return false;
+  console.log(`xote: no usable prebuilt ppx binary for ${target}, compiling from source...`);
+  const build = spawnSync('sh', [path.join(ppxDir, 'build.sh')], { stdio: 'inherit' });
+  if (build.error) {
+    /* stock Windows has ocamlopt via opam but no `sh` — say so instead of
+     * silently falling through to the generic warning */
+    console.warn('xote: build.sh needs a POSIX shell (`sh`); run it from Git Bash/WSL/Cygwin.');
+    return false;
+  }
+  return build.status === 0 && fs.existsSync(dest) && runs(dest);
+}
+
+function main() {
+  if (!installPrebuilt() && !buildFromSource()) {
+    console.warn(
+      [
+        `xote: no ppx binary available for ${target}.`,
+        'The @xote.component annotation needs it; the rest of Xote does not.',
+        'To use it, install an OCaml compiler (ocamlopt) and run:',
+        '  sh node_modules/xote/ppx/build.sh',
+        'Supported prebuilt platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64 (glibc on linux).',
+      ].join('\n'),
+    );
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  /* never fail the consumer's install over the optional ppx */
+  console.warn(`xote: ppx postinstall failed (${err && err.message ? err.message : err}); continuing without the ppx binary.`);
+  console.warn('To set it up manually: sh node_modules/xote/ppx/build.sh (needs ocamlopt).');
+}

--- a/ppx/postinstall.js
+++ b/ppx/postinstall.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/*
+ * Selects the prebuilt @xote.component ppx binary for the current platform.
+ *
+ * The npm package ships one native binary per supported platform under
+ * ppx/bin/ (built in CI, see .github/workflows/ppx-binaries.yml). This script
+ * copies the matching one to ppx/ppx (ppx/ppx.exe on Windows), which is the
+ * path consumers reference from their rescript.json:
+ *
+ *   "ppx-flags": ["xote/ppx/ppx"]
+ *
+ * Fallbacks, in order:
+ *   1. No prebuilt binary for this platform (or it does not run here — musl
+ *      libc, emulation, damaged file), but ocamlopt is available: compile
+ *      from the bundled ppx.ml source (build.sh).
+ *   2. Otherwise: print instructions and exit 0. The install never fails —
+ *      not even on an unexpected error, hence the top-level try/catch — since
+ *      the ppx is only needed by projects that list it in their own
+ *      ppx-flags, and Xote's published library sources compile without it.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ppxDir = __dirname;
+const isWindows = process.platform === 'win32';
+const target = `${process.platform}-${process.arch}`;
+const prebuilt = path.join(ppxDir, 'bin', `ppx-${target}.exe`);
+const dest = path.join(ppxDir, isWindows ? 'ppx.exe' : 'ppx');
+
+/* The linux prebuilts are glibc-linked; on musl (e.g. Alpine) they would copy
+ * fine and then die at exec time inside the ReScript build. Same probe
+ * esbuild uses: the report header only carries glibcVersionRuntime on glibc. */
+function isMuslLinux() {
+  if (process.platform !== 'linux') return false;
+  try {
+    const report = process.report && process.report.getReport();
+    return !(report && report.header && report.header.glibcVersionRuntime);
+  } catch (_err) {
+    return false;
+  }
+}
+
+/* `ppx --help` exits 0 without needing an AST: proves the binary actually
+ * loads and executes on this host (arch, libc, DLLs) — a copy can succeed
+ * where an exec cannot. */
+function runs(bin) {
+  const run = spawnSync(bin, ['--help'], { stdio: 'ignore' });
+  return !run.error && run.status === 0;
+}
+
+function installPrebuilt() {
+  if (!fs.existsSync(prebuilt)) return false;
+  if (isMuslLinux()) {
+    console.warn(
+      `xote: the prebuilt ${target} ppx binary is glibc-linked and this system uses musl; trying a source build instead.`,
+    );
+    return false;
+  }
+  fs.copyFileSync(prebuilt, dest);
+  if (!isWindows) fs.chmodSync(dest, 0o755);
+  if (!runs(dest)) {
+    console.warn(`xote: prebuilt ppx binary for ${target} does not execute on this system; trying a source build instead.`);
+    try {
+      fs.unlinkSync(dest);
+    } catch (_err) {
+      /* leave a non-executing copy behind rather than fail the install */
+    }
+    return false;
+  }
+  console.log(`xote: installed prebuilt ppx binary for ${target}`);
+  return true;
+}
+
+function buildFromSource() {
+  const probe = spawnSync('ocamlopt', ['-version'], { stdio: 'ignore', shell: isWindows });
+  if (probe.error || probe.status !== 0) return false;
+  console.log(`xote: no usable prebuilt ppx binary for ${target}, compiling from source...`);
+  const build = spawnSync('sh', [path.join(ppxDir, 'build.sh')], { stdio: 'inherit' });
+  if (build.error) {
+    /* stock Windows has ocamlopt via opam but no `sh` — say so instead of
+     * silently falling through to the generic warning */
+    console.warn('xote: build.sh needs a POSIX shell (`sh`); run it from Git Bash/WSL/Cygwin.');
+    return false;
+  }
+  return build.status === 0 && fs.existsSync(dest) && runs(dest);
+}
+
+/* When no binary could be installed, leave an executable stub at the path
+ * ppx-flags points to.
+ *
+ * Without it ReScript fails resolution rather than execution, and says so in
+ * its own terms:
+ *
+ *   try_package_path: upward traversal did not find 'xote/ppx/ppx'
+ *   Incremental build failed. Error: Could not parse Source Files
+ *
+ * which names neither xote, nor this script, nor the fix. The stub turns that
+ * into a message the reader can act on, and it is the likeliest thing anyone
+ * hits first: pnpm skips dependency install scripts by default, so the very
+ * setups that need this message are the ones that never ran this file.
+ *
+ * Skipped on Windows, where the path is ppx.exe and a shell script will not
+ * execute — there the resolution error stands.
+ */
+function installStub() {
+  if (isWindows) return false;
+  /* Deliberately terse: ReScript runs the ppx once per source file, so this is
+   * printed once per file in the project. Three short lines is noisy; the
+   * fifteen-line version this replaced buried the compiler's own error. */
+  const stub = [
+    '#!/bin/sh',
+    '# Placeholder written by xote/ppx/postinstall.js when no ppx binary could',
+    '# be installed. Replaced by the real binary once one is available.',
+    'cat >&2 <<\'MSG\'',
+    'xote: @xote.component ppx binary missing (the install script did not run).',
+    '  fix: node node_modules/xote/ppx/postinstall.js   [pnpm: pnpm approve-builds first]',
+    '  see: node_modules/xote/ppx/README.md#distribution',
+    'MSG',
+    'exit 1',
+  ].join('\n');
+  try {
+    fs.writeFileSync(dest, stub + '\n', { mode: 0o755 });
+    return true;
+  } catch (_err) {
+    /* best effort: the warning below is still printed */
+    return false;
+  }
+}
+
+function main() {
+  if (!installPrebuilt() && !buildFromSource()) {
+    installStub();
+    console.warn(
+      [
+        `xote: no ppx binary available for ${target}.`,
+        'The @xote.component annotation needs it; the rest of Xote does not.',
+        'To use it, install an OCaml compiler (ocamlopt) and run:',
+        '  sh node_modules/xote/ppx/build.sh',
+        'Supported prebuilt platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64 (glibc on linux).',
+      ].join('\n'),
+    );
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  /* never fail the consumer's install over the optional ppx */
+  console.warn(`xote: ppx postinstall failed (${err && err.message ? err.message : err}); continuing without the ppx binary.`);
+  console.warn('To set it up manually: sh node_modules/xote/ppx/build.sh (needs ocamlopt).');
+}

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -1,0 +1,1334 @@
+(* Vendored OCaml 4.06 AST (ReScript 12's ppx parsetree is Caml1999M022 = 4.06).
+   Types are copied verbatim from ocaml/ocaml@4.06 so Marshal round-trips exactly. *)
+module Location = struct
+  type t = { loc_start : Lexing.position; loc_end : Lexing.position; loc_ghost : bool }
+  type 'a loc = { txt : 'a; loc : t }
+end
+module Longident = struct
+  type t = Lident of string | Ldot of t * string | Lapply of t * t
+end
+module Asttypes = struct
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Auxiliary AST types used by parsetree and typedtree. *)
+
+type constant =
+    Const_int of int
+  | Const_char of char
+  | Const_string of string * string option
+  | Const_float of string
+  | Const_int32 of int32
+  | Const_int64 of int64
+  | Const_nativeint of nativeint
+
+type rec_flag = Nonrecursive | Recursive
+
+type direction_flag = Upto | Downto
+
+(* Order matters, used in polymorphic comparison *)
+type private_flag = Private | Public
+
+type mutable_flag = Immutable | Mutable
+
+type virtual_flag = Virtual | Concrete
+
+type override_flag = Override | Fresh
+
+type closed_flag = Closed | Open
+
+type label = string
+
+type arg_label =
+    Nolabel
+  | Labelled of string (*  label:T -> ... *)
+  | Optional of string (* ?label:T -> ... *)
+
+type 'a loc = 'a Location.loc = {
+  txt : 'a;
+  loc : Location.t;
+}
+
+
+type variance =
+  | Covariant
+  | Contravariant
+  | Invariant
+end
+module Parsetree = struct
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Abstract syntax tree produced by parsing *)
+
+open Asttypes
+
+type constant =
+    Pconst_integer of string * char option
+  (* 3 3l 3L 3n
+
+     Suffixes [g-z][G-Z] are accepted by the parser.
+     Suffixes except 'l', 'L' and 'n' are rejected by the typechecker
+  *)
+  | Pconst_char of char
+  (* 'c' *)
+  | Pconst_string of string * string option
+  (* "constant"
+     {delim|other constant|delim}
+  *)
+  | Pconst_float of string * char option
+  (* 3.4 2e5 1.4e-4
+
+     Suffixes [g-z][G-Z] are accepted by the parser.
+     Suffixes are rejected by the typechecker.
+  *)
+
+(** {1 Extension points} *)
+
+type attribute = string loc * payload
+       (* [@id ARG]
+          [@@id ARG]
+
+          Metadata containers passed around within the AST.
+          The compiler ignores unknown attributes.
+       *)
+
+and extension = string loc * payload
+      (* [%id ARG]
+         [%%id ARG]
+
+         Sub-language placeholder -- rejected by the typechecker.
+      *)
+
+and attributes = attribute list
+
+and payload =
+  | PStr of structure
+  | PSig of signature (* : SIG *)
+  | PTyp of core_type  (* : T *)
+  | PPat of pattern * expression option  (* ? P  or  ? P when E *)
+
+(** {1 Core language} *)
+
+(* Type expressions *)
+
+and core_type =
+    {
+     ptyp_desc: core_type_desc;
+     ptyp_loc: Location.t;
+     ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and core_type_desc =
+  | Ptyp_any
+        (*  _ *)
+  | Ptyp_var of string
+        (* 'a *)
+  | Ptyp_arrow of arg_label * core_type * core_type
+        (* T1 -> T2       Simple
+           ~l:T1 -> T2    Labelled
+           ?l:T1 -> T2    Optional
+         *)
+  | Ptyp_tuple of core_type list
+        (* T1 * ... * Tn
+
+           Invariant: n >= 2
+        *)
+  | Ptyp_constr of Longident.t loc * core_type list
+        (* tconstr
+           T tconstr
+           (T1, ..., Tn) tconstr
+         *)
+  | Ptyp_object of object_field list * closed_flag
+        (* < l1:T1; ...; ln:Tn >     (flag = Closed)
+           < l1:T1; ...; ln:Tn; .. > (flag = Open)
+         *)
+  | Ptyp_class of Longident.t loc * core_type list
+        (* #tconstr
+           T #tconstr
+           (T1, ..., Tn) #tconstr
+         *)
+  | Ptyp_alias of core_type * string
+        (* T as 'a *)
+  | Ptyp_variant of row_field list * closed_flag * label list option
+        (* [ `A|`B ]         (flag = Closed; labels = None)
+           [> `A|`B ]        (flag = Open;   labels = None)
+           [< `A|`B ]        (flag = Closed; labels = Some [])
+           [< `A|`B > `X `Y ](flag = Closed; labels = Some ["X";"Y"])
+         *)
+  | Ptyp_poly of string loc list * core_type
+        (* 'a1 ... 'an. T
+
+           Can only appear in the following context:
+
+           - As the core_type of a Ppat_constraint node corresponding
+             to a constraint on a let-binding: let x : 'a1 ... 'an. T
+             = e ...
+
+           - Under Cfk_virtual for methods (not values).
+
+           - As the core_type of a Pctf_method node.
+
+           - As the core_type of a Pexp_poly node.
+
+           - As the pld_type field of a label_declaration.
+
+           - As a core_type of a Ptyp_object node.
+         *)
+
+  | Ptyp_package of package_type
+        (* (module S) *)
+  | Ptyp_extension of extension
+        (* [%id] *)
+
+and package_type = Longident.t loc * (Longident.t loc * core_type) list
+      (*
+        (module S)
+        (module S with type t1 = T1 and ... and tn = Tn)
+       *)
+
+and row_field =
+  | Rtag of label loc * attributes * bool * core_type list
+        (* [`A]                   ( true,  [] )
+           [`A of T]              ( false, [T] )
+           [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
+           [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
+
+          - The 2nd field is true if the tag contains a
+            constant (empty) constructor.
+          - '&' occurs when several types are used for the same constructor
+            (see 4.2 in the manual)
+
+          - TODO: switch to a record representation, and keep location
+        *)
+  | Rinherit of core_type
+        (* [ T ] *)
+
+and object_field =
+  | Otag of label loc * attributes * core_type
+  | Oinherit of core_type
+
+(* Patterns *)
+
+and pattern =
+    {
+     ppat_desc: pattern_desc;
+     ppat_loc: Location.t;
+     ppat_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and pattern_desc =
+  | Ppat_any
+        (* _ *)
+  | Ppat_var of string loc
+        (* x *)
+  | Ppat_alias of pattern * string loc
+        (* P as 'a *)
+  | Ppat_constant of constant
+        (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+  | Ppat_interval of constant * constant
+        (* 'a'..'z'
+
+           Other forms of interval are recognized by the parser
+           but rejected by the type-checker. *)
+  | Ppat_tuple of pattern list
+        (* (P1, ..., Pn)
+
+           Invariant: n >= 2
+        *)
+  | Ppat_construct of Longident.t loc * pattern option
+        (* C                None
+           C P              Some P
+           C (P1, ..., Pn)  Some (Ppat_tuple [P1; ...; Pn])
+         *)
+  | Ppat_variant of label * pattern option
+        (* `A             (None)
+           `A P           (Some P)
+         *)
+  | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+        (* { l1=P1; ...; ln=Pn }     (flag = Closed)
+           { l1=P1; ...; ln=Pn; _}   (flag = Open)
+
+           Invariant: n > 0
+         *)
+  | Ppat_array of pattern list
+        (* [| P1; ...; Pn |] *)
+  | Ppat_or of pattern * pattern
+        (* P1 | P2 *)
+  | Ppat_constraint of pattern * core_type
+        (* (P : T) *)
+  | Ppat_type of Longident.t loc
+        (* #tconst *)
+  | Ppat_lazy of pattern
+        (* lazy P *)
+  | Ppat_unpack of string loc
+        (* (module P)
+           Note: (module P : S) is represented as
+           Ppat_constraint(Ppat_unpack, Ptyp_package)
+         *)
+  | Ppat_exception of pattern
+        (* exception P *)
+  | Ppat_extension of extension
+        (* [%id] *)
+  | Ppat_open of Longident.t loc * pattern
+        (* M.(P) *)
+
+(* Value expressions *)
+
+and expression =
+    {
+     pexp_desc: expression_desc;
+     pexp_loc: Location.t;
+     pexp_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and expression_desc =
+  | Pexp_ident of Longident.t loc
+        (* x
+           M.x
+         *)
+  | Pexp_constant of constant
+        (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+  | Pexp_let of rec_flag * value_binding list * expression
+        (* let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
+         *)
+  | Pexp_function of case list
+        (* function P1 -> E1 | ... | Pn -> En *)
+  | Pexp_fun of arg_label * expression option * pattern * expression
+        (* fun P -> E1                          (Simple, None)
+           fun ~l:P -> E1                       (Labelled l, None)
+           fun ?l:P -> E1                       (Optional l, None)
+           fun ?l:(P = E0) -> E1                (Optional l, Some E0)
+
+           Notes:
+           - If E0 is provided, only Optional is allowed.
+           - "fun P1 P2 .. Pn -> E1" is represented as nested Pexp_fun.
+           - "let f P = E" is represented using Pexp_fun.
+         *)
+  | Pexp_apply of expression * (arg_label * expression) list
+        (* E0 ~l1:E1 ... ~ln:En
+           li can be empty (non labeled argument) or start with '?'
+           (optional argument).
+
+           Invariant: n > 0
+         *)
+  | Pexp_match of expression * case list
+        (* match E0 with P1 -> E1 | ... | Pn -> En *)
+  | Pexp_try of expression * case list
+        (* try E0 with P1 -> E1 | ... | Pn -> En *)
+  | Pexp_tuple of expression list
+        (* (E1, ..., En)
+
+           Invariant: n >= 2
+        *)
+  | Pexp_construct of Longident.t loc * expression option
+        (* C                None
+           C E              Some E
+           C (E1, ..., En)  Some (Pexp_tuple[E1;...;En])
+        *)
+  | Pexp_variant of label * expression option
+        (* `A             (None)
+           `A E           (Some E)
+         *)
+  | Pexp_record of (Longident.t loc * expression) list * expression option
+        (* { l1=P1; ...; ln=Pn }     (None)
+           { E0 with l1=P1; ...; ln=Pn }   (Some E0)
+
+           Invariant: n > 0
+         *)
+  | Pexp_field of expression * Longident.t loc
+        (* E.l *)
+  | Pexp_setfield of expression * Longident.t loc * expression
+        (* E1.l <- E2 *)
+  | Pexp_array of expression list
+        (* [| E1; ...; En |] *)
+  | Pexp_ifthenelse of expression * expression * expression option
+        (* if E1 then E2 else E3 *)
+  | Pexp_sequence of expression * expression
+        (* E1; E2 *)
+  | Pexp_while of expression * expression
+        (* while E1 do E2 done *)
+  | Pexp_for of
+      pattern *  expression * expression * direction_flag * expression
+        (* for i = E1 to E2 do E3 done      (flag = Upto)
+           for i = E1 downto E2 do E3 done  (flag = Downto)
+         *)
+  | Pexp_constraint of expression * core_type
+        (* (E : T) *)
+  | Pexp_coerce of expression * core_type option * core_type
+        (* (E :> T)        (None, T)
+           (E : T0 :> T)   (Some T0, T)
+         *)
+  | Pexp_send of expression * label loc
+        (*  E # m *)
+  | Pexp_new of Longident.t loc
+        (* new M.c *)
+  | Pexp_setinstvar of label loc * expression
+        (* x <- 2 *)
+  | Pexp_override of (label loc * expression) list
+        (* {< x1 = E1; ...; Xn = En >} *)
+  | Pexp_letmodule of string loc * module_expr * expression
+        (* let module M = ME in E *)
+  | Pexp_letexception of extension_constructor * expression
+        (* let exception C in E *)
+  | Pexp_assert of expression
+        (* assert E
+           Note: "assert false" is treated in a special way by the
+           type-checker. *)
+  | Pexp_lazy of expression
+        (* lazy E *)
+  | Pexp_poly of expression * core_type option
+        (* Used for method bodies.
+
+           Can only be used as the expression under Cfk_concrete
+           for methods (not values). *)
+  | Pexp_object of class_structure
+        (* object ... end *)
+  | Pexp_newtype of string loc * expression
+        (* fun (type t) -> E *)
+  | Pexp_pack of module_expr
+        (* (module ME)
+
+           (module ME : S) is represented as
+           Pexp_constraint(Pexp_pack, Ptyp_package S) *)
+  | Pexp_open of override_flag * Longident.t loc * expression
+        (* M.(E)
+           let open M in E
+           let! open M in E *)
+  | Pexp_extension of extension
+        (* [%id] *)
+  | Pexp_unreachable
+        (* . *)
+
+and case =   (* (P -> E) or (P when E0 -> E) *)
+    {
+     pc_lhs: pattern;
+     pc_guard: expression option;
+     pc_rhs: expression;
+    }
+
+(* Value descriptions *)
+
+and value_description =
+    {
+     pval_name: string loc;
+     pval_type: core_type;
+     pval_prim: string list;
+     pval_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+     pval_loc: Location.t;
+    }
+
+(*
+  val x: T                            (prim = [])
+  external x: T = "s1" ... "sn"       (prim = ["s1";..."sn"])
+*)
+
+(* Type declarations *)
+
+and type_declaration =
+    {
+     ptype_name: string loc;
+     ptype_params: (core_type * variance) list;
+           (* ('a1,...'an) t; None represents  _*)
+     ptype_cstrs: (core_type * core_type * Location.t) list;
+           (* ... constraint T1=T1'  ... constraint Tn=Tn' *)
+     ptype_kind: type_kind;
+     ptype_private: private_flag;   (* = private ... *)
+     ptype_manifest: core_type option;  (* = T *)
+     ptype_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+     ptype_loc: Location.t;
+    }
+
+(*
+  type t                     (abstract, no manifest)
+  type t = T0                (abstract, manifest=T0)
+  type t = C of T | ...      (variant,  no manifest)
+  type t = T0 = C of T | ... (variant,  manifest=T0)
+  type t = {l: T; ...}       (record,   no manifest)
+  type t = T0 = {l : T; ...} (record,   manifest=T0)
+  type t = ..                (open,     no manifest)
+*)
+
+and type_kind =
+  | Ptype_abstract
+  | Ptype_variant of constructor_declaration list
+        (* Invariant: non-empty list *)
+  | Ptype_record of label_declaration list
+        (* Invariant: non-empty list *)
+  | Ptype_open
+
+and label_declaration =
+    {
+     pld_name: string loc;
+     pld_mutable: mutable_flag;
+     pld_type: core_type;
+     pld_loc: Location.t;
+     pld_attributes: attributes; (* l : T [@id1] [@id2] *)
+    }
+
+(*  { ...; l: T; ... }            (mutable=Immutable)
+    { ...; mutable l: T; ... }    (mutable=Mutable)
+
+    Note: T can be a Ptyp_poly.
+*)
+
+and constructor_declaration =
+    {
+     pcd_name: string loc;
+     pcd_args: constructor_arguments;
+     pcd_res: core_type option;
+     pcd_loc: Location.t;
+     pcd_attributes: attributes; (* C of ... [@id1] [@id2] *)
+    }
+
+and constructor_arguments =
+  | Pcstr_tuple of core_type list
+  | Pcstr_record of label_declaration list
+
+(*
+  | C of T1 * ... * Tn     (res = None,    args = Pcstr_tuple [])
+  | C: T0                  (res = Some T0, args = [])
+  | C: T1 * ... * Tn -> T0 (res = Some T0, args = Pcstr_tuple)
+  | C of {...}             (res = None,    args = Pcstr_record)
+  | C: {...} -> T0         (res = Some T0, args = Pcstr_record)
+  | C of {...} as t        (res = None,    args = Pcstr_record)
+*)
+
+and type_extension =
+    {
+     ptyext_path: Longident.t loc;
+     ptyext_params: (core_type * variance) list;
+     ptyext_constructors: extension_constructor list;
+     ptyext_private: private_flag;
+     ptyext_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+    }
+(*
+  type t += ...
+*)
+
+and extension_constructor =
+    {
+     pext_name: string loc;
+     pext_kind : extension_constructor_kind;
+     pext_loc : Location.t;
+     pext_attributes: attributes; (* C of ... [@id1] [@id2] *)
+    }
+
+and extension_constructor_kind =
+    Pext_decl of constructor_arguments * core_type option
+      (*
+         | C of T1 * ... * Tn     ([T1; ...; Tn], None)
+         | C: T0                  ([], Some T0)
+         | C: T1 * ... * Tn -> T0 ([T1; ...; Tn], Some T0)
+       *)
+  | Pext_rebind of Longident.t loc
+      (*
+         | C = D
+       *)
+
+(** {1 Class language} *)
+
+(* Type expressions for the class language *)
+
+and class_type =
+    {
+     pcty_desc: class_type_desc;
+     pcty_loc: Location.t;
+     pcty_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and class_type_desc =
+  | Pcty_constr of Longident.t loc * core_type list
+        (* c
+           ['a1, ..., 'an] c *)
+  | Pcty_signature of class_signature
+        (* object ... end *)
+  | Pcty_arrow of arg_label * core_type * class_type
+        (* T -> CT       Simple
+           ~l:T -> CT    Labelled l
+           ?l:T -> CT    Optional l
+         *)
+  | Pcty_extension of extension
+        (* [%id] *)
+  | Pcty_open of override_flag * Longident.t loc * class_type
+        (* let open M in CT *)
+
+and class_signature =
+    {
+     pcsig_self: core_type;
+     pcsig_fields: class_type_field list;
+    }
+(* object('selfpat) ... end
+   object ... end             (self = Ptyp_any)
+ *)
+
+and class_type_field =
+    {
+     pctf_desc: class_type_field_desc;
+     pctf_loc: Location.t;
+     pctf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+and class_type_field_desc =
+  | Pctf_inherit of class_type
+        (* inherit CT *)
+  | Pctf_val of (label loc * mutable_flag * virtual_flag * core_type)
+        (* val x: T *)
+  | Pctf_method  of (label loc * private_flag * virtual_flag * core_type)
+        (* method x: T
+
+           Note: T can be a Ptyp_poly.
+         *)
+  | Pctf_constraint  of (core_type * core_type)
+        (* constraint T1 = T2 *)
+  | Pctf_attribute of attribute
+        (* [@@@id] *)
+  | Pctf_extension of extension
+        (* [%%id] *)
+
+and 'a class_infos =
+    {
+     pci_virt: virtual_flag;
+     pci_params: (core_type * variance) list;
+     pci_name: string loc;
+     pci_expr: 'a;
+     pci_loc: Location.t;
+     pci_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+    }
+(* class c = ...
+   class ['a1,...,'an] c = ...
+   class virtual c = ...
+
+   Also used for "class type" declaration.
+*)
+
+and class_description = class_type class_infos
+
+and class_type_declaration = class_type class_infos
+
+(* Value expressions for the class language *)
+
+and class_expr =
+    {
+     pcl_desc: class_expr_desc;
+     pcl_loc: Location.t;
+     pcl_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and class_expr_desc =
+  | Pcl_constr of Longident.t loc * core_type list
+        (* c
+           ['a1, ..., 'an] c *)
+  | Pcl_structure of class_structure
+        (* object ... end *)
+  | Pcl_fun of arg_label * expression option * pattern * class_expr
+        (* fun P -> CE                          (Simple, None)
+           fun ~l:P -> CE                       (Labelled l, None)
+           fun ?l:P -> CE                       (Optional l, None)
+           fun ?l:(P = E0) -> CE                (Optional l, Some E0)
+         *)
+  | Pcl_apply of class_expr * (arg_label * expression) list
+        (* CE ~l1:E1 ... ~ln:En
+           li can be empty (non labeled argument) or start with '?'
+           (optional argument).
+
+           Invariant: n > 0
+         *)
+  | Pcl_let of rec_flag * value_binding list * class_expr
+        (* let P1 = E1 and ... and Pn = EN in CE      (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN in CE  (flag = Recursive)
+         *)
+  | Pcl_constraint of class_expr * class_type
+        (* (CE : CT) *)
+  | Pcl_extension of extension
+  (* [%id] *)
+  | Pcl_open of override_flag * Longident.t loc * class_expr
+  (* let open M in CE *)
+
+
+and class_structure =
+    {
+     pcstr_self: pattern;
+     pcstr_fields: class_field list;
+    }
+(* object(selfpat) ... end
+   object ... end           (self = Ppat_any)
+ *)
+
+and class_field =
+    {
+     pcf_desc: class_field_desc;
+     pcf_loc: Location.t;
+     pcf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+and class_field_desc =
+  | Pcf_inherit of override_flag * class_expr * string loc option
+        (* inherit CE
+           inherit CE as x
+           inherit! CE
+           inherit! CE as x
+         *)
+  | Pcf_val of (label loc * mutable_flag * class_field_kind)
+        (* val x = E
+           val virtual x: T
+         *)
+  | Pcf_method of (label loc * private_flag * class_field_kind)
+        (* method x = E            (E can be a Pexp_poly)
+           method virtual x: T     (T can be a Ptyp_poly)
+         *)
+  | Pcf_constraint of (core_type * core_type)
+        (* constraint T1 = T2 *)
+  | Pcf_initializer of expression
+        (* initializer E *)
+  | Pcf_attribute of attribute
+        (* [@@@id] *)
+  | Pcf_extension of extension
+        (* [%%id] *)
+
+and class_field_kind =
+  | Cfk_virtual of core_type
+  | Cfk_concrete of override_flag * expression
+
+and class_declaration = class_expr class_infos
+
+(** {1 Module language} *)
+
+(* Type expressions for the module language *)
+
+and module_type =
+    {
+     pmty_desc: module_type_desc;
+     pmty_loc: Location.t;
+     pmty_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and module_type_desc =
+  | Pmty_ident of Longident.t loc
+        (* S *)
+  | Pmty_signature of signature
+        (* sig ... end *)
+  | Pmty_functor of string loc * module_type option * module_type
+        (* functor(X : MT1) -> MT2 *)
+  | Pmty_with of module_type * with_constraint list
+        (* MT with ... *)
+  | Pmty_typeof of module_expr
+        (* module type of ME *)
+  | Pmty_extension of extension
+        (* [%id] *)
+  | Pmty_alias of Longident.t loc
+        (* (module M) *)
+
+and signature = signature_item list
+
+and signature_item =
+    {
+     psig_desc: signature_item_desc;
+     psig_loc: Location.t;
+    }
+
+and signature_item_desc =
+  | Psig_value of value_description
+        (*
+          val x: T
+          external x: T = "s1" ... "sn"
+         *)
+  | Psig_type of rec_flag * type_declaration list
+        (* type t1 = ... and ... and tn = ... *)
+  | Psig_typext of type_extension
+        (* type t1 += ... *)
+  | Psig_exception of extension_constructor
+        (* exception C of T *)
+  | Psig_module of module_declaration
+        (* module X : MT *)
+  | Psig_recmodule of module_declaration list
+        (* module rec X1 : MT1 and ... and Xn : MTn *)
+  | Psig_modtype of module_type_declaration
+        (* module type S = MT
+           module type S *)
+  | Psig_open of open_description
+        (* open X *)
+  | Psig_include of include_description
+        (* include MT *)
+  | Psig_class of class_description list
+        (* class c1 : ... and ... and cn : ... *)
+  | Psig_class_type of class_type_declaration list
+        (* class type ct1 = ... and ... and ctn = ... *)
+  | Psig_attribute of attribute
+        (* [@@@id] *)
+  | Psig_extension of extension * attributes
+        (* [%%id] *)
+
+and module_declaration =
+    {
+     pmd_name: string loc;
+     pmd_type: module_type;
+     pmd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pmd_loc: Location.t;
+    }
+(* S : MT *)
+
+and module_type_declaration =
+    {
+     pmtd_name: string loc;
+     pmtd_type: module_type option;
+     pmtd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pmtd_loc: Location.t;
+    }
+(* S = MT
+   S       (abstract module type declaration, pmtd_type = None)
+*)
+
+and open_description =
+    {
+     popen_lid: Longident.t loc;
+     popen_override: override_flag;
+     popen_loc: Location.t;
+     popen_attributes: attributes;
+    }
+(* open! X - popen_override = Override (silences the 'used identifier
+                              shadowing' warning)
+   open  X - popen_override = Fresh
+ *)
+
+and 'a include_infos =
+    {
+     pincl_mod: 'a;
+     pincl_loc: Location.t;
+     pincl_attributes: attributes;
+    }
+
+and include_description = module_type include_infos
+(* include MT *)
+
+and include_declaration = module_expr include_infos
+(* include ME *)
+
+and with_constraint =
+  | Pwith_type of Longident.t loc * type_declaration
+        (* with type X.t = ...
+
+           Note: the last component of the longident must match
+           the name of the type_declaration. *)
+  | Pwith_module of Longident.t loc * Longident.t loc
+        (* with module X.Y = Z *)
+  | Pwith_typesubst of Longident.t loc * type_declaration
+        (* with type X.t := ..., same format as [Pwith_type] *)
+  | Pwith_modsubst of Longident.t loc * Longident.t loc
+        (* with module X.Y := Z *)
+
+(* Value expressions for the module language *)
+
+and module_expr =
+    {
+     pmod_desc: module_expr_desc;
+     pmod_loc: Location.t;
+     pmod_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and module_expr_desc =
+  | Pmod_ident of Longident.t loc
+        (* X *)
+  | Pmod_structure of structure
+        (* struct ... end *)
+  | Pmod_functor of string loc * module_type option * module_expr
+        (* functor(X : MT1) -> ME *)
+  | Pmod_apply of module_expr * module_expr
+        (* ME1(ME2) *)
+  | Pmod_constraint of module_expr * module_type
+        (* (ME : MT) *)
+  | Pmod_unpack of expression
+        (* (val E) *)
+  | Pmod_extension of extension
+        (* [%id] *)
+
+and structure = structure_item list
+
+and structure_item =
+    {
+     pstr_desc: structure_item_desc;
+     pstr_loc: Location.t;
+    }
+
+and structure_item_desc =
+  | Pstr_eval of expression * attributes
+        (* E *)
+  | Pstr_value of rec_flag * value_binding list
+        (* let P1 = E1 and ... and Pn = EN       (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN   (flag = Recursive)
+         *)
+  | Pstr_primitive of value_description
+        (*  val x: T
+            external x: T = "s1" ... "sn" *)
+  | Pstr_type of rec_flag * type_declaration list
+        (* type t1 = ... and ... and tn = ... *)
+  | Pstr_typext of type_extension
+        (* type t1 += ... *)
+  | Pstr_exception of extension_constructor
+        (* exception C of T
+           exception C = M.X *)
+  | Pstr_module of module_binding
+        (* module X = ME *)
+  | Pstr_recmodule of module_binding list
+        (* module rec X1 = ME1 and ... and Xn = MEn *)
+  | Pstr_modtype of module_type_declaration
+        (* module type S = MT *)
+  | Pstr_open of open_description
+        (* open X *)
+  | Pstr_class of class_declaration list
+        (* class c1 = ... and ... and cn = ... *)
+  | Pstr_class_type of class_type_declaration list
+        (* class type ct1 = ... and ... and ctn = ... *)
+  | Pstr_include of include_declaration
+        (* include ME *)
+  | Pstr_attribute of attribute
+        (* [@@@id] *)
+  | Pstr_extension of extension * attributes
+        (* [%%id] *)
+
+and value_binding =
+  {
+    pvb_pat: pattern;
+    pvb_expr: expression;
+    pvb_attributes: attributes;
+    pvb_loc: Location.t;
+  }
+
+and module_binding =
+    {
+     pmb_name: string loc;
+     pmb_expr: module_expr;
+     pmb_attributes: attributes;
+     pmb_loc: Location.t;
+    }
+(* X = ME *)
+
+(** {1 Toplevel} *)
+
+(* Toplevel phrases *)
+
+type toplevel_phrase =
+  | Ptop_def of structure
+  | Ptop_dir of string * directive_argument
+     (* #use, #load ... *)
+
+and directive_argument =
+  | Pdir_none
+  | Pdir_string of string
+  | Pdir_int of string * char option
+  | Pdir_ident of Longident.t
+  | Pdir_bool of bool
+end
+
+
+(* ---- @xote.component fine-grained rewriter ------------------------------
+   Decomposes the JSX returned by an @xote.component into fine-grained reactive
+   leaves instead of wrapping the whole block in one computed:
+
+     - an attribute value that reads a Signal  ->  thunked, so JSX lowers it
+       to `View.computedAttr` (only that attribute re-runs);
+     - a <View.Text>/<View.Int>/<View.Float>/<View.Bool> child that reads a
+       Signal  ->  thunked, so it lowers to a reactive text node (only that
+       text node re-runs);
+     - genuine control flow in *node position* (an `if`/`switch` producing
+       nodes) whose result varies  ->  wrapped in `View.tracked`, the one
+       place a structural swap is unavoidable.
+
+   The element structure itself (tags, nesting) is emitted once and never
+   rebuilt. Only the leaves that actually read signals become reactive. *)
+open Asttypes
+open Parsetree
+
+let none : Location.t =
+  { Location.loc_start = Lexing.dummy_pos; loc_end = Lexing.dummy_pos; loc_ghost = true }
+let mkloc (txt : 'a) : 'a Location.loc = { Location.txt; loc = none }
+let mkexp d = { pexp_desc = d; pexp_loc = none; pexp_attributes = [] }
+let ident lid = mkexp (Pexp_ident (mkloc lid))
+let apply f args = mkexp (Pexp_apply (f, List.map (fun a -> (Nolabel, a)) args))
+
+(* Uncurried unit thunk: `Function$(fun () -> body)` with `res.arity 1`, the
+   4.06-ppx encoding ReScript uses for uncurried funcs (see PR #34). A bare
+   Pexp_fun would import as curried and be rejected in uncurried-by-default. *)
+let res_arity n : attribute =
+  let e = mkexp (Pexp_constant (Pconst_integer (string_of_int n, None))) in
+  (mkloc "res.arity", PStr [ { pstr_desc = Pstr_eval (e, []); pstr_loc = none } ])
+let unit_pat =
+  { ppat_desc = Ppat_construct (mkloc (Longident.Lident "()"), None);
+    ppat_loc = none; ppat_attributes = [] }
+let thunk body =
+  let fn = mkexp (Pexp_fun (Nolabel, None, unit_pat, body)) in
+  { pexp_desc = Pexp_construct (mkloc (Longident.Lident "Function$"), Some fn);
+    pexp_loc = none; pexp_attributes = [ res_arity 1 ] }
+
+let view_tracked = Longident.Ldot (Longident.Lident "View", "tracked")
+let wrap_tracked e = apply (ident view_tracked) [ thunk e ]
+
+(* ---- signal-read detection ----------------------------------------------
+   A read is any occurrence of `Signal.get` (applied or not). Beyond the
+   literal `Signal.get` / `X.Signal.get`, an alias environment threaded through
+   the traversal also recognises indirect reads:
+     - a value alias:    `let g = Signal.get` then `g(sig)`
+     - a module alias:   `module S = Signal` then `S.get(sig)`
+     - an open:          `open Signal` then a bare `get(sig)`
+     - a reactive helper: `let cls = () => Signal.get(x) ? …` then `cls()` —
+       a local function whose body eagerly reads a signal; calling it is a read.
+   The environment is scoped by the traversal (bindings visible only after they
+   appear); shadowing a name with a non-reactive binding removes it. *)
+type env = { vals : string list; mods : string list; funcs : string list; open_signal : bool }
+let empty_env = { vals = []; mods = []; funcs = []; open_signal = false }
+
+let is_signal_get (env : env) (e : expression) : bool =
+  match e.pexp_desc with
+  | Pexp_ident { txt = Longident.Ldot (m, "get"); _ } ->
+    (match m with
+     | Longident.Lident "Signal" -> true
+     | Longident.Ldot (_, "Signal") -> true
+     | Longident.Lident name -> List.mem name env.mods
+     | _ -> false)
+  | Pexp_ident { txt = Longident.Lident name; _ } ->
+    List.mem name env.vals || (env.open_signal && name = "get")
+  | _ -> false
+
+let sub_exprs (e : expression) : expression list =
+  match e.pexp_desc with
+  | Pexp_apply (f, args) -> f :: List.map snd args
+  | Pexp_ifthenelse (c, t, eo) -> c :: t :: (match eo with Some x -> [ x ] | None -> [])
+  | Pexp_match (x, cases) | Pexp_try (x, cases) -> x :: List.map (fun c -> c.pc_rhs) cases
+  | Pexp_construct (_, Some x) -> [ x ]
+  | Pexp_tuple xs | Pexp_array xs -> xs
+  | Pexp_field (x, _) -> [ x ]
+  | Pexp_record (fields, base) ->
+    List.map snd fields @ (match base with Some b -> [ b ] | None -> [])
+  | Pexp_constraint (x, _) -> [ x ]
+  | Pexp_coerce (x, _, _) -> [ x ]
+  | Pexp_sequence (a, b) -> [ a; b ]
+  | Pexp_let (_, vbs, body) -> List.map (fun vb -> vb.pvb_expr) vbs @ [ body ]
+  | Pexp_fun (_, def, _, body) -> (match def with Some d -> [ d ] | None -> []) @ [ body ]
+  | Pexp_open (_, _, x) -> [ x ]
+  | Pexp_assert x | Pexp_lazy x -> [ x ]
+  | _ -> []
+
+(* A reactive-helper *call*: `f(...)` where `f` is a local function whose body
+   eagerly reads a signal (tracked in env.funcs). A *bare* `f` (passed, not
+   called) is left alone — the runtime already treats a function attribute/child
+   as a computed. *)
+let is_reactive_call (env : env) (e : expression) : bool =
+  match e.pexp_desc with
+  | Pexp_apply ({ pexp_desc = Pexp_ident { txt = Longident.Lident f; _ }; _ }, _) ->
+    List.mem f env.funcs
+  | _ -> false
+
+(* An *eager* read: a `Signal.get` (or reactive-helper call) that runs when this
+   expression is evaluated, not one deferred inside a nested lambda. Reads inside
+   `() => …`, `Computed.make(() => …)`, `Prop.reactive(Computed.make(() => …))`,
+   etc. are already reactive on their own, so a value that only reads inside a
+   lambda must NOT be re-wrapped in a thunk. Stops descending at fn boundaries. *)
+let rec reads_signal_eager (env : env) (e : expression) : bool =
+  match e.pexp_desc with
+  | Pexp_fun _ -> false
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some _) -> false
+  | _ ->
+    is_reactive_call env e || is_signal_get env e
+    || List.exists (reads_signal_eager env) (sub_exprs e)
+
+(* Does `e` denote a function whose body eagerly reads a signal? Strip the
+   function's own parameters (its uncurried `Function$` wrapper and `fun`s),
+   then check the immediate body — reads_signal_eager stops at any further nested
+   lambda, so a helper that merely *returns* a thunk is correctly not counted. *)
+let func_reads (env : env) (e : expression) : bool =
+  let rec strip_params b =
+    match b.pexp_desc with Pexp_fun (_, _, _, body) -> strip_params body | _ -> b
+  in
+  match e.pexp_desc with
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some fn) ->
+    reads_signal_eager env (strip_params fn)
+  | Pexp_fun _ -> reads_signal_eager env (strip_params e)
+  | _ -> false
+
+(* ---- binding collectors ------------------------------------------------- *)
+(* `let g = Signal.get` binds `g` as a value alias; `let cls = () => …Signal.get…`
+   binds `cls` as a reactive helper; anything else shadows away a prior binding
+   of that name. *)
+let collect_val_aliases (env : env) (vbs : value_binding list) : env =
+  List.fold_left
+    (fun env vb ->
+      match vb.pvb_pat.ppat_desc with
+      | Ppat_var { txt = name; _ } ->
+        let drop = List.filter (fun n -> n <> name) in
+        if is_signal_get env vb.pvb_expr then
+          { env with vals = name :: env.vals; funcs = drop env.funcs }
+        else if func_reads env vb.pvb_expr then
+          { env with funcs = name :: env.funcs; vals = drop env.vals }
+        else { env with vals = drop env.vals; funcs = drop env.funcs }
+      | _ -> env)
+    env vbs
+
+let is_signal_module (me : module_expr) : bool =
+  match me.pmod_desc with
+  | Pmod_ident { txt = Longident.Lident "Signal"; _ } -> true
+  | Pmod_ident { txt = Longident.Ldot (_, "Signal"); _ } -> true
+  | _ -> false
+
+let collect_mod_alias (env : env) (name : string Location.loc) (me : module_expr) : env =
+  if is_signal_module me then { env with mods = name.Location.txt :: env.mods } else env
+
+let is_signal_lid = function
+  | Longident.Lident "Signal" -> true
+  | Longident.Ldot (_, "Signal") -> true
+  | _ -> false
+
+let collect_open (env : env) (lid : Longident.t) : env =
+  if is_signal_lid lid then { env with open_signal = true } else env
+
+(* ---- JSX shape helpers -------------------------------------------------- *)
+let has_jsx (e : expression) : bool =
+  List.exists (fun ((n : string Location.loc), _) -> n.Location.txt = "JSX") e.pexp_attributes
+
+let jsx_parts (e : expression) =
+  match e.pexp_desc with
+  | Pexp_apply (f, args) when has_jsx e -> Some (f, args)
+  | _ -> None
+
+(* Lowercase leading char => intrinsic HTML/SVG element (children are nodes). *)
+let is_element (f : expression) : bool =
+  match f.pexp_desc with
+  | Pexp_ident { txt = Longident.Lident s; _ } ->
+    String.length s > 0 && s.[0] >= 'a' && s.[0] <= 'z'
+  | _ -> false
+
+(* View.Text / View.Int / View.Float / View.Bool: children are *values*. *)
+let is_value_component (f : expression) : bool =
+  match f.pexp_desc with
+  | Pexp_ident { txt = Longident.Ldot (Longident.Lident "View", ("Text" | "Int" | "Float" | "Bool")); _ } ->
+    true
+  | _ -> false
+
+let is_children_label = function
+  | Labelled "children" | Optional "children" -> true
+  | _ -> false
+
+(* A value-position expression should be thunked iff it *eagerly* reads a signal
+   and isn't already JSX. Using the eager check means values that are already
+   reactive on their own — a `() => …` thunk, a `Computed`, a `Prop.reactive(…)`
+   — are left untouched (their reads are deferred inside a lambda), so
+   @xote.component is a safe drop-in on components already written that way. *)
+let should_thunk (env : env) (v : expression) : bool =
+  reads_signal_eager env v && jsx_parts v = None
+
+(* ---- decomposition ------------------------------------------------------ *)
+let rec fine_node (env : env) (e : expression) : expression =
+  match jsx_parts e with
+  | Some (f, args) when is_value_component f ->
+    { e with pexp_desc = Pexp_apply (f, List.map (value_arg env) args) }
+  | Some (f, args) ->
+    (* element or user component: attrs are value position, children nodes *)
+    { e with pexp_desc = Pexp_apply (f, List.map (element_arg env) args) }
+  | None ->
+    (* not a JSX element: a bare child expression in node position. A signal
+       read here means the *node structure* varies, which needs View.tracked.
+       But first recurse fine-grained into each branch body: that turns the
+       branches' leaves into thunks, so when the tracked scope runs a branch to
+       build its nodes the thunks are not invoked — the scope ends up tracking
+       only the condition/scrutinee (the eager reads), while a leaf inside a
+       branch keeps its own reactive scope. Net effect: changing a signal that
+       only a branch leaf reads updates just that leaf and does NOT re-run the
+       switch or rebuild the branch.
+
+       The *eager* read check matters here too: a child that is already reactive
+       on its own (e.g. `View.signalText(() => Signal.get(x))`) reads only inside
+       a lambda, so it is left as-is rather than redundantly wrapped. *)
+    if reads_signal_eager env e then wrap_tracked (decompose_branches env e) else e
+
+(* Recurse fine_node into the *node-position* bodies of control flow (the
+   condition/scrutinee and any guards stay untouched — they are value position
+   and should drive the structural swap). *)
+and decompose_branches (env : env) (e : expression) : expression =
+  match e.pexp_desc with
+  | Pexp_ifthenelse (c, t, eo) ->
+    { e with pexp_desc = Pexp_ifthenelse (c, fine_node env t, Option.map (fine_node env) eo) }
+  | Pexp_match (s, cases) ->
+    { e with pexp_desc = Pexp_match (s, List.map (fun cs -> { cs with pc_rhs = fine_node env cs.pc_rhs }) cases) }
+  | _ -> e
+
+and element_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
+  if is_children_label lbl then (lbl, map_children (fine_node env) v)
+  else
+    match lbl with
+    | Labelled _ | Optional _ ->
+      (* attribute: value position. Thunk it if reactive so it lowers to a
+         computed attribute; leave plain JSX/static/already-function values. *)
+      if should_thunk env v then (lbl, thunk v) else (lbl, v)
+    | Nolabel -> (lbl, v)
+
+and value_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
+  if is_children_label lbl then (lbl, map_children (value_leaf env) v)
+  else
+    match lbl with
+    | Labelled "value" -> (lbl, if should_thunk env v then thunk v else v)
+    | _ -> (lbl, v)
+
+(* child of a value component (View.Text ...): value position -> thunk. *)
+and value_leaf (env : env) (v : expression) : expression =
+  if should_thunk env v then thunk v else v
+
+(* Map [f] over a JSX children list (a `::`/`[]` spine); tolerate a bare
+   single child that is not wrapped in a list. *)
+and map_children f (v : expression) : expression =
+  match v.pexp_desc with
+  | Pexp_construct
+      ( ({ txt = Longident.Lident "::"; _ } as c),
+        Some ({ pexp_desc = Pexp_tuple [ hd; tl ]; _ } as tup) ) ->
+    let hd' = f hd in
+    let tl' = map_children f tl in
+    { v with pexp_desc = Pexp_construct (c, Some { tup with pexp_desc = Pexp_tuple [ hd'; tl' ] }) }
+  | Pexp_construct ({ txt = Longident.Lident "[]"; _ }, None) -> v
+  | _ -> f v
+
+(* ---- traversal: find @xote.component and decompose ----------------------- *)
+(* `@xote.component` is the single annotation: it derives props exactly like
+   `@jsx.component` (which we emit for the JSX transform to expand) *and*
+   fine-grained-decomposes the returned JSX. One attribute replaces
+   `@jsx.component` and makes the whole component tracked. *)
+let is_xote_component ((name, _) : attribute) = name.Location.txt = "xote.component"
+let strip_xote_component = List.filter (fun a -> not (is_xote_component a))
+let jsx_component_attr : attribute = (mkloc "jsx.component", PStr [])
+
+let rec map_expr (env : env) (e : expression) : expression = map_children_expr env e
+
+and map_children_expr (env : env) (e : expression) : expression =
+  let d =
+    match e.pexp_desc with
+    | Pexp_fun (l, def, p, body) -> Pexp_fun (l, def, p, map_expr env body)
+    | Pexp_let (r, vbs, body) ->
+      (* aliases bound here are visible in the body, not in the RHSs *)
+      let vbs' = List.map (map_vb env) vbs in
+      let env' = collect_val_aliases env vbs in
+      Pexp_let (r, vbs', map_expr env' body)
+    | Pexp_letmodule (name, me, body) ->
+      let env' = collect_mod_alias env name me in
+      Pexp_letmodule (name, me, map_expr env' body)
+    | Pexp_open (o, l, x) ->
+      let env' = collect_open env l.Location.txt in
+      Pexp_open (o, l, map_expr env' x)
+    | Pexp_sequence (a, b) -> Pexp_sequence (map_expr env a, map_expr env b)
+    | Pexp_apply (f, args) ->
+      Pexp_apply (map_expr env f, List.map (fun (l, a) -> (l, map_expr env a)) args)
+    | Pexp_ifthenelse (c, t, eo) ->
+      Pexp_ifthenelse (map_expr env c, map_expr env t, Option.map (map_expr env) eo)
+    | Pexp_match (x, cases) ->
+      Pexp_match (map_expr env x, List.map (fun cs -> { cs with pc_rhs = map_expr env cs.pc_rhs }) cases)
+    | Pexp_constraint (x, t) -> Pexp_constraint (map_expr env x, t)
+    | Pexp_tuple xs -> Pexp_tuple (List.map (map_expr env) xs)
+    | Pexp_array xs -> Pexp_array (List.map (map_expr env) xs)
+    | Pexp_construct (l, eo) -> Pexp_construct (l, Option.map (map_expr env) eo)
+    | other -> other
+  in
+  { e with pexp_desc = d }
+
+and map_vb (env : env) (vb : value_binding) : value_binding =
+  match List.find_opt is_xote_component vb.pvb_attributes with
+  | Some _ ->
+    (* swap @xote.component -> @jsx.component and decompose the returned JSX *)
+    { vb with
+      pvb_attributes = jsx_component_attr :: strip_xote_component vb.pvb_attributes;
+      pvb_expr = decompose_component_body env vb.pvb_expr }
+  | None -> { vb with pvb_expr = map_expr env vb.pvb_expr }
+
+(* Walk to the component's tail (return) expression, threading the alias env
+   through lets/opens and running the normal traversal on non-tail parts (so a
+   nested reactive leaves still work), then fine-grain the returned JSX. *)
+and decompose_component_body (env : env) (e : expression) : expression =
+  match e.pexp_desc with
+  (* Uncurried function encoding: `Function$(fun … -> body)` (with res.arity on
+     the construct, preserved by the record-with). Unwrap to reach the fun. *)
+  | Pexp_construct (({ txt = Longident.Lident "Function$"; _ } as c), Some fn) ->
+    { e with pexp_desc = Pexp_construct (c, Some (decompose_component_body env fn)) }
+  | Pexp_fun (l, def, p, body) ->
+    { e with pexp_desc = Pexp_fun (l, def, p, decompose_component_body env body) }
+  | Pexp_let (r, vbs, body) ->
+    let vbs' = List.map (map_vb env) vbs in
+    let env' = collect_val_aliases env vbs in
+    { e with pexp_desc = Pexp_let (r, vbs', decompose_component_body env' body) }
+  | Pexp_letmodule (name, me, body) ->
+    let env' = collect_mod_alias env name me in
+    { e with pexp_desc = Pexp_letmodule (name, me, decompose_component_body env' body) }
+  | Pexp_open (o, l, x) ->
+    let env' = collect_open env l.Location.txt in
+    { e with pexp_desc = Pexp_open (o, l, decompose_component_body env' x) }
+  | Pexp_sequence (a, b) ->
+    { e with pexp_desc = Pexp_sequence (map_expr env a, decompose_component_body env b) }
+  | Pexp_constraint (x, t) ->
+    { e with pexp_desc = Pexp_constraint (decompose_component_body env x, t) }
+  | _ -> fine_node env e
+
+(* Structure items are threaded left-to-right so a top-level `let g = Signal.get`,
+   `module S = Signal`, or `open Signal` is visible to later items. *)
+let rec map_structure (env : env) (s : structure) : structure =
+  let _, rev =
+    List.fold_left
+      (fun (env, acc) si -> (update_env_si env si, map_si env si :: acc))
+      (env, []) s
+  in
+  List.rev rev
+
+and update_env_si (env : env) si =
+  match si.pstr_desc with
+  | Pstr_value (_, vbs) -> collect_val_aliases env vbs
+  | Pstr_module mb -> collect_mod_alias env mb.pmb_name mb.pmb_expr
+  | Pstr_open od -> collect_open env od.popen_lid.Location.txt
+  | _ -> env
+
+and map_si (env : env) si =
+  match si.pstr_desc with
+  | Pstr_value (r, vbs) -> { si with pstr_desc = Pstr_value (r, List.map (map_vb env) vbs) }
+  | Pstr_module mb -> { si with pstr_desc = Pstr_module (map_mb env mb) }
+  | Pstr_eval (e, attrs) -> { si with pstr_desc = Pstr_eval (map_expr env e, attrs) }
+  | _ -> si
+
+and map_mb (env : env) mb = { mb with pmb_expr = map_mod env mb.pmb_expr }
+and map_mod (env : env) me =
+  match me.pmod_desc with
+  | Pmod_structure s -> { me with pmod_desc = Pmod_structure (map_structure env s) }
+  | _ -> me
+
+(* ---- ReScript -ppx binary protocol: `ppx <infile> <outfile>` ------------ *)
+let impl_magic = "Caml1999M022"
+let () =
+  let n = Array.length Sys.argv in
+  let infile = Sys.argv.(n - 2) and outfile = Sys.argv.(n - 1) in
+  let ic = open_in_bin infile in
+  let magic = really_input_string ic (String.length impl_magic) in
+  let name : string = input_value ic in
+  let payload : Obj.t = input_value ic in
+  close_in ic;
+  let oc = open_out_bin outfile in
+  output_string oc magic;
+  output_value oc name;
+  (if magic = impl_magic then output_value oc (map_structure empty_env (Obj.magic payload : structure))
+   else output_value oc payload);
+  close_out oc

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -1045,6 +1045,40 @@ let sub_exprs (e : expression) : expression list =
   | Pexp_assert x | Pexp_lazy x -> [ x ]
   | _ -> []
 
+(* The map counterpart of sub_exprs: rebuild [e] with [f] applied to each
+   immediate sub-expression, leaving everything else (patterns, guards,
+   labels, types) untouched. *)
+let map_sub_exprs (f : expression -> expression) (e : expression) : expression =
+  let d =
+    match e.pexp_desc with
+    | Pexp_apply (fn, args) -> Pexp_apply (f fn, List.map (fun (l, a) -> (l, f a)) args)
+    | Pexp_ifthenelse (c, t, eo) -> Pexp_ifthenelse (f c, f t, Option.map f eo)
+    | Pexp_match (x, cases) ->
+      Pexp_match (f x, List.map (fun c -> { c with pc_rhs = f c.pc_rhs }) cases)
+    | Pexp_try (x, cases) ->
+      Pexp_try (f x, List.map (fun c -> { c with pc_rhs = f c.pc_rhs }) cases)
+    | Pexp_construct (l, eo) -> Pexp_construct (l, Option.map f eo)
+    | Pexp_variant (l, eo) -> Pexp_variant (l, Option.map f eo)
+    | Pexp_tuple xs -> Pexp_tuple (List.map f xs)
+    | Pexp_array xs -> Pexp_array (List.map f xs)
+    | Pexp_field (x, l) -> Pexp_field (f x, l)
+    | Pexp_setfield (a, l, b) -> Pexp_setfield (f a, l, f b)
+    | Pexp_send (x, l) -> Pexp_send (f x, l)
+    | Pexp_record (fields, base) ->
+      Pexp_record (List.map (fun (l, v) -> (l, f v)) fields, Option.map f base)
+    | Pexp_constraint (x, t) -> Pexp_constraint (f x, t)
+    | Pexp_coerce (x, a, b) -> Pexp_coerce (f x, a, b)
+    | Pexp_sequence (a, b) -> Pexp_sequence (f a, f b)
+    | Pexp_let (r, vbs, body) ->
+      Pexp_let (r, List.map (fun vb -> { vb with pvb_expr = f vb.pvb_expr }) vbs, f body)
+    | Pexp_fun (l, def, p, body) -> Pexp_fun (l, Option.map f def, p, f body)
+    | Pexp_open (o, l, x) -> Pexp_open (o, l, f x)
+    | Pexp_assert x -> Pexp_assert (f x)
+    | Pexp_lazy x -> Pexp_lazy (f x)
+    | other -> other
+  in
+  { e with pexp_desc = d }
+
 (* A reactive-helper *call*: `f(...)` where `f` is a local function whose body
    eagerly reads a signal (tracked in env.funcs). A *bare* `f` (passed, not
    called) is left alone — the runtime already treats a function attribute/child
@@ -1148,6 +1182,49 @@ let is_value_component (f : expression) : bool =
     true
   | _ -> false
 
+(* ---- render callbacks ----------------------------------------------------
+   A prop whose value is a *function returning JSX* — `render={item => <li>…}`
+   on View.For/Value/Maybe, or any user component taking a render callback.
+   The lambda's body is node position, so it must be decomposed like any other
+   node: without this, a bare child inside a render callback is never coerced
+   and `<span> {item.name} </span>` fails to compile with "This has type:
+   string". Only bodies that actually reach JSX qualify, so event handlers and
+   other function props (`by={p => p.id}`, `onClick={…}`) are left alone. *)
+
+(* The expression a block finally evaluates to (past lets/opens/sequences). *)
+let rec tail_expr (e : expression) : expression =
+  match e.pexp_desc with
+  | Pexp_let (_, _, body) -> tail_expr body
+  | Pexp_letmodule (_, _, body) -> tail_expr body
+  | Pexp_open (_, _, x) -> tail_expr x
+  | Pexp_sequence (_, b) -> tail_expr b
+  | Pexp_constraint (x, _) -> tail_expr x
+  | _ -> e
+
+(* The body of a (possibly uncurried, possibly multi-parameter) function. *)
+let rec fun_body (e : expression) : expression option =
+  match e.pexp_desc with
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some fn) -> fun_body fn
+  | Pexp_fun (_, _, _, body) ->
+    (match fun_body body with Some inner -> Some inner | None -> Some body)
+  | _ -> None
+
+(* Does this expression produce JSX? Directly, or through control flow whose
+   branches do — `() => if cond { <p/> } else { <span/> }` is as much a node
+   producer as `() => <p/>`. *)
+let rec returns_jsx (e : expression) : bool =
+  let t = tail_expr e in
+  if jsx_parts t <> None || is_jsx_fragment t then true
+  else
+    match t.pexp_desc with
+    | Pexp_ifthenelse (_, a, b) ->
+      returns_jsx a || (match b with Some x -> returns_jsx x | None -> false)
+    | Pexp_match (_, cases) -> List.exists (fun c -> returns_jsx c.pc_rhs) cases
+    | _ -> false
+
+let is_render_callback (e : expression) : bool =
+  match fun_body e with Some body -> returns_jsx body | None -> false
+
 let is_children_label = function
   | Labelled "children" | Optional "children" -> true
   | _ -> false
@@ -1206,15 +1283,26 @@ let rec fine_node (env : env) (e : expression) : expression =
 
           The *eager* read check matters here too: a control-flow child that is
           already reactive on its own reads only inside a lambda, so it is left
-          as-is rather than redundantly wrapped. *)
-       if reads_signal_eager env e then wrap_tracked (decompose_branches env e) else e
+          as-is rather than redundantly wrapped.
+
+          A condition with no eager read needs no View.tracked — its structure
+          cannot change — but its branches are still node position and must be
+          decomposed all the same. Skipping them (as this did) meant a bare
+          child inside a statically-conditioned branch never reached
+          View.child, so `{if isActive { <b> {"yes"} </b> } else { … }}` failed
+          to compile with "This has type: string" pointing at the literal
+          rather than at the conditional. Conditioning on a plain bool (a prop,
+          a local) is ordinary UI code, so this path matters as much as the
+          reactive one. *)
+       let branches = decompose_branches env e in
+       if reads_signal_eager env e then wrap_tracked branches else branches
      | Pexp_let (r, vbs, body) ->
        (* A block expression in node position — `{let x = …; <span/>}`. Recurse
           into the tail so the JSX inside keeps fine-grained leaves instead of
           the whole block collapsing into one coarse View.child thunk (which
           would rebuild the subtree — and lose element identity — on every
           dependency change). Bindings scope exactly like the component body. *)
-       let vbs' = List.map (map_vb env) vbs in
+       let vbs' = List.map (map_local_vb env) vbs in
        let env' = collect_val_aliases env vbs in
        { e with pexp_desc = Pexp_let (r, vbs', fine_node env' body) }
      | Pexp_letmodule (name, me, body) ->
@@ -1232,8 +1320,32 @@ let rec fine_node (env : env) (e : expression) : expression =
           an eager signal read is thunked so it re-runs as reactive text; a static
           scalar becomes static text; a value that is already a node passes through
           untouched (View.child detects nodes at runtime). This removes the value-
-          primitive ceremony under the annotation. *)
+          primitive ceremony under the annotation.
+
+          Whatever else the expression is — an application, a pipe, an array,
+          a `try`, a record — it can still *contain* JSX, and any JSX it
+          contains is node position too. So descend first (see
+          decompose_node_shaped), then coerce the result. *)
+       let e = decompose_node_shaped env e in
        wrap_child (if should_thunk env e then thunk e else e))
+
+(* Descend through a node-position expression that is not itself JSX, and
+   decompose the node-shaped things inside it: JSX, and functions returning
+   JSX. Everything else is rebuilt unchanged.
+
+   This is deliberately shape-agnostic. Special-casing containers (application
+   arguments, then arrays, then …) kept missing one: `View.fragment([<p/>])`,
+   `xs->Array.map(x => <li> {x} </li>)`, `opt->Option.getOr(<p/>)` and
+   `try { <p/> } catch { … }` are all just JSX sitting somewhere inside an
+   expression whose value becomes a node. Walking the whole expression covers
+   them uniformly, and covers shapes nobody has written yet. *)
+and decompose_node_shaped (env : env) (e : expression) : expression =
+  map_sub_exprs
+    (fun sub ->
+      if jsx_parts sub <> None || is_jsx_fragment sub then fine_node env sub
+      else if is_render_callback sub then fine_callback env sub
+      else decompose_node_shaped env sub)
+    e
 
 (* Recurse fine_node into the *node-position* bodies of control flow (the
    condition/scrutinee and any guards stay untouched — they are value position
@@ -1260,11 +1372,24 @@ and component_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * 
   (* User-component props are left untouched: an eager `Signal.get(x)` prop is a
      legitimate one-shot read of a plain-typed prop (pass the signal itself when
      the prop should be reactive). The exceptions are node-shaped values, which
-     are node position wherever they appear: children, and any prop whose value
-     is itself JSX — recurse so their reactive leaves stay fine-grained. *)
+     are node position wherever they appear: children, any prop whose value is
+     itself JSX, and any prop whose value is a *function returning* JSX (a
+     render callback) — recurse so their reactive leaves stay fine-grained and
+     their bare children are coerced. *)
   if is_children_label lbl then (lbl, map_children (fine_node env) v)
   else if jsx_parts v <> None || is_jsx_fragment v then (lbl, fine_node env v)
+  else if is_render_callback v then (lbl, fine_callback env v)
   else (lbl, v)
+
+(* Decompose the body of a render callback, walking past its parameters (and
+   the uncurried `Function$` wrapper) to the node-position body. *)
+and fine_callback (env : env) (e : expression) : expression =
+  match e.pexp_desc with
+  | Pexp_construct (({ txt = Longident.Lident "Function$"; _ } as c), Some fn) ->
+    { e with pexp_desc = Pexp_construct (c, Some (fine_callback env fn)) }
+  | Pexp_fun (l, def, p, body) ->
+    { e with pexp_desc = Pexp_fun (l, def, p, fine_callback env body) }
+  | _ -> fine_node env e
 
 and value_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
   if is_children_label lbl then (lbl, map_children (value_leaf env) v)
@@ -1332,6 +1457,21 @@ and map_vb (env : env) (vb : value_binding) : value_binding =
       pvb_expr = decompose_component_body env vb.pvb_expr }
   | None -> { vb with pvb_expr = map_expr env vb.pvb_expr }
 
+(* A binding *inside* an annotated component. Its value is rendered as part of
+   that component, so JSX bound to a name — `let row = <p> {"x"} </p>` — and a
+   local helper returning JSX — `let btn = label => <button> {label} </button>`
+   — are decomposed exactly like inline markup. Without this the annotation
+   stopped at the component's return expression, and pulling a piece of markup
+   out into a local binding silently lost fine-grained leaves and required the
+   value-primitive wrappers back. *)
+and map_local_vb (env : env) (vb : value_binding) : value_binding =
+  if List.exists is_xote_component vb.pvb_attributes then map_vb env vb
+  else
+    let v = vb.pvb_expr in
+    if jsx_parts v <> None || is_jsx_fragment v then { vb with pvb_expr = fine_node env v }
+    else if is_render_callback v then { vb with pvb_expr = fine_callback env v }
+    else map_vb env vb
+
 (* Walk to the component's tail (return) expression, threading the alias env
    through lets/opens and running the normal traversal on non-tail parts (so a
    nested reactive leaves still work), then fine-grain the returned JSX. *)
@@ -1344,7 +1484,7 @@ and decompose_component_body (env : env) (e : expression) : expression =
   | Pexp_fun (l, def, p, body) ->
     { e with pexp_desc = Pexp_fun (l, def, p, decompose_component_body env body) }
   | Pexp_let (r, vbs, body) ->
-    let vbs' = List.map (map_vb env) vbs in
+    let vbs' = List.map (map_local_vb env) vbs in
     let env' = collect_val_aliases env vbs in
     { e with pexp_desc = Pexp_let (r, vbs', decompose_component_body env' body) }
   | Pexp_letmodule (name, me, body) ->
@@ -1358,6 +1498,37 @@ and decompose_component_body (env : env) (e : expression) : expression =
   | Pexp_constraint (x, t) ->
     { e with pexp_desc = Pexp_constraint (decompose_component_body env x, t) }
   | _ -> fine_node env e
+
+(* Does this file opt in to the annotation at all? A file containing at least
+   one @xote.component is written in the fine-grained style, so JSX anywhere in
+   it — including plain helper functions like
+   `let filterButton = (label, …) => <button> {label} </button>` — is
+   decomposed too. Helpers that return markup are components in all but name,
+   and requiring the value-primitive wrappers back in them was the last place
+   the two styles collided.
+
+   Files with no annotation are left completely untouched, so a project mixing
+   @jsx.component code with explicit thunks keeps its current semantics. *)
+let rec structure_has_component (s : structure) : bool =
+  List.exists
+    (fun si ->
+      match si.pstr_desc with
+      | Pstr_value (_, vbs) ->
+        List.exists (fun vb -> List.exists is_xote_component vb.pvb_attributes) vbs
+      | Pstr_module mb -> module_has_component mb.pmb_expr
+      | Pstr_recmodule mbs -> List.exists (fun mb -> module_has_component mb.pmb_expr) mbs
+      | _ -> false)
+    s
+
+and module_has_component (me : module_expr) : bool =
+  match me.pmod_desc with
+  | Pmod_structure s -> structure_has_component s
+  | Pmod_constraint (m, _) -> module_has_component m
+  | Pmod_functor (_, _, b) -> module_has_component b
+  | _ -> false
+
+(* Set once per file, before the traversal runs. *)
+let fine_grain_helpers = ref false
 
 (* Structure items are threaded left-to-right so a top-level `let g = Signal.get`,
    `module S = Signal`, or `open Signal` is visible to later items. *)
@@ -1378,7 +1549,9 @@ and update_env_si (env : env) si =
 
 and map_si (env : env) si =
   match si.pstr_desc with
-  | Pstr_value (r, vbs) -> { si with pstr_desc = Pstr_value (r, List.map (map_vb env) vbs) }
+  | Pstr_value (r, vbs) ->
+    let f = if !fine_grain_helpers then map_local_vb env else map_vb env in
+    { si with pstr_desc = Pstr_value (r, List.map f vbs) }
   | Pstr_module mb -> { si with pstr_desc = Pstr_module (map_mb env mb) }
   | Pstr_recmodule mbs -> { si with pstr_desc = Pstr_recmodule (List.map (map_mb env) mbs) }
   | Pstr_include incl ->
@@ -1439,6 +1612,8 @@ let () =
   output_string oc magic;
   output_value oc name;
   (if magic = impl_magic then
-     output_value oc (map_structure empty_env (Obj.magic payload : structure))
+     let structure = (Obj.magic payload : structure) in
+     fine_grain_helpers := structure_has_component structure;
+     output_value oc (map_structure empty_env structure)
    else output_value oc payload);
   close_out oc

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -988,6 +988,9 @@ let thunk body =
 let view_tracked = Longident.Ldot (Longident.Lident "View", "tracked")
 let wrap_tracked e = apply (ident view_tracked) [ thunk e ]
 
+let view_child = Longident.Ldot (Longident.Lident "View", "child")
+let wrap_child e = apply (ident view_child) [ e ]
+
 (* ---- signal-read detection ----------------------------------------------
    A read is any occurrence of `Signal.get` (applied or not). Beyond the
    literal `Signal.get` / `X.Signal.get`, an alias environment threaded through
@@ -1114,6 +1117,14 @@ let jsx_parts (e : expression) =
   | Pexp_apply (f, args) when has_jsx e -> Some (f, args)
   | _ -> None
 
+(* A JSX fragment `<>…</>` is a `::`/`[]` list carrying the JSX attribute (not a
+   Pexp_apply, so jsx_parts misses it). Its children are node position. *)
+let is_jsx_fragment (e : expression) : bool =
+  has_jsx e
+  && (match e.pexp_desc with
+      | Pexp_construct ({ txt = Longident.Lident ("::" | "[]"); _ }, _) -> true
+      | _ -> false)
+
 (* Lowercase leading char => intrinsic HTML/SVG element (children are nodes). *)
 let is_element (f : expression) : bool =
   match f.pexp_desc with
@@ -1148,21 +1159,39 @@ let rec fine_node (env : env) (e : expression) : expression =
   | Some (f, args) ->
     (* element or user component: attrs are value position, children nodes *)
     { e with pexp_desc = Pexp_apply (f, List.map (element_arg env) args) }
+  | None when is_jsx_fragment e ->
+    (* A fragment `<>…</>` is a JSX-tagged `::`/`[]` list, not a Pexp_apply, so
+       jsx_parts misses it. Recurse fine_node into each child exactly like an
+       element's children (map_children preserves the outer @JSX attribute), so
+       nested reactive regions stay *independent*. Without this the whole fragment
+       would be wrapped in one coarse thunk and any nested `if`/`switch` inside it
+       would collapse into that single tracked scope — rebuilding every sibling on
+       one signal change. *)
+    map_children (fine_node env) e
   | None ->
-    (* not a JSX element: a bare child expression in node position. A signal
-       read here means the *node structure* varies, which needs View.tracked.
-       But first recurse fine-grained into each branch body: that turns the
-       branches' leaves into thunks, so when the tracked scope runs a branch to
-       build its nodes the thunks are not invoked — the scope ends up tracking
-       only the condition/scrutinee (the eager reads), while a leaf inside a
-       branch keeps its own reactive scope. Net effect: changing a signal that
-       only a branch leaf reads updates just that leaf and does NOT re-run the
-       switch or rebuild the branch.
+    (match e.pexp_desc with
+     | Pexp_ifthenelse _ | Pexp_match _ ->
+       (* Control flow in node position: the *node structure* varies, which needs
+          View.tracked. First recurse fine-grained into each branch body: that
+          turns the branches' leaves into thunks, so when the tracked scope runs
+          a branch to build its nodes the thunks are not invoked — the scope ends
+          up tracking only the condition/scrutinee (the eager reads), while a leaf
+          inside a branch keeps its own reactive scope. Net effect: changing a
+          signal that only a branch leaf reads updates just that leaf and does NOT
+          re-run the switch or rebuild the branch.
 
-       The *eager* read check matters here too: a child that is already reactive
-       on its own (e.g. `View.signalText(() => Signal.get(x))`) reads only inside
-       a lambda, so it is left as-is rather than redundantly wrapped. *)
-    if reads_signal_eager env e then wrap_tracked (decompose_branches env e) else e
+          The *eager* read check matters here too: a control-flow child that is
+          already reactive on its own reads only inside a lambda, so it is left
+          as-is rather than redundantly wrapped. *)
+       if reads_signal_eager env e then wrap_tracked (decompose_branches env e) else e
+     | _ ->
+       (* A bare value child — `<div>{Signal.get(count)}</div>` — with no explicit
+          <View.Int>/<View.Text> wrapper. Coerce it to a node with View.child:
+          an eager signal read is thunked so it re-runs as reactive text; a static
+          scalar becomes static text; a value that is already a node passes through
+          untouched (View.child detects nodes at runtime). This removes the value-
+          primitive ceremony under the annotation. *)
+       wrap_child (if should_thunk env e then thunk e else e))
 
 (* Recurse fine_node into the *node-position* bodies of control flow (the
    condition/scrutinee and any guards stay untouched — they are value position

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -1021,10 +1021,19 @@ let sub_exprs (e : expression) : expression list =
   match e.pexp_desc with
   | Pexp_apply (f, args) -> f :: List.map snd args
   | Pexp_ifthenelse (c, t, eo) -> c :: t :: (match eo with Some x -> [ x ] | None -> [])
-  | Pexp_match (x, cases) | Pexp_try (x, cases) -> x :: List.map (fun c -> c.pc_rhs) cases
+  | Pexp_match (x, cases) | Pexp_try (x, cases) ->
+    (* guards are evaluated eagerly alongside the scrutinee — a signal read in
+       `| _ if Signal.get(flag) => …` must count, or the switch is never tracked *)
+    x
+    :: List.concat_map
+         (fun c -> (match c.pc_guard with Some g -> [ g ] | None -> []) @ [ c.pc_rhs ])
+         cases
   | Pexp_construct (_, Some x) -> [ x ]
+  | Pexp_variant (_, Some x) -> [ x ]
   | Pexp_tuple xs | Pexp_array xs -> xs
   | Pexp_field (x, _) -> [ x ]
+  | Pexp_setfield (a, _, b) -> [ a; b ]
+  | Pexp_send (x, _) -> [ x ]
   | Pexp_record (fields, base) ->
     List.map snd fields @ (match base with Some b -> [ b ] | None -> [])
   | Pexp_constraint (x, _) -> [ x ]
@@ -1151,14 +1160,29 @@ let is_children_label = function
 let should_thunk (env : env) (v : expression) : bool =
   reads_signal_eager env v && jsx_parts v = None
 
+(* `@xote.component` is the single annotation: it derives props exactly like
+   `@jsx.component` (which we emit for the JSX transform to expand) *and*
+   fine-grained-decomposes the returned JSX. One attribute replaces
+   `@jsx.component` and makes the whole component tracked. *)
+let is_xote_component ((name, _) : attribute) = name.Location.txt = "xote.component"
+let strip_xote_component = List.filter (fun a -> not (is_xote_component a))
+let jsx_component_attr : attribute = (mkloc "jsx.component", PStr [])
+
 (* ---- decomposition ------------------------------------------------------ *)
 let rec fine_node (env : env) (e : expression) : expression =
   match jsx_parts e with
   | Some (f, args) when is_value_component f ->
     { e with pexp_desc = Pexp_apply (f, List.map (value_arg env) args) }
-  | Some (f, args) ->
-    (* element or user component: attrs are value position, children nodes *)
+  | Some (f, args) when is_element f ->
+    (* intrinsic HTML/SVG element: attrs are value position (thunked when they
+       eagerly read a signal, so they lower to computed attributes), children
+       are node position *)
     { e with pexp_desc = Pexp_apply (f, List.map (element_arg env) args) }
+  | Some (f, args) ->
+    (* user component: children are node position, but its labelled props land
+       in the component's *typed props record*, so thunking them would change
+       their type and break compilation with a baffling error *)
+    { e with pexp_desc = Pexp_apply (f, List.map (component_arg env) args) }
   | None when is_jsx_fragment e ->
     (* A fragment `<>…</>` is a JSX-tagged `::`/`[]` list, not a Pexp_apply, so
        jsx_parts misses it. Recurse fine_node into each child exactly like an
@@ -1184,6 +1208,24 @@ let rec fine_node (env : env) (e : expression) : expression =
           already reactive on its own reads only inside a lambda, so it is left
           as-is rather than redundantly wrapped. *)
        if reads_signal_eager env e then wrap_tracked (decompose_branches env e) else e
+     | Pexp_let (r, vbs, body) ->
+       (* A block expression in node position — `{let x = …; <span/>}`. Recurse
+          into the tail so the JSX inside keeps fine-grained leaves instead of
+          the whole block collapsing into one coarse View.child thunk (which
+          would rebuild the subtree — and lose element identity — on every
+          dependency change). Bindings scope exactly like the component body. *)
+       let vbs' = List.map (map_vb env) vbs in
+       let env' = collect_val_aliases env vbs in
+       { e with pexp_desc = Pexp_let (r, vbs', fine_node env' body) }
+     | Pexp_letmodule (name, me, body) ->
+       let env' = collect_mod_alias env name me in
+       { e with pexp_desc = Pexp_letmodule (name, me, fine_node env' body) }
+     | Pexp_open (o, l, x) ->
+       let env' = collect_open env l.Location.txt in
+       { e with pexp_desc = Pexp_open (o, l, fine_node env' x) }
+     | Pexp_sequence (a, b) ->
+       { e with pexp_desc = Pexp_sequence (map_expr env a, fine_node env b) }
+     | Pexp_constraint (x, t) -> { e with pexp_desc = Pexp_constraint (fine_node env x, t) }
      | _ ->
        (* A bare value child — `<div>{Signal.get(count)}</div>` — with no explicit
           <View.Int>/<View.Text> wrapper. Coerce it to a node with View.child:
@@ -1214,6 +1256,16 @@ and element_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * ex
       if should_thunk env v then (lbl, thunk v) else (lbl, v)
     | Nolabel -> (lbl, v)
 
+and component_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
+  (* User-component props are left untouched: an eager `Signal.get(x)` prop is a
+     legitimate one-shot read of a plain-typed prop (pass the signal itself when
+     the prop should be reactive). The exceptions are node-shaped values, which
+     are node position wherever they appear: children, and any prop whose value
+     is itself JSX — recurse so their reactive leaves stay fine-grained. *)
+  if is_children_label lbl then (lbl, map_children (fine_node env) v)
+  else if jsx_parts v <> None || is_jsx_fragment v then (lbl, fine_node env v)
+  else (lbl, v)
+
 and value_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
   if is_children_label lbl then (lbl, map_children (value_leaf env) v)
   else
@@ -1239,15 +1291,7 @@ and map_children f (v : expression) : expression =
   | _ -> f v
 
 (* ---- traversal: find @xote.component and decompose ----------------------- *)
-(* `@xote.component` is the single annotation: it derives props exactly like
-   `@jsx.component` (which we emit for the JSX transform to expand) *and*
-   fine-grained-decomposes the returned JSX. One attribute replaces
-   `@jsx.component` and makes the whole component tracked. *)
-let is_xote_component ((name, _) : attribute) = name.Location.txt = "xote.component"
-let strip_xote_component = List.filter (fun a -> not (is_xote_component a))
-let jsx_component_attr : attribute = (mkloc "jsx.component", PStr [])
-
-let rec map_expr (env : env) (e : expression) : expression = map_children_expr env e
+and map_expr (env : env) (e : expression) : expression = map_children_expr env e
 
 and map_children_expr (env : env) (e : expression) : expression =
   let d =
@@ -1336,6 +1380,9 @@ and map_si (env : env) si =
   match si.pstr_desc with
   | Pstr_value (r, vbs) -> { si with pstr_desc = Pstr_value (r, List.map (map_vb env) vbs) }
   | Pstr_module mb -> { si with pstr_desc = Pstr_module (map_mb env mb) }
+  | Pstr_recmodule mbs -> { si with pstr_desc = Pstr_recmodule (List.map (map_mb env) mbs) }
+  | Pstr_include incl ->
+    { si with pstr_desc = Pstr_include { incl with pincl_mod = map_mod env incl.pincl_mod } }
   | Pstr_eval (e, attrs) -> { si with pstr_desc = Pstr_eval (map_expr env e, attrs) }
   | _ -> si
 
@@ -1343,21 +1390,55 @@ and map_mb (env : env) mb = { mb with pmb_expr = map_mod env mb.pmb_expr }
 and map_mod (env : env) me =
   match me.pmod_desc with
   | Pmod_structure s -> { me with pmod_desc = Pmod_structure (map_structure env s) }
+  (* `module Widget: Sig = { … }` and functor bodies still contain components;
+     skipping them would leave @xote.component silently unexpanded *)
+  | Pmod_constraint (m, mt) -> { me with pmod_desc = Pmod_constraint (map_mod env m, mt) }
+  | Pmod_functor (name, mt, body) ->
+    { me with pmod_desc = Pmod_functor (name, mt, map_mod env body) }
   | _ -> me
 
 (* ---- ReScript -ppx binary protocol: `ppx <infile> <outfile>` ------------ *)
 let impl_magic = "Caml1999M022"
+let usage =
+  "xote ppx: fine-grained @xote.component rewriter for ReScript.\n\
+   Invoked by the compiler via rescript.json ppx-flags as `ppx <ast-in> <ast-out>`."
+
 let () =
   let n = Array.length Sys.argv in
+  (* `--help` doubles as the postinstall/CI smoke test: it proves the binary
+     loads and executes on the host (right libc, right arch) without an AST. *)
+  if n = 2 && (Sys.argv.(1) = "--help" || Sys.argv.(1) = "-h") then begin
+    print_endline usage;
+    exit 0
+  end;
+  if n < 3 then begin
+    prerr_endline usage;
+    exit 2
+  end;
   let infile = Sys.argv.(n - 2) and outfile = Sys.argv.(n - 1) in
   let ic = open_in_bin infile in
   let magic = really_input_string ic (String.length impl_magic) in
   let name : string = input_value ic in
   let payload : Obj.t = input_value ic in
   close_in ic;
+  (* Interface ASTs (Caml1999N…) legitimately pass through untouched. A
+     different *implementation* magic means the compiler's ppx ABI moved and
+     @xote.component cannot be expanded — fail the build here with a clear
+     message rather than passing the AST through and letting it die later on
+     a confusing type error. *)
+  let is_impl = String.length magic >= 9 && String.sub magic 0 9 = "Caml1999M" in
+  if is_impl && magic <> impl_magic then begin
+    prerr_endline
+      ("xote ppx: unsupported AST magic " ^ magic ^ " (this ppx expects " ^ impl_magic
+       ^ "), so @xote.component cannot be expanded in " ^ name
+       ^ ". The installed ReScript version's ppx ABI is newer than this ppx supports; "
+       ^ "upgrade xote, or remove it from ppx-flags.");
+    exit 2
+  end;
   let oc = open_out_bin outfile in
   output_string oc magic;
   output_value oc name;
-  (if magic = impl_magic then output_value oc (map_structure empty_env (Obj.magic payload : structure))
+  (if magic = impl_magic then
+     output_value oc (map_structure empty_env (Obj.magic payload : structure))
    else output_value oc payload);
   close_out oc

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -1,0 +1,880 @@
+(* The vendored OCaml 4.06 parsetree lives in `ast.ml`, kept verbatim from the
+   compiler so `Marshal` round-trips exactly and a future AST re-sync stays a
+   copy rather than a merge. Everything in this file is the project's own code. *)
+open Ast
+(* ---- @xote.component fine-grained rewriter ------------------------------
+   Decomposes the JSX returned by an @xote.component into fine-grained reactive
+   leaves instead of wrapping the whole block in one computed:
+
+     - an attribute value that reads a Signal  ->  thunked, so JSX lowers it
+       to `View.computedAttr` (only that attribute re-runs);
+     - a <View.Text>/<View.Int>/<View.Float>/<View.Bool> child that reads a
+       Signal  ->  thunked, so it lowers to a reactive text node (only that
+       text node re-runs);
+     - genuine control flow in *node position* (an `if`/`switch` producing
+       nodes) whose result varies  ->  wrapped in `View.tracked`, the one
+       place a structural swap is unavoidable.
+
+   The element structure itself (tags, nesting) is emitted once and never
+   rebuilt. Only the leaves that actually read signals become reactive. *)
+open Asttypes
+open Parsetree
+
+let none : Location.t =
+  { Location.loc_start = Lexing.dummy_pos; loc_end = Lexing.dummy_pos; loc_ghost = true }
+let mkloc (txt : 'a) : 'a Location.loc = { Location.txt; loc = none }
+let mkexp d = { pexp_desc = d; pexp_loc = none; pexp_attributes = [] }
+let ident lid = mkexp (Pexp_ident (mkloc lid))
+let apply f args = mkexp (Pexp_apply (f, List.map (fun a -> (Nolabel, a)) args))
+
+(* Uncurried unit thunk: `Function$(fun () -> body)` with `res.arity 1`, the
+   4.06-ppx encoding ReScript uses for uncurried funcs (see PR #34). A bare
+   Pexp_fun would import as curried and be rejected in uncurried-by-default. *)
+let res_arity n : attribute =
+  let e = mkexp (Pexp_constant (Pconst_integer (string_of_int n, None))) in
+  (mkloc "res.arity", PStr [ { pstr_desc = Pstr_eval (e, []); pstr_loc = none } ])
+let unit_pat =
+  { ppat_desc = Ppat_construct (mkloc (Longident.Lident "()"), None);
+    ppat_loc = none; ppat_attributes = [] }
+let thunk body =
+  let fn = mkexp (Pexp_fun (Nolabel, None, unit_pat, body)) in
+  { pexp_desc = Pexp_construct (mkloc (Longident.Lident "Function$"), Some fn);
+    pexp_loc = none; pexp_attributes = [ res_arity 1 ] }
+
+let view_tracked = Longident.Ldot (Longident.Lident "View", "tracked")
+let wrap_tracked e = apply (ident view_tracked) [ thunk e ]
+
+let view_child = Longident.Ldot (Longident.Lident "View", "child")
+let wrap_child e = apply (ident view_child) [ e ]
+
+(* ---- signal-read detection ----------------------------------------------
+   A read is a tracked `get`: `Signal.get`, and equally `MaybeSignal.get` /
+   `Prop.get` (the deprecated alias), which read through the static-or-reactive
+   wrapper and subscribe just the same. Beyond the literal `Signal.get` /
+   `X.MaybeSignal.get`, an alias environment threaded through the traversal also
+   recognises indirect reads:
+     - a value alias:    `let g = Signal.get` then `g(sig)`
+     - a module alias:   `module S = Signal` then `S.get(sig)`
+     - an open:          `open Signal` then a bare `get(sig)`
+     - a reactive helper: `let cls = () => Signal.get(x) ? …` then `cls()` —
+       a local function whose body eagerly reads a signal; calling it is a read.
+     - a same-file module helper: `module Store = { let count = s => Signal.get(s) }`
+       then `Store.count(s)` — collected per module while walking the structure.
+   The environment is scoped by the traversal (bindings visible only after they
+   appear); shadowing a name with a non-reactive binding removes it. *)
+type env = {
+  vals : string list;
+  mods : string list;
+  funcs : string list;
+  (* reactive helpers reached through a same-file module, as "Store.count" *)
+  qfuncs : string list;
+  open_signal : bool;
+}
+let empty_env = { vals = []; mods = []; funcs = []; qfuncs = []; open_signal = false }
+
+(* Modules whose `get` is a *tracked* read. `peek` is deliberately absent from
+   every one of them: it is the untracked read. *)
+let is_read_module_name = function
+  | "Signal" | "MaybeSignal" | "Prop" -> true
+  | _ -> false
+
+let is_read_fn (env : env) (e : expression) : bool =
+  match e.pexp_desc with
+  | Pexp_ident { txt = Longident.Ldot (m, "get"); _ } ->
+    (match m with
+     | Longident.Lident name -> is_read_module_name name || List.mem name env.mods
+     | Longident.Ldot (_, name) -> is_read_module_name name
+     | _ -> false)
+  | Pexp_ident { txt = Longident.Lident name; _ } ->
+    List.mem name env.vals || (env.open_signal && name = "get")
+  | _ -> false
+
+let sub_exprs (e : expression) : expression list =
+  match e.pexp_desc with
+  | Pexp_apply (f, args) -> f :: List.map snd args
+  | Pexp_ifthenelse (c, t, eo) -> c :: t :: (match eo with Some x -> [ x ] | None -> [])
+  | Pexp_match (x, cases) | Pexp_try (x, cases) ->
+    (* guards are evaluated eagerly alongside the scrutinee — a signal read in
+       `| _ if Signal.get(flag) => …` must count, or the switch is never tracked *)
+    x
+    :: List.concat_map
+         (fun c -> (match c.pc_guard with Some g -> [ g ] | None -> []) @ [ c.pc_rhs ])
+         cases
+  | Pexp_construct (_, Some x) -> [ x ]
+  | Pexp_variant (_, Some x) -> [ x ]
+  | Pexp_tuple xs | Pexp_array xs -> xs
+  | Pexp_field (x, _) -> [ x ]
+  | Pexp_setfield (a, _, b) -> [ a; b ]
+  | Pexp_send (x, _) -> [ x ]
+  | Pexp_record (fields, base) ->
+    List.map snd fields @ (match base with Some b -> [ b ] | None -> [])
+  | Pexp_constraint (x, _) -> [ x ]
+  | Pexp_coerce (x, _, _) -> [ x ]
+  | Pexp_sequence (a, b) -> [ a; b ]
+  | Pexp_let (_, vbs, body) -> List.map (fun vb -> vb.pvb_expr) vbs @ [ body ]
+  | Pexp_fun (_, def, _, body) -> (match def with Some d -> [ d ] | None -> []) @ [ body ]
+  | Pexp_open (_, _, x) -> [ x ]
+  | Pexp_assert x | Pexp_lazy x -> [ x ]
+  | _ -> []
+
+(* The map counterpart of sub_exprs: rebuild [e] with [f] applied to each
+   immediate sub-expression, leaving everything else (patterns, guards,
+   labels, types) untouched.
+
+   These two look like hand-maintained duplicates and are tempting to unify —
+   don't. They answer different questions, and the difference is `when` guards:
+
+     - sub_exprs asks "what is *evaluated* when this expression runs?" Guards are,
+       so they are included, which is the only reason a switch whose sole signal
+       read sits in a guard gets tracked at all.
+     - map_sub_exprs asks "what could be *node position*?" A guard is a boolean,
+       never a node, so rewriting through it would be meaningless.
+
+   Deriving sub_exprs from this function drops guards from read detection and
+   silently un-tracks that switch. The example's `GuardSwitch` case is the
+   regression test for exactly that. *)
+let map_sub_exprs (f : expression -> expression) (e : expression) : expression =
+  let d =
+    match e.pexp_desc with
+    | Pexp_apply (fn, args) -> Pexp_apply (f fn, List.map (fun (l, a) -> (l, f a)) args)
+    | Pexp_ifthenelse (c, t, eo) -> Pexp_ifthenelse (f c, f t, Option.map f eo)
+    | Pexp_match (x, cases) ->
+      Pexp_match (f x, List.map (fun c -> { c with pc_rhs = f c.pc_rhs }) cases)
+    | Pexp_try (x, cases) ->
+      Pexp_try (f x, List.map (fun c -> { c with pc_rhs = f c.pc_rhs }) cases)
+    | Pexp_construct (l, eo) -> Pexp_construct (l, Option.map f eo)
+    | Pexp_variant (l, eo) -> Pexp_variant (l, Option.map f eo)
+    | Pexp_tuple xs -> Pexp_tuple (List.map f xs)
+    | Pexp_array xs -> Pexp_array (List.map f xs)
+    | Pexp_field (x, l) -> Pexp_field (f x, l)
+    | Pexp_setfield (a, l, b) -> Pexp_setfield (f a, l, f b)
+    | Pexp_send (x, l) -> Pexp_send (f x, l)
+    | Pexp_record (fields, base) ->
+      Pexp_record (List.map (fun (l, v) -> (l, f v)) fields, Option.map f base)
+    | Pexp_constraint (x, t) -> Pexp_constraint (f x, t)
+    | Pexp_coerce (x, a, b) -> Pexp_coerce (f x, a, b)
+    | Pexp_sequence (a, b) -> Pexp_sequence (f a, f b)
+    | Pexp_let (r, vbs, body) ->
+      Pexp_let (r, List.map (fun vb -> { vb with pvb_expr = f vb.pvb_expr }) vbs, f body)
+    | Pexp_fun (l, def, p, body) -> Pexp_fun (l, Option.map f def, p, f body)
+    | Pexp_open (o, l, x) -> Pexp_open (o, l, f x)
+    | Pexp_assert x -> Pexp_assert (f x)
+    | Pexp_lazy x -> Pexp_lazy (f x)
+    | other -> other
+  in
+  { e with pexp_desc = d }
+
+(* A reactive-helper *call*: `f(...)` where `f` is a local function whose body
+   eagerly reads a signal (tracked in env.funcs). A *bare* `f` (passed, not
+   called) is left alone — the runtime already treats a function attribute/child
+   as a computed. *)
+let is_reactive_call (env : env) (e : expression) : bool =
+  match e.pexp_desc with
+  | Pexp_apply ({ pexp_desc = Pexp_ident { txt = Longident.Lident f; _ }; _ }, _) ->
+    List.mem f env.funcs
+  | Pexp_apply
+      ({ pexp_desc = Pexp_ident { txt = Longident.Ldot (Longident.Lident m, f); _ }; _ }, _) ->
+    List.mem (m ^ "." ^ f) env.qfuncs
+  | _ -> false
+
+(* An *eager* read: a `Signal.get` (or reactive-helper call) that runs when this
+   expression is evaluated, not one deferred inside a nested lambda. Reads inside
+   `() => …`, `Computed.make(() => …)`, `Prop.reactive(Computed.make(() => …))`,
+   etc. are already reactive on their own, so a value that only reads inside a
+   lambda must NOT be re-wrapped in a thunk. Stops descending at fn boundaries. *)
+let rec reads_signal_eager (env : env) (e : expression) : bool =
+  match e.pexp_desc with
+  | Pexp_fun _ -> false
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some _) -> false
+  | _ ->
+    is_reactive_call env e || is_read_fn env e
+    || List.exists (reads_signal_eager env) (sub_exprs e)
+
+(* Does `e` denote a function whose body eagerly reads a signal? Strip the
+   function's own parameters (its uncurried `Function$` wrapper and `fun`s),
+   then check the immediate body — reads_signal_eager stops at any further nested
+   lambda, so a helper that merely *returns* a thunk is correctly not counted. *)
+let func_reads (env : env) (e : expression) : bool =
+  let rec strip_params b =
+    match b.pexp_desc with Pexp_fun (_, _, _, body) -> strip_params body | _ -> b
+  in
+  match e.pexp_desc with
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some fn) ->
+    reads_signal_eager env (strip_params fn)
+  | Pexp_fun _ -> reads_signal_eager env (strip_params e)
+  | _ -> false
+
+(* ---- binding collectors ------------------------------------------------- *)
+(* `let g = Signal.get` binds `g` as a value alias; `let cls = () => …Signal.get…`
+   binds `cls` as a reactive helper; anything else shadows away a prior binding
+   of that name. *)
+let collect_val_aliases (env : env) (vbs : value_binding list) : env =
+  List.fold_left
+    (fun env vb ->
+      match vb.pvb_pat.ppat_desc with
+      | Ppat_var { txt = name; _ } ->
+        let drop = List.filter (fun n -> n <> name) in
+        if is_read_fn env vb.pvb_expr then
+          { env with vals = name :: env.vals; funcs = drop env.funcs }
+        else if func_reads env vb.pvb_expr then
+          { env with funcs = name :: env.funcs; vals = drop env.vals }
+        else { env with vals = drop env.vals; funcs = drop env.funcs }
+      | _ -> env)
+    env vbs
+
+let is_read_module (me : module_expr) : bool =
+  match me.pmod_desc with
+  | Pmod_ident { txt = Longident.Lident name; _ } -> is_read_module_name name
+  | Pmod_ident { txt = Longident.Ldot (_, name); _ } -> is_read_module_name name
+  | _ -> false
+
+let collect_mod_alias (env : env) (name : string Location.loc) (me : module_expr) : env =
+  if is_read_module me then { env with mods = name.Location.txt :: env.mods } else env
+
+let is_read_lid = function
+  | Longident.Lident name -> is_read_module_name name
+  | Longident.Ldot (_, name) -> is_read_module_name name
+  | _ -> false
+
+let collect_open (env : env) (lid : Longident.t) : env =
+  if is_read_lid lid then { env with open_signal = true } else env
+
+(* ---- JSX shape helpers -------------------------------------------------- *)
+let has_jsx (e : expression) : bool =
+  List.exists (fun ((n : string Location.loc), _) -> n.Location.txt = "JSX") e.pexp_attributes
+
+let jsx_parts (e : expression) =
+  match e.pexp_desc with
+  | Pexp_apply (f, args) when has_jsx e -> Some (f, args)
+  | _ -> None
+
+(* A JSX fragment `<>…</>` is a `::`/`[]` list carrying the JSX attribute (not a
+   Pexp_apply, so jsx_parts misses it). Its children are node position. *)
+let is_jsx_fragment (e : expression) : bool =
+  has_jsx e
+  && (match e.pexp_desc with
+      | Pexp_construct ({ txt = Longident.Lident ("::" | "[]"); _ }, _) -> true
+      | _ -> false)
+
+(* Lowercase leading char => intrinsic HTML/SVG element (children are nodes). *)
+let is_element (f : expression) : bool =
+  match f.pexp_desc with
+  | Pexp_ident { txt = Longident.Lident s; _ } ->
+    String.length s > 0 && s.[0] >= 'a' && s.[0] <= 'z'
+  | _ -> false
+
+(* View.Text / View.Int / View.Float / View.Bool: children are *values*. *)
+let is_value_component (f : expression) : bool =
+  match f.pexp_desc with
+  | Pexp_ident { txt = Longident.Ldot (Longident.Lident "View", ("Text" | "Int" | "Float" | "Bool")); _ } ->
+    true
+  | _ -> false
+
+(* Does this expression contain JSX anywhere? A value that builds nodes is not a
+   scalar leaf, so it is never probed for a hidden read (the JSX inside it is
+   decomposed on its own). *)
+let rec contains_jsx (e : expression) : bool =
+  jsx_parts e <> None || is_jsx_fragment e || List.exists contains_jsx (sub_exprs e)
+
+(* ---- hidden reads --------------------------------------------------------
+   Detection is syntactic, so a read behind a call the ppx cannot see the
+   definition of — `Store.waitingCount(store)` from another module, a read
+   pulled out of a data structure — looks exactly like a static value and
+   compiles to one. That was the single silent failure mode.
+
+   The ppx cannot resolve such a call, but it can *tell that one is there*: an
+   expression made only of constants, identifiers, field accesses, lambdas and
+   structural combinations of those provably calls nothing, and anything else
+   might. Leaves in the second group are wrapped in `View.probe`, which decides
+   at runtime — it evaluates the expression inside a throwaway computed and
+   warns, naming this source location, if the evaluation actually subscribed to
+   a signal. Inert leaves are emitted untouched, so the common cases (a literal,
+   a prop, `item.name`) cost nothing. *)
+
+(* A symbolic identifier (`>`, `++`, `===`) is a ReScript primitive operator, so
+   applying one is as inert as its arguments. *)
+let is_operator_name (s : string) : bool =
+  String.length s > 0
+  && (match s.[0] with 'a' .. 'z' | 'A' .. 'Z' | '_' -> false | _ -> true)
+
+(* Xote's and rescript-signals' own entry points never hide a tracked read: they
+   build nodes (`View.text`, `Html.div`) or reactive values that carry their own
+   subscription (`Computed.make`, `MaybeSignal.reactive`), and the one function
+   here that *is* a read — `Signal.get`/`MaybeSignal.get` — is recognised and
+   thunked before probing is ever considered. `Signal.peek` is untracked by
+   design. So a call into one of them is as inert as its arguments, and probing
+   it would only report node-shaped values nobody can act on. *)
+let is_library_module = function
+  | "View" | "Html" | "XoteJSX" | "Signal" | "Computed" | "Effect" | "MaybeSignal" | "Prop" ->
+    true
+  | _ -> false
+
+let is_library_call_path (lid : Longident.t) : bool =
+  match lid with
+  | Longident.Ldot (Longident.Lident m, _) | Longident.Ldot (Longident.Ldot (_, m), _) ->
+    is_library_module m
+  | _ -> false
+
+let rec is_inert (e : expression) : bool =
+  match e.pexp_desc with
+  (* Leaves; and lambdas, whose body is deferred — whatever it reads, it reads
+     reactively, so the lambda itself calls nothing now. *)
+  | Pexp_constant _ | Pexp_ident _ | Pexp_fun _ | Pexp_function _ | Pexp_unreachable -> true
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some _) -> true
+  (* An application is inert only when the callee provably calls nothing of its
+     own: a primitive operator, or one of Xote's own entry points. *)
+  | Pexp_apply ({ pexp_desc = Pexp_ident { txt = Longident.Lident op; _ }; _ }, args)
+    when is_operator_name op ->
+    List.for_all (fun (_, a) -> is_inert a) args
+  | Pexp_apply ({ pexp_desc = Pexp_ident { txt = lid; _ }; _ }, args)
+    when is_library_call_path lid ->
+    List.for_all (fun (_, a) -> is_inert a) args
+  (* Purely structural: inert exactly when all of its parts are. `sub_exprs`
+     already enumerates those parts (`when` guards included), so deferring to it
+     keeps this in step instead of re-deriving every constructor's shape here —
+     one fewer hand-maintained copy of the AST layout. *)
+  | Pexp_construct _ | Pexp_variant _ | Pexp_field _ | Pexp_constraint _ | Pexp_coerce _
+  | Pexp_lazy _ | Pexp_tuple _ | Pexp_array _ | Pexp_record _ | Pexp_ifthenelse _
+  | Pexp_match _ | Pexp_sequence _ | Pexp_let _ | Pexp_open _ ->
+    List.for_all is_inert (sub_exprs e)
+  (* Anything else — an ordinary call, a method send, try/assert — might reach a
+     read the ppx cannot see, so it gets probed.
+
+     This default must stay `false`. Routing it to `sub_exprs` instead would make
+     any constructor missing from that function *vacuously* inert (`for_all` over
+     an empty list is `true`) and switch the safety net off silently, which is
+     the one direction this analysis must never fail in. *)
+  | _ -> false
+
+(* The file being rewritten, used when an expression carries no location. *)
+let source_file = ref ""
+
+let site_of (loc : Location.t) : string =
+  let p = loc.Location.loc_start in
+  let file =
+    if p.Lexing.pos_fname = "" then !source_file else Filename.basename p.Lexing.pos_fname
+  in
+  let file = if file = "" then "@xote.component" else file in
+  if p.Lexing.pos_lnum <= 0 then file
+  else Printf.sprintf "%s:%d:%d" file p.Lexing.pos_lnum (p.Lexing.pos_cnum - p.Lexing.pos_bol + 1)
+
+let view_probe = Longident.Ldot (Longident.Lident "View", "probe")
+let str_const s = mkexp (Pexp_constant (Pconst_string (s, None)))
+let wrap_probe (e : expression) : expression =
+  apply (ident view_probe) [ str_const (site_of e.pexp_loc); thunk e ]
+
+(* ---- render callbacks ----------------------------------------------------
+   A prop whose value is a *function returning JSX* — `render={item => <li>…}`
+   on View.For/Value/Maybe, or any user component taking a render callback.
+   The lambda's body is node position, so it must be decomposed like any other
+   node: without this, a bare child inside a render callback is never coerced
+   and `<span> {item.name} </span>` fails to compile with "This has type:
+   string". Only bodies that actually reach JSX qualify, so event handlers and
+   other function props (`by={p => p.id}`, `onClick={…}`) are left alone. *)
+
+(* The expression a block finally evaluates to (past lets/opens/sequences). *)
+let rec tail_expr (e : expression) : expression =
+  match e.pexp_desc with
+  | Pexp_let (_, _, body) -> tail_expr body
+  | Pexp_letmodule (_, _, body) -> tail_expr body
+  | Pexp_open (_, _, x) -> tail_expr x
+  | Pexp_sequence (_, b) -> tail_expr b
+  | Pexp_constraint (x, _) -> tail_expr x
+  | _ -> e
+
+(* The body of a (possibly uncurried, possibly multi-parameter) function. *)
+let rec fun_body (e : expression) : expression option =
+  match e.pexp_desc with
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some fn) -> fun_body fn
+  | Pexp_fun (_, _, _, body) ->
+    (match fun_body body with Some inner -> Some inner | None -> Some body)
+  | _ -> None
+
+(* Does this expression produce JSX? Directly, or through control flow whose
+   branches do — `() => if cond { <p/> } else { <span/> }` is as much a node
+   producer as `() => <p/>`. *)
+let rec returns_jsx (e : expression) : bool =
+  let t = tail_expr e in
+  if jsx_parts t <> None || is_jsx_fragment t then true
+  else
+    match t.pexp_desc with
+    | Pexp_ifthenelse (_, a, b) ->
+      returns_jsx a || (match b with Some x -> returns_jsx x | None -> false)
+    | Pexp_match (_, cases) -> List.exists (fun c -> returns_jsx c.pc_rhs) cases
+    | _ -> false
+
+let is_render_callback (e : expression) : bool =
+  match fun_body e with Some body -> returns_jsx body | None -> false
+
+let is_children_label = function
+  | Labelled "children" | Optional "children" -> true
+  | _ -> false
+
+let label_name = function Labelled n | Optional n -> Some n | Nolabel -> None
+
+(* Labels that are never a reactive value leaf, so never worth probing: an event
+   handler is a callback, and `attrs` is the escape-hatch array whose entries
+   carry their own `View.attr`/`View.computedAttr` reactivity. *)
+let is_non_leaf_label (lbl : arg_label) : bool =
+  match label_name lbl with
+  | Some "attrs" -> true
+  | Some n -> String.length n > 2 && n.[0] = 'o' && n.[1] = 'n' && n.[2] >= 'A' && n.[2] <= 'Z'
+  | None -> false
+
+(* A value-position expression should be thunked iff it *eagerly* reads a signal
+   and isn't already JSX. Using the eager check means values that are already
+   reactive on their own — a `() => …` thunk, a `Computed`, a `Prop.reactive(…)`
+   — are left untouched (their reads are deferred inside a lambda), so
+   @xote.component is a safe drop-in on components already written that way. *)
+let should_thunk (env : env) (v : expression) : bool =
+  reads_signal_eager env v && jsx_parts v = None
+
+(* A value-position expression whose read status the ppx cannot decide: it is
+   not a visible read (that is already thunked), and it is not provably
+   call-free either. `View.probe` settles it at runtime. Node-shaped values are
+   excluded — they are decomposed, not read. *)
+let should_probe (env : env) (v : expression) : bool =
+  (not (should_thunk env v)) && (not (is_inert v)) && not (contains_jsx v)
+
+(* A value-position leaf: thunk a visible read, probe an unresolvable call,
+   leave everything else exactly as written. *)
+let leaf_value (env : env) (v : expression) : expression =
+  if should_thunk env v then thunk v else if should_probe env v then wrap_probe v else v
+
+(* `@xote.component` is the single annotation: it derives props exactly like
+   `@jsx.component` (which we emit for the JSX transform to expand) *and*
+   fine-grained-decomposes the returned JSX. One attribute replaces
+   `@jsx.component` and makes the whole component tracked. *)
+let is_xote_component ((name, _) : attribute) = name.Location.txt = "xote.component"
+let strip_xote_component = List.filter (fun a -> not (is_xote_component a))
+let jsx_component_attr : attribute = (mkloc "jsx.component", PStr [])
+
+(* ---- decomposition ------------------------------------------------------ *)
+let rec fine_node (env : env) (e : expression) : expression =
+  match jsx_parts e with
+  | Some (f, args) when is_value_component f ->
+    { e with pexp_desc = Pexp_apply (f, List.map (value_arg env) args) }
+  | Some (f, args) when is_element f ->
+    (* intrinsic HTML/SVG element: attrs are value position (thunked when they
+       eagerly read a signal, so they lower to computed attributes), children
+       are node position *)
+    { e with pexp_desc = Pexp_apply (f, List.map (element_arg env) args) }
+  | Some (f, args) ->
+    (* user component: children are node position, but its labelled props land
+       in the component's *typed props record*, so thunking them would change
+       their type and break compilation with a baffling error *)
+    { e with pexp_desc = Pexp_apply (f, List.map (component_arg env) args) }
+  | None when is_jsx_fragment e ->
+    (* A fragment `<>…</>` is a JSX-tagged `::`/`[]` list, not a Pexp_apply, so
+       jsx_parts misses it. Recurse fine_node into each child exactly like an
+       element's children (map_children preserves the outer @JSX attribute), so
+       nested reactive regions stay *independent*. Without this the whole fragment
+       would be wrapped in one coarse thunk and any nested `if`/`switch` inside it
+       would collapse into that single tracked scope — rebuilding every sibling on
+       one signal change. *)
+    map_children (fine_node env) e
+  | None ->
+    (match e.pexp_desc with
+     | Pexp_ifthenelse _ | Pexp_match _ ->
+       (* Control flow in node position: the *node structure* varies, which needs
+          View.tracked. First recurse fine-grained into each branch body: that
+          turns the branches' leaves into thunks, so when the tracked scope runs
+          a branch to build its nodes the thunks are not invoked — the scope ends
+          up tracking only the condition/scrutinee (the eager reads), while a leaf
+          inside a branch keeps its own reactive scope. Net effect: changing a
+          signal that only a branch leaf reads updates just that leaf and does NOT
+          re-run the switch or rebuild the branch.
+
+          The *eager* read check matters here too: a control-flow child that is
+          already reactive on its own reads only inside a lambda, so it is left
+          as-is rather than redundantly wrapped.
+
+          A condition with no eager read needs no View.tracked — its structure
+          cannot change — but its branches are still node position and must be
+          decomposed all the same. Skipping them (as this did) meant a bare
+          child inside a statically-conditioned branch never reached
+          View.child, so `{if isActive { <b> {"yes"} </b> } else { … }}` failed
+          to compile with "This has type: string" pointing at the literal
+          rather than at the conditional. Conditioning on a plain bool (a prop,
+          a local) is ordinary UI code, so this path matters as much as the
+          reactive one. *)
+       let branches = decompose_branches env e in
+       if reads_signal_eager env e then wrap_tracked branches
+       else
+         (* No visible read, so no `View.tracked`. If the condition/scrutinee is
+            not provably call-free, the structure may in fact depend on a signal
+            the ppx cannot see; probe it so that failure is reported instead of
+            silently rendering one frozen branch. *)
+         probe_condition env branches
+     | _ ->
+       (match thread_binding env fine_node e with
+        (* A block expression in node position — `{let x = …; <span/>}`. The tail
+           is the node; recursing into it keeps the JSX inside fine-grained
+           instead of collapsing the whole block into one coarse View.child thunk
+           (which would rebuild the subtree, and lose element identity, on every
+           dependency change). *)
+        | Some threaded -> threaded
+        | None ->
+       (* A bare value child — `<div>{Signal.get(count)}</div>` — with no explicit
+          <View.Int>/<View.Text> wrapper. Coerce it to a node with View.child:
+          an eager signal read is thunked so it re-runs as reactive text; a static
+          scalar becomes static text; a value that is already a node passes through
+          untouched (View.child detects nodes at runtime). This removes the value-
+          primitive ceremony under the annotation.
+
+          Whatever else the expression is — an application, a pipe, an array,
+          a `try`, a record — it can still *contain* JSX, and any JSX it
+          contains is node position too. So descend first (see
+          decompose_node_shaped), then coerce the result. *)
+          let e = decompose_node_shaped env e in
+          wrap_child (leaf_value env e)))
+
+(* The binding forms a node-position expression can be wrapped in. Each threads
+   the alias environment into its body and hands that body to [recurse]; the
+   parts that are *not* node position — a sequenced statement, a bound value —
+   go through the ordinary traversal instead. Returns None if [e] is not one.
+
+   `fine_node` and `decompose_component_body` walk exactly these five wrappers
+   with different destinations, and had a hand-written copy each. Adding a
+   binding form to one and not the other is the same drift that left
+   container-bound JSX unreached, so they share one list. *)
+and thread_binding (env : env) (recurse : env -> expression -> expression) (e : expression)
+    : expression option =
+  match e.pexp_desc with
+  | Pexp_let (r, vbs, body) ->
+    let vbs' = List.map (map_local_vb env) vbs in
+    let env' = collect_val_aliases env vbs in
+    Some { e with pexp_desc = Pexp_let (r, vbs', recurse env' body) }
+  | Pexp_letmodule (name, me, body) ->
+    let env' = collect_mod_alias env name me in
+    Some { e with pexp_desc = Pexp_letmodule (name, me, recurse env' body) }
+  | Pexp_open (o, l, x) ->
+    let env' = collect_open env l.Location.txt in
+    Some { e with pexp_desc = Pexp_open (o, l, recurse env' x) }
+  | Pexp_sequence (a, b) ->
+    Some { e with pexp_desc = Pexp_sequence (map_expr env a, recurse env b) }
+  | Pexp_constraint (x, t) -> Some { e with pexp_desc = Pexp_constraint (recurse env x, t) }
+  | _ -> None
+
+(* Descend through a node-position expression that is not itself JSX, and
+   decompose the node-shaped things inside it: JSX, and functions returning
+   JSX. Everything else is rebuilt unchanged.
+
+   This is deliberately shape-agnostic. Special-casing containers (application
+   arguments, then arrays, then …) kept missing one: `View.fragment([<p/>])`,
+   `xs->Array.map(x => <li> {x} </li>)`, `opt->Option.getOr(<p/>)` and
+   `try { <p/> } catch { … }` are all just JSX sitting somewhere inside an
+   expression whose value becomes a node. Walking the whole expression covers
+   them uniformly, and covers shapes nobody has written yet. *)
+and decompose_node_shaped (env : env) (e : expression) : expression =
+  map_sub_exprs (decompose_here env) e
+
+(* Decompose one expression *in place*, whatever shape it happens to be: JSX is
+   fine-grained, a function returning JSX is entered through its parameters, and
+   anything else is descended into on the chance it holds JSX further down.
+
+   Both callers need exactly this trio — `decompose_node_shaped` applies it to
+   every sub-expression, `map_local_vb` applies it to a binding's value — and
+   they had drifted apart once already, which is how container-bound JSX
+   (`let rows = [<li/>]`) went unreached. Naming it keeps them in step.
+
+   `component_arg` deliberately does *not* use this: a user-component prop that
+   is not node-shaped is left exactly as written, rather than descended into. *)
+and decompose_here (env : env) (e : expression) : expression =
+  if jsx_parts e <> None || is_jsx_fragment e then fine_node env e
+  else if is_render_callback e then fine_callback env e
+  else decompose_node_shaped env e
+
+(* Wrap the condition/scrutinee (and any `when` guards) of an *untracked*
+   control-flow child in `View.probe`. These drive the structural swap, so a
+   read hidden in one of them freezes the whole branch, not just one value. *)
+and probe_condition (env : env) (e : expression) : expression =
+  let p (v : expression) = if should_probe env v then wrap_probe v else v in
+  match e.pexp_desc with
+  | Pexp_ifthenelse (c, t, eo) -> { e with pexp_desc = Pexp_ifthenelse (p c, t, eo) }
+  | Pexp_match (s, cases) ->
+    { e with
+      pexp_desc =
+        Pexp_match
+          (p s, List.map (fun cs -> { cs with pc_guard = Option.map p cs.pc_guard }) cases) }
+  | _ -> e
+
+(* Recurse fine_node into the *node-position* bodies of control flow (the
+   condition/scrutinee and any guards stay untouched — they are value position
+   and should drive the structural swap). *)
+and decompose_branches (env : env) (e : expression) : expression =
+  match e.pexp_desc with
+  | Pexp_ifthenelse (c, t, eo) ->
+    { e with pexp_desc = Pexp_ifthenelse (c, fine_node env t, Option.map (fine_node env) eo) }
+  | Pexp_match (s, cases) ->
+    { e with pexp_desc = Pexp_match (s, List.map (fun cs -> { cs with pc_rhs = fine_node env cs.pc_rhs }) cases) }
+  | _ -> e
+
+and element_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
+  if is_children_label lbl then (lbl, map_children (fine_node env) v)
+  else
+    match lbl with
+    | Labelled _ | Optional _ ->
+      (* attribute: value position. Thunk it if reactive so it lowers to a
+         computed attribute; leave plain JSX/static/already-function values. *)
+      if is_non_leaf_label lbl then (lbl, if should_thunk env v then thunk v else v)
+      else (lbl, leaf_value env v)
+    | Nolabel -> (lbl, v)
+
+and component_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
+  (* User-component props are left untouched: an eager `Signal.get(x)` prop is a
+     legitimate one-shot read of a plain-typed prop (pass the signal itself when
+     the prop should be reactive). The exceptions are node-shaped values, which
+     are node position wherever they appear: children, any prop whose value is
+     itself JSX, and any prop whose value is a *function returning* JSX (a
+     render callback) — recurse so their reactive leaves stay fine-grained and
+     their bare children are coerced. *)
+  if is_children_label lbl then (lbl, map_children (fine_node env) v)
+  else if jsx_parts v <> None || is_jsx_fragment v then (lbl, fine_node env v)
+  else if is_render_callback v then (lbl, fine_callback env v)
+  else (lbl, v)
+
+(* Decompose the body of a render callback, walking past its parameters (and
+   the uncurried `Function$` wrapper) to the node-position body. *)
+and fine_callback (env : env) (e : expression) : expression =
+  match e.pexp_desc with
+  | Pexp_construct (({ txt = Longident.Lident "Function$"; _ } as c), Some fn) ->
+    { e with pexp_desc = Pexp_construct (c, Some (fine_callback env fn)) }
+  | Pexp_fun (l, def, p, body) ->
+    { e with pexp_desc = Pexp_fun (l, def, p, fine_callback env body) }
+  | _ -> fine_node env e
+
+and value_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
+  if is_children_label lbl then (lbl, map_children (leaf_value env) v)
+  else
+    match lbl with
+    | Labelled "value" -> (lbl, leaf_value env v)
+    | _ -> (lbl, v)
+
+(* Map [f] over a JSX children list (a `::`/`[]` spine); tolerate a bare
+   single child that is not wrapped in a list. *)
+and map_children f (v : expression) : expression =
+  match v.pexp_desc with
+  | Pexp_construct
+      ( ({ txt = Longident.Lident "::"; _ } as c),
+        Some ({ pexp_desc = Pexp_tuple [ hd; tl ]; _ } as tup) ) ->
+    let hd' = f hd in
+    let tl' = map_children f tl in
+    { v with pexp_desc = Pexp_construct (c, Some { tup with pexp_desc = Pexp_tuple [ hd'; tl' ] }) }
+  | Pexp_construct ({ txt = Longident.Lident "[]"; _ }, None) -> v
+  | _ -> f v
+
+(* ---- traversal: find @xote.component and decompose ----------------------- *)
+and map_expr (env : env) (e : expression) : expression =
+  let d =
+    match e.pexp_desc with
+    | Pexp_fun (l, def, p, body) -> Pexp_fun (l, def, p, map_expr env body)
+    | Pexp_let (r, vbs, body) ->
+      (* aliases bound here are visible in the body, not in the RHSs *)
+      let vbs' = List.map (map_vb env) vbs in
+      let env' = collect_val_aliases env vbs in
+      Pexp_let (r, vbs', map_expr env' body)
+    | Pexp_letmodule (name, me, body) ->
+      let env' = collect_mod_alias env name me in
+      Pexp_letmodule (name, me, map_expr env' body)
+    | Pexp_open (o, l, x) ->
+      let env' = collect_open env l.Location.txt in
+      Pexp_open (o, l, map_expr env' x)
+    | Pexp_sequence (a, b) -> Pexp_sequence (map_expr env a, map_expr env b)
+    | Pexp_apply (f, args) ->
+      Pexp_apply (map_expr env f, List.map (fun (l, a) -> (l, map_expr env a)) args)
+    | Pexp_ifthenelse (c, t, eo) ->
+      Pexp_ifthenelse (map_expr env c, map_expr env t, Option.map (map_expr env) eo)
+    | Pexp_match (x, cases) ->
+      Pexp_match (map_expr env x, List.map (fun cs -> { cs with pc_rhs = map_expr env cs.pc_rhs }) cases)
+    | Pexp_constraint (x, t) -> Pexp_constraint (map_expr env x, t)
+    | Pexp_tuple xs -> Pexp_tuple (List.map (map_expr env) xs)
+    | Pexp_array xs -> Pexp_array (List.map (map_expr env) xs)
+    | Pexp_construct (l, eo) -> Pexp_construct (l, Option.map (map_expr env) eo)
+    | other -> other
+  in
+  { e with pexp_desc = d }
+
+and map_vb (env : env) (vb : value_binding) : value_binding =
+  match List.find_opt is_xote_component vb.pvb_attributes with
+  | Some _ ->
+    (* swap @xote.component -> @jsx.component and decompose the returned JSX *)
+    { vb with
+      pvb_attributes = jsx_component_attr :: strip_xote_component vb.pvb_attributes;
+      pvb_expr = decompose_component_body env vb.pvb_expr }
+  | None -> { vb with pvb_expr = map_expr env vb.pvb_expr }
+
+(* A binding *inside* an annotated component. Its value is rendered as part of
+   that component, so JSX bound to a name — `let row = <p> {"x"} </p>` — and a
+   local helper returning JSX — `let btn = label => <button> {label} </button>`
+   — are decomposed exactly like inline markup. Without this the annotation
+   stopped at the component's return expression, and pulling a piece of markup
+   out into a local binding silently lost fine-grained leaves and required the
+   value-primitive wrappers back. *)
+and map_local_vb (env : env) (vb : value_binding) : value_binding =
+  if List.exists is_xote_component vb.pvb_attributes then map_vb env vb
+  else
+    (* Whatever shape the value is — JSX, a helper returning JSX, or JSX sitting
+       one container down (`let rows = [<li/>]`, `Some(<h1/>)`, a tuple,
+       `xs => Array.map(xs, x => <li/>)`) — it is rendered as part of this
+       component, so it is decomposed like inline markup.
+
+       Stopping at the first two shapes was the third instance of one bug: an
+       expression that ends up in node position was not reached by the traversal.
+       It was also the worst-behaved one, because unreached leaves are never
+       *visited* — so they get no `View.probe` either, and a reactive attribute
+       inside container-bound JSX compiled to a frozen value with no warning. *)
+    { vb with pvb_expr = decompose_here env vb.pvb_expr }
+
+(* Walk to the component's tail (return) expression, threading the alias env
+   through lets/opens and running the normal traversal on non-tail parts (so a
+   nested reactive leaves still work), then fine-grain the returned JSX. *)
+and decompose_component_body (env : env) (e : expression) : expression =
+  match e.pexp_desc with
+  (* Uncurried function encoding: `Function$(fun … -> body)` (with res.arity on
+     the construct, preserved by the record-with). Unwrap to reach the fun. *)
+  | Pexp_construct (({ txt = Longident.Lident "Function$"; _ } as c), Some fn) ->
+    { e with pexp_desc = Pexp_construct (c, Some (decompose_component_body env fn)) }
+  | Pexp_fun (l, def, p, body) ->
+    { e with pexp_desc = Pexp_fun (l, def, p, decompose_component_body env body) }
+  | _ ->
+    (match thread_binding env decompose_component_body e with
+     | Some threaded -> threaded
+     | None -> fine_node env e)
+
+(* Does this file opt in to the annotation at all? A file containing at least
+   one @xote.component is written in the fine-grained style, so JSX anywhere in
+   it — including plain helper functions like
+   `let filterButton = (label, …) => <button> {label} </button>` — is
+   decomposed too. Helpers that return markup are components in all but name,
+   and requiring the value-primitive wrappers back in them was the last place
+   the two styles collided.
+
+   Files with no annotation are left completely untouched, so a project mixing
+   @jsx.component code with explicit thunks keeps its current semantics. *)
+let rec structure_has_component (s : structure) : bool =
+  List.exists
+    (fun si ->
+      match si.pstr_desc with
+      | Pstr_value (_, vbs) ->
+        List.exists (fun vb -> List.exists is_xote_component vb.pvb_attributes) vbs
+      | Pstr_module mb -> module_has_component mb.pmb_expr
+      | Pstr_recmodule mbs -> List.exists (fun mb -> module_has_component mb.pmb_expr) mbs
+      | _ -> false)
+    s
+
+and module_has_component (me : module_expr) : bool =
+  match me.pmod_desc with
+  | Pmod_structure s -> structure_has_component s
+  | Pmod_constraint (m, _) -> module_has_component m
+  | Pmod_functor (_, _, b) -> module_has_component b
+  | _ -> false
+
+(* Set once per file, before the traversal runs. *)
+let fine_grain_helpers = ref false
+
+(* Structure items are threaded left-to-right so a top-level `let g = Signal.get`,
+   `module S = Signal`, or `open Signal` is visible to later items. *)
+let rec map_structure (env : env) (s : structure) : structure =
+  let _, rev =
+    List.fold_left
+      (fun (env, acc) si -> (update_env_si env si, map_si env si :: acc))
+      (env, []) s
+  in
+  List.rev rev
+
+and update_env_si (env : env) si =
+  match si.pstr_desc with
+  | Pstr_value (_, vbs) -> collect_val_aliases env vbs
+  | Pstr_module mb ->
+    let env = collect_mod_alias env mb.pmb_name mb.pmb_expr in
+    collect_module_funcs env mb.pmb_name.Location.txt mb.pmb_expr
+  | Pstr_open od -> collect_open env od.popen_lid.Location.txt
+  | _ -> env
+
+(* `module Store = { let count = s => Signal.get(s) }` in this file makes
+   `Store.count(s)` a read like any local helper. Walk the module body with the
+   surrounding environment (so it can use outer aliases), then qualify the
+   reactive names it introduced. Only same-file modules are reachable — a helper
+   imported from another file is what `View.probe` covers. *)
+and collect_module_funcs (env : env) (name : string) (me : module_expr) : env =
+  match me.pmod_desc with
+  | Pmod_structure s | Pmod_constraint ({ pmod_desc = Pmod_structure s; _ }, _) ->
+    let inner = List.fold_left update_env_si env s in
+    let added before after = List.filter (fun n -> not (List.mem n before)) after in
+    let names = added env.funcs inner.funcs @ added env.vals inner.vals in
+    { env with qfuncs = List.map (fun n -> name ^ "." ^ n) names @ env.qfuncs }
+  | _ -> env
+
+and map_si (env : env) si =
+  match si.pstr_desc with
+  | Pstr_value (r, vbs) ->
+    let f = if !fine_grain_helpers then map_local_vb env else map_vb env in
+    { si with pstr_desc = Pstr_value (r, List.map f vbs) }
+  | Pstr_module mb -> { si with pstr_desc = Pstr_module (map_mb env mb) }
+  | Pstr_recmodule mbs -> { si with pstr_desc = Pstr_recmodule (List.map (map_mb env) mbs) }
+  | Pstr_include incl ->
+    { si with pstr_desc = Pstr_include { incl with pincl_mod = map_mod env incl.pincl_mod } }
+  | Pstr_eval (e, attrs) -> { si with pstr_desc = Pstr_eval (map_expr env e, attrs) }
+  | _ -> si
+
+and map_mb (env : env) mb = { mb with pmb_expr = map_mod env mb.pmb_expr }
+and map_mod (env : env) me =
+  match me.pmod_desc with
+  | Pmod_structure s -> { me with pmod_desc = Pmod_structure (map_structure env s) }
+  (* `module Widget: Sig = { … }` and functor bodies still contain components;
+     skipping them would leave @xote.component silently unexpanded *)
+  | Pmod_constraint (m, mt) -> { me with pmod_desc = Pmod_constraint (map_mod env m, mt) }
+  | Pmod_functor (name, mt, body) ->
+    { me with pmod_desc = Pmod_functor (name, mt, map_mod env body) }
+  | _ -> me
+
+(* ---- ReScript -ppx binary protocol: `ppx <infile> <outfile>` ------------ *)
+let impl_magic = "Caml1999M022"
+let usage =
+  "xote ppx: fine-grained @xote.component rewriter for ReScript.\n\
+   Invoked by the compiler via rescript.json ppx-flags as `ppx <ast-in> <ast-out>`."
+
+let () =
+  let n = Array.length Sys.argv in
+  (* `--help` doubles as the postinstall/CI smoke test: it proves the binary
+     loads and executes on the host (right libc, right arch) without an AST. *)
+  if n = 2 && (Sys.argv.(1) = "--help" || Sys.argv.(1) = "-h") then begin
+    print_endline usage;
+    exit 0
+  end;
+  if n < 3 then begin
+    prerr_endline usage;
+    exit 2
+  end;
+  let infile = Sys.argv.(n - 2) and outfile = Sys.argv.(n - 1) in
+  let ic = open_in_bin infile in
+  let magic = really_input_string ic (String.length impl_magic) in
+  let name : string = input_value ic in
+  let payload : Obj.t = input_value ic in
+  close_in ic;
+  (* Interface ASTs (Caml1999N…) legitimately pass through untouched. A
+     different *implementation* magic means the compiler's ppx ABI moved and
+     @xote.component cannot be expanded — fail the build here with a clear
+     message rather than passing the AST through and letting it die later on
+     a confusing type error. *)
+  let is_impl = String.length magic >= 9 && String.sub magic 0 9 = "Caml1999M" in
+  if is_impl && magic <> impl_magic then begin
+    prerr_endline
+      ("xote ppx: unsupported AST magic " ^ magic ^ " (this ppx expects " ^ impl_magic
+       ^ "), so @xote.component cannot be expanded in " ^ name
+       ^ ". The installed ReScript version's ppx ABI is newer than this ppx supports; "
+       ^ "upgrade xote, or remove it from ppx-flags.");
+    exit 2
+  end;
+  let oc = open_out_bin outfile in
+  output_string oc magic;
+  output_value oc name;
+  (if magic = impl_magic then
+     let structure = (Obj.magic payload : structure) in
+     source_file := Filename.basename name;
+     fine_grain_helpers := structure_has_component structure;
+     output_value oc (map_structure empty_env structure)
+   else output_value oc payload);
+  close_out oc
+

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -992,26 +992,42 @@ let view_child = Longident.Ldot (Longident.Lident "View", "child")
 let wrap_child e = apply (ident view_child) [ e ]
 
 (* ---- signal-read detection ----------------------------------------------
-   A read is any occurrence of `Signal.get` (applied or not). Beyond the
-   literal `Signal.get` / `X.Signal.get`, an alias environment threaded through
-   the traversal also recognises indirect reads:
+   A read is a tracked `get`: `Signal.get`, and equally `MaybeSignal.get` /
+   `Prop.get` (the deprecated alias), which read through the static-or-reactive
+   wrapper and subscribe just the same. Beyond the literal `Signal.get` /
+   `X.MaybeSignal.get`, an alias environment threaded through the traversal also
+   recognises indirect reads:
      - a value alias:    `let g = Signal.get` then `g(sig)`
      - a module alias:   `module S = Signal` then `S.get(sig)`
      - an open:          `open Signal` then a bare `get(sig)`
      - a reactive helper: `let cls = () => Signal.get(x) ? …` then `cls()` —
        a local function whose body eagerly reads a signal; calling it is a read.
+     - a same-file module helper: `module Store = { let count = s => Signal.get(s) }`
+       then `Store.count(s)` — collected per module while walking the structure.
    The environment is scoped by the traversal (bindings visible only after they
    appear); shadowing a name with a non-reactive binding removes it. *)
-type env = { vals : string list; mods : string list; funcs : string list; open_signal : bool }
-let empty_env = { vals = []; mods = []; funcs = []; open_signal = false }
+type env = {
+  vals : string list;
+  mods : string list;
+  funcs : string list;
+  (* reactive helpers reached through a same-file module, as "Store.count" *)
+  qfuncs : string list;
+  open_signal : bool;
+}
+let empty_env = { vals = []; mods = []; funcs = []; qfuncs = []; open_signal = false }
 
-let is_signal_get (env : env) (e : expression) : bool =
+(* Modules whose `get` is a *tracked* read. `peek` is deliberately absent from
+   every one of them: it is the untracked read. *)
+let is_read_module_name = function
+  | "Signal" | "MaybeSignal" | "Prop" -> true
+  | _ -> false
+
+let is_read_fn (env : env) (e : expression) : bool =
   match e.pexp_desc with
   | Pexp_ident { txt = Longident.Ldot (m, "get"); _ } ->
     (match m with
-     | Longident.Lident "Signal" -> true
-     | Longident.Ldot (_, "Signal") -> true
-     | Longident.Lident name -> List.mem name env.mods
+     | Longident.Lident name -> is_read_module_name name || List.mem name env.mods
+     | Longident.Ldot (_, name) -> is_read_module_name name
      | _ -> false)
   | Pexp_ident { txt = Longident.Lident name; _ } ->
     List.mem name env.vals || (env.open_signal && name = "get")
@@ -1087,6 +1103,9 @@ let is_reactive_call (env : env) (e : expression) : bool =
   match e.pexp_desc with
   | Pexp_apply ({ pexp_desc = Pexp_ident { txt = Longident.Lident f; _ }; _ }, _) ->
     List.mem f env.funcs
+  | Pexp_apply
+      ({ pexp_desc = Pexp_ident { txt = Longident.Ldot (Longident.Lident m, f); _ }; _ }, _) ->
+    List.mem (m ^ "." ^ f) env.qfuncs
   | _ -> false
 
 (* An *eager* read: a `Signal.get` (or reactive-helper call) that runs when this
@@ -1099,7 +1118,7 @@ let rec reads_signal_eager (env : env) (e : expression) : bool =
   | Pexp_fun _ -> false
   | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some _) -> false
   | _ ->
-    is_reactive_call env e || is_signal_get env e
+    is_reactive_call env e || is_read_fn env e
     || List.exists (reads_signal_eager env) (sub_exprs e)
 
 (* Does `e` denote a function whose body eagerly reads a signal? Strip the
@@ -1126,7 +1145,7 @@ let collect_val_aliases (env : env) (vbs : value_binding list) : env =
       match vb.pvb_pat.ppat_desc with
       | Ppat_var { txt = name; _ } ->
         let drop = List.filter (fun n -> n <> name) in
-        if is_signal_get env vb.pvb_expr then
+        if is_read_fn env vb.pvb_expr then
           { env with vals = name :: env.vals; funcs = drop env.funcs }
         else if func_reads env vb.pvb_expr then
           { env with funcs = name :: env.funcs; vals = drop env.vals }
@@ -1134,22 +1153,22 @@ let collect_val_aliases (env : env) (vbs : value_binding list) : env =
       | _ -> env)
     env vbs
 
-let is_signal_module (me : module_expr) : bool =
+let is_read_module (me : module_expr) : bool =
   match me.pmod_desc with
-  | Pmod_ident { txt = Longident.Lident "Signal"; _ } -> true
-  | Pmod_ident { txt = Longident.Ldot (_, "Signal"); _ } -> true
+  | Pmod_ident { txt = Longident.Lident name; _ } -> is_read_module_name name
+  | Pmod_ident { txt = Longident.Ldot (_, name); _ } -> is_read_module_name name
   | _ -> false
 
 let collect_mod_alias (env : env) (name : string Location.loc) (me : module_expr) : env =
-  if is_signal_module me then { env with mods = name.Location.txt :: env.mods } else env
+  if is_read_module me then { env with mods = name.Location.txt :: env.mods } else env
 
-let is_signal_lid = function
-  | Longident.Lident "Signal" -> true
-  | Longident.Ldot (_, "Signal") -> true
+let is_read_lid = function
+  | Longident.Lident name -> is_read_module_name name
+  | Longident.Ldot (_, name) -> is_read_module_name name
   | _ -> false
 
 let collect_open (env : env) (lid : Longident.t) : env =
-  if is_signal_lid lid then { env with open_signal = true } else env
+  if is_read_lid lid then { env with open_signal = true } else env
 
 (* ---- JSX shape helpers -------------------------------------------------- *)
 let has_jsx (e : expression) : bool =
@@ -1181,6 +1200,100 @@ let is_value_component (f : expression) : bool =
   | Pexp_ident { txt = Longident.Ldot (Longident.Lident "View", ("Text" | "Int" | "Float" | "Bool")); _ } ->
     true
   | _ -> false
+
+(* Does this expression contain JSX anywhere? A value that builds nodes is not a
+   scalar leaf, so it is never probed for a hidden read (the JSX inside it is
+   decomposed on its own). *)
+let rec contains_jsx (e : expression) : bool =
+  jsx_parts e <> None || is_jsx_fragment e || List.exists contains_jsx (sub_exprs e)
+
+(* ---- hidden reads --------------------------------------------------------
+   Detection is syntactic, so a read behind a call the ppx cannot see the
+   definition of — `Store.waitingCount(store)` from another module, a read
+   pulled out of a data structure — looks exactly like a static value and
+   compiles to one. That was the single silent failure mode.
+
+   The ppx cannot resolve such a call, but it can *tell that one is there*: an
+   expression made only of constants, identifiers, field accesses, lambdas and
+   structural combinations of those provably calls nothing, and anything else
+   might. Leaves in the second group are wrapped in `View.probe`, which decides
+   at runtime — it evaluates the expression inside a throwaway computed and
+   warns, naming this source location, if the evaluation actually subscribed to
+   a signal. Inert leaves are emitted untouched, so the common cases (a literal,
+   a prop, `item.name`) cost nothing. *)
+
+(* A symbolic identifier (`>`, `++`, `===`) is a ReScript primitive operator, so
+   applying one is as inert as its arguments. *)
+let is_operator_name (s : string) : bool =
+  String.length s > 0
+  && (match s.[0] with 'a' .. 'z' | 'A' .. 'Z' | '_' -> false | _ -> true)
+
+(* Xote's and rescript-signals' own entry points never hide a tracked read: they
+   build nodes (`View.text`, `Html.div`) or reactive values that carry their own
+   subscription (`Computed.make`, `MaybeSignal.reactive`), and the one function
+   here that *is* a read — `Signal.get`/`MaybeSignal.get` — is recognised and
+   thunked before probing is ever considered. `Signal.peek` is untracked by
+   design. So a call into one of them is as inert as its arguments, and probing
+   it would only report node-shaped values nobody can act on. *)
+let is_library_module = function
+  | "View" | "Html" | "XoteJSX" | "Signal" | "Computed" | "Effect" | "MaybeSignal" | "Prop" ->
+    true
+  | _ -> false
+
+let is_library_call_path (lid : Longident.t) : bool =
+  match lid with
+  | Longident.Ldot (Longident.Lident m, _) | Longident.Ldot (Longident.Ldot (_, m), _) ->
+    is_library_module m
+  | _ -> false
+
+let rec is_inert (e : expression) : bool =
+  match e.pexp_desc with
+  | Pexp_constant _ | Pexp_ident _ | Pexp_fun _ | Pexp_function _ | Pexp_unreachable -> true
+  (* a thunk defers its body: whatever it reads, it reads reactively *)
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some _) -> true
+  | Pexp_construct (_, eo) | Pexp_variant (_, eo) ->
+    (match eo with Some x -> is_inert x | None -> true)
+  | Pexp_field (x, _) | Pexp_constraint (x, _) | Pexp_coerce (x, _, _) | Pexp_lazy x -> is_inert x
+  | Pexp_tuple xs | Pexp_array xs -> List.for_all is_inert xs
+  | Pexp_record (fields, base) ->
+    List.for_all (fun (_, v) -> is_inert v) fields
+    && (match base with Some b -> is_inert b | None -> true)
+  | Pexp_ifthenelse (c, t, eo) ->
+    is_inert c && is_inert t && (match eo with Some x -> is_inert x | None -> true)
+  | Pexp_match (s, cases) ->
+    is_inert s
+    && List.for_all
+         (fun c ->
+           is_inert c.pc_rhs && match c.pc_guard with Some g -> is_inert g | None -> true)
+         cases
+  | Pexp_sequence (a, b) -> is_inert a && is_inert b
+  | Pexp_let (_, vbs, body) ->
+    List.for_all (fun vb -> is_inert vb.pvb_expr) vbs && is_inert body
+  | Pexp_open (_, _, x) -> is_inert x
+  | Pexp_apply ({ pexp_desc = Pexp_ident { txt = Longident.Lident op; _ }; _ }, args)
+    when is_operator_name op ->
+    List.for_all (fun (_, a) -> is_inert a) args
+  | Pexp_apply ({ pexp_desc = Pexp_ident { txt = lid; _ }; _ }, args)
+    when is_library_call_path lid ->
+    List.for_all (fun (_, a) -> is_inert a) args
+  | _ -> false
+
+(* The file being rewritten, used when an expression carries no location. *)
+let source_file = ref ""
+
+let site_of (loc : Location.t) : string =
+  let p = loc.Location.loc_start in
+  let file =
+    if p.Lexing.pos_fname = "" then !source_file else Filename.basename p.Lexing.pos_fname
+  in
+  let file = if file = "" then "@xote.component" else file in
+  if p.Lexing.pos_lnum <= 0 then file
+  else Printf.sprintf "%s:%d:%d" file p.Lexing.pos_lnum (p.Lexing.pos_cnum - p.Lexing.pos_bol + 1)
+
+let view_probe = Longident.Ldot (Longident.Lident "View", "probe")
+let str_const s = mkexp (Pexp_constant (Pconst_string (s, None)))
+let wrap_probe (e : expression) : expression =
+  apply (ident view_probe) [ str_const (site_of e.pexp_loc); thunk e ]
 
 (* ---- render callbacks ----------------------------------------------------
    A prop whose value is a *function returning JSX* — `render={item => <li>…}`
@@ -1229,6 +1342,17 @@ let is_children_label = function
   | Labelled "children" | Optional "children" -> true
   | _ -> false
 
+let label_name = function Labelled n | Optional n -> Some n | Nolabel -> None
+
+(* Labels that are never a reactive value leaf, so never worth probing: an event
+   handler is a callback, and `attrs` is the escape-hatch array whose entries
+   carry their own `View.attr`/`View.computedAttr` reactivity. *)
+let is_non_leaf_label (lbl : arg_label) : bool =
+  match label_name lbl with
+  | Some "attrs" -> true
+  | Some n -> String.length n > 2 && n.[0] = 'o' && n.[1] = 'n' && n.[2] >= 'A' && n.[2] <= 'Z'
+  | None -> false
+
 (* A value-position expression should be thunked iff it *eagerly* reads a signal
    and isn't already JSX. Using the eager check means values that are already
    reactive on their own — a `() => …` thunk, a `Computed`, a `Prop.reactive(…)`
@@ -1236,6 +1360,18 @@ let is_children_label = function
    @xote.component is a safe drop-in on components already written that way. *)
 let should_thunk (env : env) (v : expression) : bool =
   reads_signal_eager env v && jsx_parts v = None
+
+(* A value-position expression whose read status the ppx cannot decide: it is
+   not a visible read (that is already thunked), and it is not provably
+   call-free either. `View.probe` settles it at runtime. Node-shaped values are
+   excluded — they are decomposed, not read. *)
+let should_probe (env : env) (v : expression) : bool =
+  (not (should_thunk env v)) && (not (is_inert v)) && not (contains_jsx v)
+
+(* A value-position leaf: thunk a visible read, probe an unresolvable call,
+   leave everything else exactly as written. *)
+let leaf_value (env : env) (v : expression) : expression =
+  if should_thunk env v then thunk v else if should_probe env v then wrap_probe v else v
 
 (* `@xote.component` is the single annotation: it derives props exactly like
    `@jsx.component` (which we emit for the JSX transform to expand) *and*
@@ -1295,7 +1431,13 @@ let rec fine_node (env : env) (e : expression) : expression =
           a local) is ordinary UI code, so this path matters as much as the
           reactive one. *)
        let branches = decompose_branches env e in
-       if reads_signal_eager env e then wrap_tracked branches else branches
+       if reads_signal_eager env e then wrap_tracked branches
+       else
+         (* No visible read, so no `View.tracked`. If the condition/scrutinee is
+            not provably call-free, the structure may in fact depend on a signal
+            the ppx cannot see; probe it so that failure is reported instead of
+            silently rendering one frozen branch. *)
+         probe_condition env branches
      | Pexp_let (r, vbs, body) ->
        (* A block expression in node position — `{let x = …; <span/>}`. Recurse
           into the tail so the JSX inside keeps fine-grained leaves instead of
@@ -1327,7 +1469,7 @@ let rec fine_node (env : env) (e : expression) : expression =
           contains is node position too. So descend first (see
           decompose_node_shaped), then coerce the result. *)
        let e = decompose_node_shaped env e in
-       wrap_child (if should_thunk env e then thunk e else e))
+       wrap_child (leaf_value env e))
 
 (* Descend through a node-position expression that is not itself JSX, and
    decompose the node-shaped things inside it: JSX, and functions returning
@@ -1347,6 +1489,20 @@ and decompose_node_shaped (env : env) (e : expression) : expression =
       else decompose_node_shaped env sub)
     e
 
+(* Wrap the condition/scrutinee (and any `when` guards) of an *untracked*
+   control-flow child in `View.probe`. These drive the structural swap, so a
+   read hidden in one of them freezes the whole branch, not just one value. *)
+and probe_condition (env : env) (e : expression) : expression =
+  let p (v : expression) = if should_probe env v then wrap_probe v else v in
+  match e.pexp_desc with
+  | Pexp_ifthenelse (c, t, eo) -> { e with pexp_desc = Pexp_ifthenelse (p c, t, eo) }
+  | Pexp_match (s, cases) ->
+    { e with
+      pexp_desc =
+        Pexp_match
+          (p s, List.map (fun cs -> { cs with pc_guard = Option.map p cs.pc_guard }) cases) }
+  | _ -> e
+
 (* Recurse fine_node into the *node-position* bodies of control flow (the
    condition/scrutinee and any guards stay untouched — they are value position
    and should drive the structural swap). *)
@@ -1365,7 +1521,8 @@ and element_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * ex
     | Labelled _ | Optional _ ->
       (* attribute: value position. Thunk it if reactive so it lowers to a
          computed attribute; leave plain JSX/static/already-function values. *)
-      if should_thunk env v then (lbl, thunk v) else (lbl, v)
+      if is_non_leaf_label lbl then (lbl, if should_thunk env v then thunk v else v)
+      else (lbl, leaf_value env v)
     | Nolabel -> (lbl, v)
 
 and component_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
@@ -1395,12 +1552,11 @@ and value_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expr
   if is_children_label lbl then (lbl, map_children (value_leaf env) v)
   else
     match lbl with
-    | Labelled "value" -> (lbl, if should_thunk env v then thunk v else v)
+    | Labelled "value" -> (lbl, leaf_value env v)
     | _ -> (lbl, v)
 
 (* child of a value component (View.Text ...): value position -> thunk. *)
-and value_leaf (env : env) (v : expression) : expression =
-  if should_thunk env v then thunk v else v
+and value_leaf (env : env) (v : expression) : expression = leaf_value env v
 
 (* Map [f] over a JSX children list (a `::`/`[]` spine); tolerate a bare
    single child that is not wrapped in a list. *)
@@ -1543,8 +1699,24 @@ let rec map_structure (env : env) (s : structure) : structure =
 and update_env_si (env : env) si =
   match si.pstr_desc with
   | Pstr_value (_, vbs) -> collect_val_aliases env vbs
-  | Pstr_module mb -> collect_mod_alias env mb.pmb_name mb.pmb_expr
+  | Pstr_module mb ->
+    let env = collect_mod_alias env mb.pmb_name mb.pmb_expr in
+    collect_module_funcs env mb.pmb_name.Location.txt mb.pmb_expr
   | Pstr_open od -> collect_open env od.popen_lid.Location.txt
+  | _ -> env
+
+(* `module Store = { let count = s => Signal.get(s) }` in this file makes
+   `Store.count(s)` a read like any local helper. Walk the module body with the
+   surrounding environment (so it can use outer aliases), then qualify the
+   reactive names it introduced. Only same-file modules are reachable — a helper
+   imported from another file is what `View.probe` covers. *)
+and collect_module_funcs (env : env) (name : string) (me : module_expr) : env =
+  match me.pmod_desc with
+  | Pmod_structure s | Pmod_constraint ({ pmod_desc = Pmod_structure s; _ }, _) ->
+    let inner = List.fold_left update_env_si env s in
+    let added before after = List.filter (fun n -> not (List.mem n before)) after in
+    let names = added env.funcs inner.funcs @ added env.vals inner.vals in
+    { env with qfuncs = List.map (fun n -> name ^ "." ^ n) names @ env.qfuncs }
   | _ -> env
 
 and map_si (env : env) si =
@@ -1613,6 +1785,7 @@ let () =
   output_value oc name;
   (if magic = impl_magic then
      let structure = (Obj.magic payload : structure) in
+     source_file := Filename.basename name;
      fine_grain_helpers := structure_has_component structure;
      output_value oc (map_structure empty_env structure)
    else output_value oc payload);

--- a/scripts/check-ppx-binaries.mjs
+++ b/scripts/check-ppx-binaries.mjs
@@ -1,0 +1,21 @@
+/* prepublishOnly guard: refuse to publish a tarball without the prebuilt ppx
+ * binaries. They exist only in the release workflow (built per-platform and
+ * downloaded into ppx/bin/), so a manual `npm publish` from a dev checkout
+ * would otherwise silently ship a package where every consumer without an
+ * OCaml toolchain gets the degraded no-ppx path. */
+import { existsSync, statSync } from 'node:fs';
+
+const targets = ['linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64', 'win32-x64'];
+const missing = targets.filter(t => {
+  const p = `ppx/bin/ppx-${t}.exe`;
+  return !existsSync(p) || statSync(p).size === 0;
+});
+
+if (missing.length > 0) {
+  console.error(
+    `xote: refusing to publish without prebuilt ppx binaries (missing: ${missing.join(', ')}).\n` +
+      'Publish via .github/workflows/release.yml, which builds them per platform and downloads them into ppx/bin/.',
+  );
+  process.exit(1);
+}
+console.log('xote: all prebuilt ppx binaries present.');

--- a/src/View.res
+++ b/src/View.res
@@ -594,6 +594,12 @@ let fragment = (children: array<node>): node => Fragment(children)
 
 let signalFragment = (signal: Signal.t<array<node>>): node => SignalFragment(signal)
 
+/* Auto-tracked reactive block: every signal read while `body` runs subscribes
+   the block, which re-evaluates `body` and replaces its children wholesale
+   (no diffing) whenever a dependency changes. Prefer `eachWithKey`/`For` for
+   lists and keep tracked blocks small. */
+let tracked = (body: unit => node): node => SignalFragment(Computed.make(() => [body()]))
+
 let childrenToArray = (child: option<node>): array<node> => {
   switch child {
   | Some(Fragment(children)) => children
@@ -772,6 +778,244 @@ let renderValuePrimitiveProps = (props: 'props, stringify: 'scalar => string): n
   | (None, None) => null()
   }
 }
+
+/* Is this runtime value already a `node`? Nodes are ReScript variants compiled
+   to objects carrying a string `TAG` in the set below; Signals, Props, scalars
+   and functions are not, so a value already built into a node passes straight
+   through `child`. */
+let isNode: 'a => bool = %raw(`function (v) {
+  if (v === null || typeof v !== "object" || typeof v.TAG !== "string") { return false }
+  switch (v.TAG) {
+    case "Element":
+    case "Text":
+    case "SignalText":
+    case "Fragment":
+    case "SignalFragment":
+    case "Keyed":
+    case "LazyComponent":
+    case "KeyedList":
+      return true
+    default:
+      return false
+  }
+}`)
+
+/* Stringify any scalar child (int/float/string/bool) without knowing its type
+   at compile time; null/undefined render as empty. */
+let stringifyChild: 'a => string = %raw(`function (v) { return v == null ? "" : String(v) }`)
+
+/* Is this runtime value a rescript-signals signal/computed? Positive shape
+   check against `Signal.t` ({id: int, value, equals: fn, subs: object}) —
+   detecting by shape rather than assuming any non-node object is a signal
+   keeps records/dicts that land in `child` from reaching `Signal.get`. */
+let isSignal: 'a => bool = %raw(`function (v) {
+  return v !== null && typeof v === "object"
+    && typeof v.id === "number"
+    && typeof v.equals === "function"
+    && typeof v.subs === "object" && v.subs !== null
+    && "value" in v
+}`)
+
+let isArray: 'a => bool = %raw(`function (v) { return Array.isArray(v) }`)
+
+/* A value that renders as text on its own (string, number, boolean), as
+   opposed to a node, a signal, a collection, or nothing. */
+let isScalar: 'a => bool = %raw(`function (v) {
+  const t = typeof v
+  return t === "string" || t === "number" || t === "boolean"
+}`)
+
+/* ============================================================================
+ * Development-only diagnostics
+ * ============================================================================ */
+
+/* Both diagnostics below cost something in production — the probe allocates a
+   throwaway computed per unresolved leaf, and `warnUnrenderable` formats a
+   console argument on every coerced child — so both are skipped there.
+   `globalThis.__XOTE_DEV__` wins when set; otherwise `process.env.NODE_ENV`
+   (which bundlers inline) decides. When neither is available they stay on: a
+   silently stale UI is worse than an allocation. */
+let readDevFlag: unit => bool = %raw(`function () {
+  try {
+    if (typeof globalThis !== "undefined" && globalThis.__XOTE_DEV__ !== undefined) {
+      return !!globalThis.__XOTE_DEV__
+    }
+    if (typeof process !== "undefined" && process.env && process.env.NODE_ENV) {
+      return process.env.NODE_ENV !== "production"
+    }
+  } catch (_) {}
+  return true
+}`)
+
+let devMode: ref<option<bool>> = ref(None)
+
+let isDevMode = (): bool =>
+  switch devMode.contents {
+  | Some(enabled) => enabled
+  | None => {
+      let enabled = readDevFlag()
+      devMode := Some(enabled)
+      enabled
+    }
+  }
+
+let logUnrenderable: 'a => unit = %raw(`function (v) {
+  console.warn(
+    "[Xote] View.child: this value is not a node, signal, array, function or scalar and cannot be rendered; it was stringified. Build a node from it (View.text, JSX, ...) instead:",
+    v
+  )
+}`)
+
+/* Reaching here means the child is already rendering wrong, so the warning is
+   worth an allocation in development — but in production the render is what it
+   is, and the message helps nobody. */
+let warnUnrenderable = (value: 'a): unit =>
+  if isDevMode() {
+    logUnrenderable(value)
+  }
+
+/* Coerce an arbitrary JSX child into a node. This is what `@xote.component`
+   emits for a *bare* child in element position — `<div>{Signal.get(count)}</div>`
+   — so a value primitive (`<View.Int>`) is no longer required:
+
+     - an already-built node passes through untouched;
+     - a reactive thunk (what the ppx emits for an eager signal read) re-runs on
+       change — a scalar result becomes reactive text, a node result a tracked
+       fragment;
+     - a bare `Signal.t` (detected by shape) becomes reactive text; a plain
+       scalar, static text;
+     - an array is coerced element-wise into a `Fragment`;
+     - null/undefined render nothing;
+     - any other object cannot be rendered: it is stringified with a console
+       warning rather than treated as a signal.
+
+   A thunk whose first evaluation is a *scalar* locks into reactive-text mode
+   (safe: ReScript typing keeps scalar thunks scalar). Any other first value —
+   node, array, option<node>, null — gets a tracked fragment that re-coerces
+   the result on every run, so shape changes like `None -> Some(node)` render
+   correctly. The one unsupported shape change is scalar-first-then-node from
+   an untyped hand-written thunk.
+
+   The explicit `View.Text`/`Int`/`Float`/`Bool` value primitives still work for
+   non-ppx code and for stronger typing; this is the ergonomic default under the
+   annotation. */
+let rec child = (value: 'a): node => {
+  if isNode(value) {
+    (Obj.magic(value): node)
+  } else {
+    /* Nullish first: `null` is itself an object, so it has to be ruled out
+       before the object branch. */
+    if RuntimeValue.isNullish(value) {
+      null()
+    } else if RuntimeValue.isFunction(value) {
+      let compute: unit => 'b = Obj.magic(value)
+      let signal = Computed.make(compute)
+      if isScalar(Signal.peek(signal)) {
+        /* scalar-first thunk: a reactive text node. ReScript typing keeps a
+           scalar thunk scalar, so locking text mode here is safe. */
+        SignalText(Computed.make(() => stringifyChild(Signal.get(signal))))
+      } else {
+        /* node-, array-, option- or otherwise object-first thunk: a tracked
+           fragment that re-coerces the result on *every* run, so thunks over
+           `option<node>` (None first, Some(node) later) and array-returning
+           thunks stay correct instead of being locked into text mode by
+           their first value. */
+        SignalFragment(Computed.make(() => [child(Obj.magic(Signal.get(signal)))]))
+      }
+    } else if RuntimeValue.isObject(value) {
+      if isSignal(value) {
+        let signal: Signal.t<'b> = Obj.magic(value)
+        SignalText(Computed.make(() => stringifyChild(Signal.get(signal))))
+      } else if isArray(value) {
+        let items: array<'b> = Obj.magic(value)
+        Fragment(items->Array.map(item => child(item)))
+      } else {
+        warnUnrenderable(value)
+        text(stringifyChild(value))
+      }
+    } else {
+      text(stringifyChild(value))
+    }
+  }
+}
+
+/* ============================================================================
+ * Hidden signal reads (@xote.component)
+ * ============================================================================ */
+
+/* The ppx detects signal reads *syntactically*. A read it cannot see the
+   definition of — an imported helper (`Store.waitingCount(store)`), a read
+   pulled out of a data structure — is compiled as a plain value: the leaf is
+   evaluated once and never updates, and no error or warning is produced. Inside
+   an enclosing `tracked` block the same read silently widens that block's
+   dependencies, so one broadcast re-renders the whole region.
+
+   `probe` is what `@xote.component` emits around a leaf whose expression
+   contains a call it could not resolve. The first time that leaf is evaluated
+   it runs inside a throwaway computed, and what that computed subscribed to
+   settles the question:
+
+     - nothing subscribed: the leaf really is static. The computed is disposed
+       and the value returned, so `probe` is exactly the identity function.
+     - something subscribed: the read was hidden from the ppx. The value is read
+       back *through* the computed, so an enclosing tracked block subscribes
+       exactly as it would have without the probe (behaviour is unchanged), and
+       a one-time warning naming the source location tells the developer to
+       thunk it.
+
+   The warning is only emitted for a *scalar* result — the shape that silently
+   renders a stale number or class name. A reactive result (a signal, a thunk, a
+   `MaybeSignal`) is already handled by the runtime, and a node-shaped result is
+   built fresh by whatever renders it. */
+
+/* Does this computed subscribe to any signal? Reads `subs.firstDep` on the
+   `rescript-signals` computed. If the internal shape is not recognised, report
+   `false`: no warning and no behaviour change is the safe direction. */
+let hasDependencies: 'a => bool = %raw(`function (c) {
+  var subs = c == null ? null : c.subs
+  if (subs === null || typeof subs !== "object" || !("firstDep" in subs)) { return false }
+  return subs.firstDep != null
+}`)
+
+let warnHiddenRead = (site: string): unit =>
+  Console.warn(
+    "[Xote] " ++
+    site ++
+    ": this value reads a signal through a call @xote.component cannot see " ++
+    "(a helper from another module, MaybeSignal.get, a read stored in a data structure), " ++
+    "so it compiled to a one-shot value that will never update — and inside a tracked " ++
+    "block it widens that block and re-renders it wholesale. Wrap it in a thunk " ++
+    "(`{() => ...}`) or inline the Signal.get. " ++
+    "See https://github.com/brnrdog/xote/blob/main/ppx/README.md#hidden-reads",
+  )
+
+/* Each site is probed once. The answer is a property of the source expression,
+   not of this render, so re-probing would only repeat the same finding — and
+   the leaked-read branch has to keep its computed alive to stay subscribed.
+   Every later evaluation of a probed leaf is therefore a plain call, and the
+   report is emitted once however often the component renders. */
+let probedSites: Dict.t<bool> = Dict.make()
+
+let probe = (site: string, compute: unit => 'a): 'a =>
+  if !isDevMode() || probedSites->Dict.get(site)->Option.isSome {
+    compute()
+  } else {
+    probedSites->Dict.set(site, true)
+    let signal = Computed.make(compute)
+    if hasDependencies(signal) {
+      if isScalar(Signal.peek(signal)) {
+        warnHiddenRead(site)
+      }
+      /* Read back through the computed so an enclosing tracked block captures
+         the same dependencies it would have captured without the probe. The
+         computed is deliberately not disposed: it is what carries them. */
+      Signal.get(signal)
+    } else {
+      let value = Signal.peek(signal)
+      Computed.dispose(signal)
+      value
+    }
+  }
 
 module Text = {
   type props<'value, 'children> = {

--- a/src/View.res
+++ b/src/View.res
@@ -806,6 +806,27 @@ let isNode: 'a => bool = %raw(`function (v) {
    at compile time; null/undefined render as empty. */
 let stringifyChild: 'a => string = %raw(`function (v) { return v == null ? "" : String(v) }`)
 
+/* Is this runtime value a rescript-signals signal/computed? Positive shape
+   check against `Signal.t` ({id: int, value, equals: fn, subs: object}) —
+   detecting by shape rather than assuming any non-node object is a signal
+   keeps records/dicts that land in `child` from reaching `Signal.get`. */
+let isSignal: 'a => bool = %raw(`function (v) {
+  return v !== null && typeof v === "object"
+    && typeof v.id === "number"
+    && typeof v.equals === "function"
+    && typeof v.subs === "object" && v.subs !== null
+    && "value" in v
+}`)
+
+let isArray: 'a => bool = %raw(`function (v) { return Array.isArray(v) }`)
+
+let warnUnrenderable: 'a => unit = %raw(`function (v) {
+  console.warn(
+    "[Xote] View.child: this value is not a node, signal, array, function or scalar and cannot be rendered; it was stringified. Build a node from it (View.text, JSX, ...) instead:",
+    v
+  )
+}`)
+
 /* Coerce an arbitrary JSX child into a node. This is what `@xote.component`
    emits for a *bare* child in element position — `<div>{Signal.get(count)}</div>`
    — so a value primitive (`<View.Int>`) is no longer required:
@@ -814,13 +835,24 @@ let stringifyChild: 'a => string = %raw(`function (v) { return v == null ? "" : 
      - a reactive thunk (what the ppx emits for an eager signal read) re-runs on
        change — a scalar result becomes reactive text, a node result a tracked
        fragment;
-     - a bare `Signal.t` becomes reactive text; a plain scalar, static text;
-     - null/undefined render nothing.
+     - a bare `Signal.t` (detected by shape) becomes reactive text; a plain
+       scalar, static text;
+     - an array is coerced element-wise into a `Fragment`;
+     - null/undefined render nothing;
+     - any other object cannot be rendered: it is stringified with a console
+       warning rather than treated as a signal.
+
+   A thunk whose first evaluation is a *scalar* locks into reactive-text mode
+   (safe: ReScript typing keeps scalar thunks scalar). Any other first value —
+   node, array, option<node>, null — gets a tracked fragment that re-coerces
+   the result on every run, so shape changes like `None -> Some(node)` render
+   correctly. The one unsupported shape change is scalar-first-then-node from
+   an untyped hand-written thunk.
 
    The explicit `View.Text`/`Int`/`Float`/`Bool` value primitives still work for
    non-ppx code and for stronger typing; this is the ergonomic default under the
    annotation. */
-let child = (value: 'a): node => {
+let rec child = (value: 'a): node => {
   if isNode(value) {
     (Obj.magic(value): node)
   } else {
@@ -828,15 +860,30 @@ let child = (value: 'a): node => {
     | Function(_) => {
         let compute: unit => 'b = Obj.magic(value)
         let signal = Computed.make(compute)
-        if isNode(Signal.peek(signal)) {
-          SignalFragment(Computed.make(() => [(Obj.magic(Signal.get(signal)): node)]))
-        } else {
+        switch Signal.peek(signal)->Core.Type.Classify.classify {
+        | String(_) | Number(_) | Bool(_) =>
+          /* scalar-first thunk: a reactive text node. ReScript typing keeps a
+             scalar thunk scalar, so locking text mode here is safe. */
           SignalText(Computed.make(() => stringifyChild(Signal.get(signal))))
+        | _ =>
+          /* node-, array-, option- or otherwise object-first thunk: a tracked
+             fragment that re-coerces the result on *every* run, so thunks over
+             `option<node>` (None first, Some(node) later) and array-returning
+             thunks stay correct instead of being locked into text mode by
+             their first value. */
+          SignalFragment(Computed.make(() => [child(Obj.magic(Signal.get(signal)))]))
         }
       }
-    | Object(_) => {
+    | Object(_) =>
+      if isSignal(value) {
         let signal: Signal.t<'b> = Obj.magic(value)
         SignalText(Computed.make(() => stringifyChild(Signal.get(signal))))
+      } else if isArray(value) {
+        let items: array<'b> = Obj.magic(value)
+        Fragment(items->Core.Array.map(item => child(item)))
+      } else {
+        warnUnrenderable(value)
+        text(stringifyChild(value))
       }
     | Null | Undefined => null()
     | _ => text(stringifyChild(value))

--- a/src/View.res
+++ b/src/View.res
@@ -781,6 +781,69 @@ let renderValuePrimitiveProps = (props: 'props, stringify: 'scalar => string): n
   }
 }
 
+/* Is this runtime value already a `node`? Nodes are ReScript variants compiled
+   to objects carrying a string `TAG` in the set below; Signals, Props, scalars
+   and functions are not, so a value already built into a node passes straight
+   through `child`. */
+let isNode: 'a => bool = %raw(`function (v) {
+  if (v === null || typeof v !== "object" || typeof v.TAG !== "string") { return false }
+  switch (v.TAG) {
+    case "Element":
+    case "Text":
+    case "SignalText":
+    case "Fragment":
+    case "SignalFragment":
+    case "Keyed":
+    case "LazyComponent":
+    case "KeyedList":
+      return true
+    default:
+      return false
+  }
+}`)
+
+/* Stringify any scalar child (int/float/string/bool) without knowing its type
+   at compile time; null/undefined render as empty. */
+let stringifyChild: 'a => string = %raw(`function (v) { return v == null ? "" : String(v) }`)
+
+/* Coerce an arbitrary JSX child into a node. This is what `@xote.component`
+   emits for a *bare* child in element position — `<div>{Signal.get(count)}</div>`
+   — so a value primitive (`<View.Int>`) is no longer required:
+
+     - an already-built node passes through untouched;
+     - a reactive thunk (what the ppx emits for an eager signal read) re-runs on
+       change — a scalar result becomes reactive text, a node result a tracked
+       fragment;
+     - a bare `Signal.t` becomes reactive text; a plain scalar, static text;
+     - null/undefined render nothing.
+
+   The explicit `View.Text`/`Int`/`Float`/`Bool` value primitives still work for
+   non-ppx code and for stronger typing; this is the ergonomic default under the
+   annotation. */
+let child = (value: 'a): node => {
+  if isNode(value) {
+    (Obj.magic(value): node)
+  } else {
+    switch value->Core.Type.Classify.classify {
+    | Function(_) => {
+        let compute: unit => 'b = Obj.magic(value)
+        let signal = Computed.make(compute)
+        if isNode(Signal.peek(signal)) {
+          SignalFragment(Computed.make(() => [(Obj.magic(Signal.get(signal)): node)]))
+        } else {
+          SignalText(Computed.make(() => stringifyChild(Signal.get(signal))))
+        }
+      }
+    | Object(_) => {
+        let signal: Signal.t<'b> = Obj.magic(value)
+        SignalText(Computed.make(() => stringifyChild(Signal.get(signal))))
+      }
+    | Null | Undefined => null()
+    | _ => text(stringifyChild(value))
+    }
+  }
+}
+
 module Text = {
   type props<'value, 'children> = {
     value?: 'value,

--- a/src/View.res
+++ b/src/View.res
@@ -596,6 +596,12 @@ let fragment = (children: array<node>): node => Fragment(children)
 
 let signalFragment = (signal: Signal.t<array<node>>): node => SignalFragment(signal)
 
+/* Auto-tracked reactive block: every signal read while `body` runs subscribes
+   the block, which re-evaluates `body` and replaces its children wholesale
+   (no diffing) whenever a dependency changes. Prefer `eachWithKey`/`For` for
+   lists and keep tracked blocks small. */
+let tracked = (body: unit => node): node => SignalFragment(Computed.make(() => [body()]))
+
 let childrenToArray = (child: option<node>): array<node> => {
   switch child {
   | Some(Fragment(children)) => children

--- a/src/View.res
+++ b/src/View.res
@@ -891,6 +891,113 @@ let rec child = (value: 'a): node => {
   }
 }
 
+/* ============================================================================
+ * Hidden signal reads (@xote.component)
+ * ============================================================================ */
+
+/* The ppx detects signal reads *syntactically*. A read it cannot see the
+   definition of — an imported helper (`Store.waitingCount(store)`), a read
+   pulled out of a data structure — is compiled as a plain value: the leaf is
+   evaluated once and never updates, and no error or warning is produced. Inside
+   an enclosing `tracked` block the same read silently widens that block's
+   dependencies, so one broadcast re-renders the whole region.
+
+   `probe` is what `@xote.component` emits around a leaf whose expression
+   contains a call it could not resolve. The first time that leaf is evaluated
+   it runs inside a throwaway computed, and what that computed subscribed to
+   settles the question:
+
+     - nothing subscribed: the leaf really is static. The computed is disposed
+       and the value returned, so `probe` is exactly the identity function.
+     - something subscribed: the read was hidden from the ppx. The value is read
+       back *through* the computed, so an enclosing tracked block subscribes
+       exactly as it would have without the probe (behaviour is unchanged), and
+       a one-time warning naming the source location tells the developer to
+       thunk it.
+
+   The warning is only emitted for a *scalar* result — the shape that silently
+   renders a stale number or class name. A reactive result (a signal, a thunk, a
+   `MaybeSignal`) is already handled by the runtime, and a node-shaped result is
+   built fresh by whatever renders it. */
+
+/* Does this computed subscribe to any signal? Reads `subs.firstDep` on the
+   `rescript-signals` computed. If the internal shape is not recognised, report
+   `false`: no warning and no behaviour change is the safe direction. */
+let hasDependencies: 'a => bool = %raw(`function (c) {
+  var subs = c == null ? null : c.subs
+  if (subs === null || typeof subs !== "object" || !("firstDep" in subs)) { return false }
+  return subs.firstDep != null
+}`)
+
+/* Probing costs one throwaway computed per unresolved leaf, so it is skipped in
+   production builds. `globalThis.__XOTE_DEV__` wins when set; otherwise
+   `process.env.NODE_ENV` (which bundlers inline) decides. When neither is
+   available the probe stays on: a silently stale UI is worse than an allocation. */
+let readDevFlag: unit => bool = %raw(`function () {
+  try {
+    if (typeof globalThis !== "undefined" && globalThis.__XOTE_DEV__ !== undefined) {
+      return !!globalThis.__XOTE_DEV__
+    }
+    if (typeof process !== "undefined" && process.env && process.env.NODE_ENV) {
+      return process.env.NODE_ENV !== "production"
+    }
+  } catch (_) {}
+  return true
+}`)
+
+let probeEnabled: ref<option<bool>> = ref(None)
+
+let isProbeEnabled = (): bool =>
+  switch probeEnabled.contents {
+  | Some(enabled) => enabled
+  | None => {
+      let enabled = readDevFlag()
+      probeEnabled := Some(enabled)
+      enabled
+    }
+  }
+
+let warnHiddenRead = (site: string): unit =>
+  Console.warn(
+    "[Xote] " ++
+    site ++
+    ": this value reads a signal through a call @xote.component cannot see " ++
+    "(a helper from another module, MaybeSignal.get, a read stored in a data structure), " ++
+    "so it compiled to a one-shot value that will never update — and inside a tracked " ++
+    "block it widens that block and re-renders it wholesale. Wrap it in a thunk " ++
+    "(`{() => ...}`) or inline the Signal.get. " ++
+    "See https://github.com/brnrdog/xote/blob/main/ppx/README.md#hidden-reads",
+  )
+
+/* Each site is probed once. The answer is a property of the source expression,
+   not of this render, so re-probing would only repeat the same finding — and
+   the leaked-read branch has to keep its computed alive to stay subscribed.
+   Every later evaluation of a probed leaf is therefore a plain call, and the
+   report is emitted once however often the component renders. */
+let probedSites: Dict.t<bool> = Dict.make()
+
+let probe = (site: string, compute: unit => 'a): 'a =>
+  if !isProbeEnabled() || probedSites->Dict.get(site)->Option.isSome {
+    compute()
+  } else {
+    probedSites->Dict.set(site, true)
+    let signal = Computed.make(compute)
+    if hasDependencies(signal) {
+      switch Signal.peek(signal)->Core.Type.Classify.classify {
+      | String(_) | Number(_) | Bool(_) => warnHiddenRead(site)
+      | _ => ()
+      }
+      /* Read back through the computed so an enclosing tracked block captures
+         the same dependencies it would have captured without the probe. The
+         computed is deliberately not disposed: it is what carries them. */
+      Signal.get(signal)
+    } else {
+      let value = Signal.peek(signal)
+      Computed.dispose(signal)
+      value
+    }
+  }
+
 module Text = {
   type props<'value, 'children> = {
     value?: 'value,

--- a/tests/Component_test.res
+++ b/tests/Component_test.res
@@ -124,6 +124,41 @@ let suite = Zekr.suite(
       let r2 = Dom.Assert.toHaveTextContent(container, "replaced")
       combineResults([r1, r2])
     }),
+    test("tracked block re-renders when a signal read inside changes", () => {
+      let {container} = Dom.render("")
+      let count = Signal.make(0)
+      let _ = mountTo(
+        View.tracked(() =>
+          Html.p(~children=[View.text("Count: " ++ Signal.get(count)->Int.toString)], ())
+        ),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "Count: 0")
+      Signal.set(count, 5)
+      let r2 = Dom.Assert.toHaveTextContent(container, "Count: 5")
+      combineResults([r1, r2])
+    }),
+    test("tracked block re-discovers conditional signal reads", () => {
+      let {container} = Dom.render("")
+      let show = Signal.make(false)
+      let name = Signal.make("Ada")
+      let _ = mountTo(
+        View.tracked(() =>
+          if Signal.get(show) {
+            View.text("Hello, " ++ Signal.get(name))
+          } else {
+            View.text("hidden")
+          }
+        ),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "hidden")
+      Signal.set(show, true)
+      let r2 = Dom.Assert.toHaveTextContent(container, "Hello, Ada")
+      Signal.set(name, "Grace")
+      let r3 = Dom.Assert.toHaveTextContent(container, "Hello, Grace")
+      combineResults([r1, r2, r3])
+    }),
     test("null node renders empty content", () => {
       let {container} = Dom.render("")
       let _ = mountTo(Html.div(~children=[View.null(), View.text("visible")], ()), container)

--- a/tests/Component_test.res
+++ b/tests/Component_test.res
@@ -159,6 +159,114 @@ let suite = Zekr.suite(
       let r3 = Dom.Assert.toHaveTextContent(container, "Hello, Grace")
       combineResults([r1, r2, r3])
     }),
+    test("child coerces a static scalar to static text", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        Html.div(~children=[View.child("Count: "), View.child(42)], ()),
+        container,
+      )
+      Dom.Assert.toHaveTextContent(container, "Count: 42")
+    }),
+    test("child passes an already-built node through untouched", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(View.child(View.text("already a node")), container)
+      Dom.Assert.toHaveTextContent(container, "already a node")
+    }),
+    test("child renders null and undefined as nothing", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        Html.div(
+          ~children=[View.child(%raw(`null`)), View.text("visible"), View.child(%raw(`undefined`))],
+          (),
+        ),
+        container,
+      )
+      Dom.Assert.toHaveTextContent(container, "visible")
+    }),
+    test("child turns a raw signal into reactive text", () => {
+      let {container} = Dom.render("")
+      let count = Signal.make(1)
+      let _ = mountTo(View.child(count), container)
+      let r1 = Dom.Assert.toHaveTextContent(container, "1")
+      Signal.set(count, 2)
+      let r2 = Dom.Assert.toHaveTextContent(container, "2")
+      combineResults([r1, r2])
+    }),
+    test("child turns an eager-read thunk into reactive text", () => {
+      let {container} = Dom.render("")
+      let count = Signal.make(10)
+      let _ = mountTo(View.child(() => Signal.get(count)), container)
+      let r1 = Dom.Assert.toHaveTextContent(container, "10")
+      Signal.set(count, 11)
+      let r2 = Dom.Assert.toHaveTextContent(container, "11")
+      combineResults([r1, r2])
+    }),
+    test("child turns a node-returning thunk into a tracked fragment", () => {
+      let {container} = Dom.render("")
+      let count = Signal.make(0)
+      let _ = mountTo(
+        View.child(() =>
+          Html.p(~children=[View.text("n=" ++ Signal.get(count)->Int.toString)], ())
+        ),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "n=0")
+      Signal.set(count, 7)
+      let r2 = Dom.Assert.toHaveTextContent(container, "n=7")
+      combineResults([r1, r2])
+    }),
+    test("child thunk over option<node> survives None -> Some(node)", () => {
+      let {container} = Dom.render("")
+      let show = Signal.make(false)
+      let _ = mountTo(
+        Html.div(
+          ~children=[
+            View.child(() =>
+              Signal.get(show) ? Some(Html.p(~children=[View.text("shown")], ())) : None
+            ),
+            View.text("|end"),
+          ],
+          (),
+        ),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "|end")
+      Signal.set(show, true)
+      let r2 = Dom.Assert.toHaveTextContent(container, "shown|end")
+      Signal.set(show, false)
+      let r3 = Dom.Assert.toHaveTextContent(container, "|end")
+      combineResults([r1, r2, r3])
+    }),
+    test("child thunk returning an array of nodes renders and updates", () => {
+      let {container} = Dom.render("")
+      let items = Signal.make(["a", "b"])
+      let _ = mountTo(
+        View.child(() => Signal.get(items)->Array.map(item => View.text(item))),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "ab")
+      Signal.set(items, ["a", "b", "c"])
+      let r2 = Dom.Assert.toHaveTextContent(container, "abc")
+      combineResults([r1, r2])
+    }),
+    test("child coerces an array element-wise into a fragment", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        Html.div(
+          ~children=[View.child([View.text("a"), View.text("b")]), View.child([1, 2, 3])],
+          (),
+        ),
+        container,
+      )
+      Dom.Assert.toHaveTextContent(container, "ab123")
+    }),
+    test("child does not treat a plain record as a signal", () => {
+      let {container} = Dom.render("")
+      /* a non-node, non-signal object: must not reach Signal.get — it renders
+         stringified (with a console warning) instead of crashing */
+      let _ = mountTo(View.child({"label": "x"}), container)
+      Dom.Assert.toHaveTextContent(container, "[object Object]")
+    }),
     test("null node renders empty content", () => {
       let {container} = Dom.render("")
       let _ = mountTo(Html.div(~children=[View.null(), View.text("visible")], ()), container)

--- a/tests/Component_test.res
+++ b/tests/Component_test.res
@@ -124,6 +124,149 @@ let suite = Zekr.suite(
       let r2 = Dom.Assert.toHaveTextContent(container, "replaced")
       combineResults([r1, r2])
     }),
+    test("tracked block re-renders when a signal read inside changes", () => {
+      let {container} = Dom.render("")
+      let count = Signal.make(0)
+      let _ = mountTo(
+        View.tracked(() =>
+          Html.p(~children=[View.text("Count: " ++ Signal.get(count)->Int.toString)], ())
+        ),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "Count: 0")
+      Signal.set(count, 5)
+      let r2 = Dom.Assert.toHaveTextContent(container, "Count: 5")
+      combineResults([r1, r2])
+    }),
+    test("tracked block re-discovers conditional signal reads", () => {
+      let {container} = Dom.render("")
+      let show = Signal.make(false)
+      let name = Signal.make("Ada")
+      let _ = mountTo(
+        View.tracked(() =>
+          if Signal.get(show) {
+            View.text("Hello, " ++ Signal.get(name))
+          } else {
+            View.text("hidden")
+          }
+        ),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "hidden")
+      Signal.set(show, true)
+      let r2 = Dom.Assert.toHaveTextContent(container, "Hello, Ada")
+      Signal.set(name, "Grace")
+      let r3 = Dom.Assert.toHaveTextContent(container, "Hello, Grace")
+      combineResults([r1, r2, r3])
+    }),
+    test("child coerces a static scalar to static text", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        Html.div(~children=[View.child("Count: "), View.child(42)], ()),
+        container,
+      )
+      Dom.Assert.toHaveTextContent(container, "Count: 42")
+    }),
+    test("child passes an already-built node through untouched", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(View.child(View.text("already a node")), container)
+      Dom.Assert.toHaveTextContent(container, "already a node")
+    }),
+    test("child renders null and undefined as nothing", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        Html.div(
+          ~children=[View.child(%raw(`null`)), View.text("visible"), View.child(%raw(`undefined`))],
+          (),
+        ),
+        container,
+      )
+      Dom.Assert.toHaveTextContent(container, "visible")
+    }),
+    test("child turns a raw signal into reactive text", () => {
+      let {container} = Dom.render("")
+      let count = Signal.make(1)
+      let _ = mountTo(View.child(count), container)
+      let r1 = Dom.Assert.toHaveTextContent(container, "1")
+      Signal.set(count, 2)
+      let r2 = Dom.Assert.toHaveTextContent(container, "2")
+      combineResults([r1, r2])
+    }),
+    test("child turns an eager-read thunk into reactive text", () => {
+      let {container} = Dom.render("")
+      let count = Signal.make(10)
+      let _ = mountTo(View.child(() => Signal.get(count)), container)
+      let r1 = Dom.Assert.toHaveTextContent(container, "10")
+      Signal.set(count, 11)
+      let r2 = Dom.Assert.toHaveTextContent(container, "11")
+      combineResults([r1, r2])
+    }),
+    test("child turns a node-returning thunk into a tracked fragment", () => {
+      let {container} = Dom.render("")
+      let count = Signal.make(0)
+      let _ = mountTo(
+        View.child(() =>
+          Html.p(~children=[View.text("n=" ++ Signal.get(count)->Int.toString)], ())
+        ),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "n=0")
+      Signal.set(count, 7)
+      let r2 = Dom.Assert.toHaveTextContent(container, "n=7")
+      combineResults([r1, r2])
+    }),
+    test("child thunk over option<node> survives None -> Some(node)", () => {
+      let {container} = Dom.render("")
+      let show = Signal.make(false)
+      let _ = mountTo(
+        Html.div(
+          ~children=[
+            View.child(() =>
+              Signal.get(show) ? Some(Html.p(~children=[View.text("shown")], ())) : None
+            ),
+            View.text("|end"),
+          ],
+          (),
+        ),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "|end")
+      Signal.set(show, true)
+      let r2 = Dom.Assert.toHaveTextContent(container, "shown|end")
+      Signal.set(show, false)
+      let r3 = Dom.Assert.toHaveTextContent(container, "|end")
+      combineResults([r1, r2, r3])
+    }),
+    test("child thunk returning an array of nodes renders and updates", () => {
+      let {container} = Dom.render("")
+      let items = Signal.make(["a", "b"])
+      let _ = mountTo(
+        View.child(() => Signal.get(items)->Array.map(item => View.text(item))),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "ab")
+      Signal.set(items, ["a", "b", "c"])
+      let r2 = Dom.Assert.toHaveTextContent(container, "abc")
+      combineResults([r1, r2])
+    }),
+    test("child coerces an array element-wise into a fragment", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        Html.div(
+          ~children=[View.child([View.text("a"), View.text("b")]), View.child([1, 2, 3])],
+          (),
+        ),
+        container,
+      )
+      Dom.Assert.toHaveTextContent(container, "ab123")
+    }),
+    test("child does not treat a plain record as a signal", () => {
+      let {container} = Dom.render("")
+      /* a non-node, non-signal object: must not reach Signal.get — it renders
+         stringified (with a console warning) instead of crashing */
+      let _ = mountTo(View.child({"label": "x"}), container)
+      Dom.Assert.toHaveTextContent(container, "[object Object]")
+    }),
     test("null node renders empty content", () => {
       let {container} = Dom.render("")
       let _ = mountTo(Html.div(~children=[View.null(), View.text("visible")], ()), container)

--- a/tests/DevMode_test.mjs
+++ b/tests/DevMode_test.mjs
@@ -1,0 +1,42 @@
+/* The development-only diagnostics in View — the hidden-read probe and the
+ * unrenderable-child warning — are gated on a flag that is read once and cached
+ * for the process. That cache is why this lives in its own file rather than in
+ * the main suite: `Tests.res.mjs` exercises both diagnostics, so by the time it
+ * finishes the flag is already resolved to "development" and the production
+ * path can no longer be observed in that process.
+ *
+ * Run with __XOTE_DEV__ = false and assert the quiet path: no console output,
+ * and — the part that actually matters — the same rendered node either way. A
+ * gate that silenced the warning by also changing what renders would be a much
+ * worse bug than the noise it was meant to remove. */
+import assert from "node:assert/strict";
+
+globalThis.__XOTE_DEV__ = false;
+
+const View = await import("../src/View.res.mjs");
+const Signal = await import("../src/Signal.res.mjs");
+
+const warnings = [];
+const realWarn = console.warn;
+console.warn = (...args) => warnings.push(args.join(" "));
+
+/* Unrenderable child: a record is neither node, signal, array, thunk nor
+   scalar, so it is stringified. In production that happens silently. */
+const unrenderable = View.child({ name: "Ada" });
+
+/* Hidden read: a call the ppx could not resolve that does read a signal. In
+   development View.probe reports it; in production it must not even allocate
+   the throwaway computed used to detect it. */
+const hidden = Signal.make("tone-a");
+const probed = View.probe("DevMode_test.mjs:0:0", () => Signal.get(hidden));
+
+console.warn = realWarn;
+
+assert.deepEqual(warnings, [], `expected no console output in production, got:\n${warnings.join("\n")}`);
+
+/* Behaviour is identical to development — only the diagnostics are gone. */
+assert.equal(unrenderable.TAG, "Text");
+assert.equal(unrenderable._0, "[object Object]");
+assert.equal(probed, "tone-a");
+
+console.log("dev-mode gating tests passed");

--- a/tests/Probe_test.res
+++ b/tests/Probe_test.res
@@ -1,0 +1,93 @@
+open! Zekr
+
+/* `View.probe` is what `@xote.component` emits around a leaf whose expression
+   contains a call the ppx cannot resolve. It has to be invisible when the leaf
+   really is static, and report the leaf — once — when the call turns out to
+   read a signal behind the ppx's back. */
+
+let mountTo = (node, container) => {
+  View.mount(node, container)
+  container
+}
+
+let captureWarnings: unit => unit = %raw(`function () {
+  globalThis.__probeWarnings = []
+  globalThis.__probeRealWarn = console.warn
+  console.warn = function (message) { globalThis.__probeWarnings.push(String(message)) }
+}`)
+
+let releaseWarnings: unit => array<string> = %raw(`function () {
+  console.warn = globalThis.__probeRealWarn
+  return globalThis.__probeWarnings
+}`)
+
+let mentions = (messages: array<string>, site: string) =>
+  messages->Array.some(message => message->String.includes(site))
+
+let suite = Zekr.suite(
+  "Probe",
+  [
+    test("returns the value untouched when nothing is read", () => {
+      captureWarnings()
+      let value = View.probe("Quiet.res:1:1", () => "static")
+      let warnings = releaseWarnings()
+      combineResults([assertEqual(value, "static"), assertEqual(Array.length(warnings), 0)])
+    }),
+    test("reports a scalar leaf that reads a signal through an opaque call", () => {
+      let count = Signal.make(4)
+      /* stands in for an imported helper: the ppx sees only the call */
+      let hidden = () => Signal.get(count)
+      captureWarnings()
+      let value = View.probe("Hidden.res:12:9", () => hidden())
+      let warnings = releaseWarnings()
+      combineResults([
+        assertEqual(value, 4),
+        assertTrue(mentions(warnings, "Hidden.res:12:9")),
+        assertTrue(mentions(warnings, "() => ...")),
+      ])
+    }),
+    test("reports each site once, however often it is evaluated", () => {
+      let count = Signal.make(1)
+      let hidden = () => Signal.get(count)
+      captureWarnings()
+      let _ = View.probe("Repeat.res:3:3", () => hidden())
+      let _ = View.probe("Repeat.res:3:3", () => hidden())
+      let _ = View.probe("Repeat.res:3:3", () => hidden())
+      let warnings = releaseWarnings()
+      assertEqual(
+        warnings->Array.filter(w => w->String.includes("Repeat.res:3:3"))->Array.length,
+        1,
+      )
+    }),
+    test("stays silent for a deliberate untracked peek", () => {
+      let count = Signal.make(7)
+      let peeked = () => Signal.peek(count)
+      captureWarnings()
+      let value = View.probe("Peek.res:5:5", () => peeked())
+      let warnings = releaseWarnings()
+      combineResults([assertEqual(value, 7), assertEqual(Array.length(warnings), 0)])
+    }),
+    test("stays silent for a value that is reactive on its own", () => {
+      let count = Signal.make(2)
+      captureWarnings()
+      let value = View.probe("Reactive.res:7:7", () => Computed.make(() => Signal.get(count) * 2))
+      let warnings = releaseWarnings()
+      combineResults([assertEqual(Signal.get(value), 4), assertEqual(Array.length(warnings), 0)])
+    }),
+    test("an enclosing tracked block still subscribes through the probe", () => {
+      let {container} = Dom.render("")
+      let label = Signal.make("a")
+      let hidden = () => Signal.get(label)
+      captureWarnings()
+      let _ = mountTo(
+        View.tracked(() => View.text(View.probe("Tracked.res:9:9", () => hidden()))),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "a")
+      Signal.set(label, "b")
+      let r2 = Dom.Assert.toHaveTextContent(container, "b")
+      let warnings = releaseWarnings()
+      combineResults([r1, r2, assertTrue(mentions(warnings, "Tracked.res:9:9"))])
+    }),
+  ],
+)

--- a/tests/SSR_test.res
+++ b/tests/SSR_test.res
@@ -57,6 +57,17 @@ let suite = Zekr.suite(
         assertContains(html, "<!--/#-->"),
       ])
     }),
+    test("wraps tracked block with fragment hydration markers", () => {
+      let html = SSR.renderToString(() => {
+        let sig = Signal.make("tracked content")
+        View.tracked(() => Html.p(~children=[View.text(Signal.get(sig))], ()))
+      })
+      combineResults([
+        assertContains(html, "<!--#-->"),
+        assertContains(html, "tracked content"),
+        assertContains(html, "<!--/#-->"),
+      ])
+    }),
     test("wraps keyed list items with key markers", () => {
       let html = SSR.renderToString(() => {
         let items = Signal.make(["a", "b"])

--- a/tests/Tests.res
+++ b/tests/Tests.res
@@ -9,6 +9,7 @@ Zekr.runSuites([
   KeyedList_test.suite,
   Route_test.suite,
   PublicApi_test.suite,
+  Probe_test.suite,
   SSR_test.suite,
   SSRState_test.suite,
   Hydration_test.suite,


### PR DESCRIPTION
## Summary

Two complementary layers for auto-tracking in Xote's view layer:

- **`View.tracked(() => …)`** — runtime block; every signal read inside auto-subscribes it. Lowers to `SignalFragment` + `Computed` (SSR/hydration unchanged). Replaces children wholesale on change, so it suits small blocks. It is also the PPX's lowering target for structural swaps, and the option for projects that use no PPX at all.
- **Native PPX (`ppx/`)** — a single `@xote.component` annotation that replaces `@jsx.component` (so props still derive) **and** decomposes the returned JSX into **fine-grained leaves** at compile time, removing the wholesale-replacement tradeoff. Reactive attributes and text become their own `computedAttr` / reactive-text leaves; `View.tracked` is emitted only around `if`/`switch` structural swaps. Enclosing elements keep DOM identity across updates.

Design write-up: `docs/proposals/tracked-blocks.md`. Adoption and distribution decision: #141.

**Dependencies:** none new. Both layers build on the `Signal`/`Computed` primitives in the current `rescript-signals`. Inspired by [rescript-signals#34](https://github.com/brnrdog/rescript-signals/pull/34) and sharing that PPX's vendored-AST plumbing as a starting point, but independent of it: nothing here imports its additions, so it compiles against today's release.

## Before / after

`@xote.component` replaces `@jsx.component` and makes the return fine-grained in one attribute. Props (`label`) stay static, signal reads become reactive leaves, and no `() => …` thunks or `signalText` are needed:

```rescript
// before
@jsx.component
let make = (~label: string) => {
  let count = Signal.make(0)
  <div class={() => Signal.get(count) > 0 ? "on" : "off"}>
    <View.Text> {label} </View.Text>
    <View.Int> {count} </View.Int>
  </div>
}

// after
@xote.component
let make = (~label: string) => {
  let count = Signal.make(0)
  <div class={Signal.get(count) > 0 ? "on" : "off"}>
    {label}
    {Signal.get(count)}
  </div>
}
```

**Bare `{…}` children need no value primitive.** A string, a number, a signal read, or an already-built node can sit directly in element position: the annotation wraps each in the runtime helper `View.child`, which coerces it (an eager signal read becomes a reactive text leaf, a static scalar becomes static text, a node passes through, `null`/`undefined` render nothing). Dropping the `<View.Text>` / `<View.Int>` wrappers is the point of the annotation, not just the removal of thunks.

The explicit primitives remain available and are what non-PPX code uses, or what you reach for when you want the stronger `int`/`float` typing on the child. Keyed lists still use `View.For` with `by`.

Control flow with a reactive leaf in a branch: the `switch` is inline, and the branch's `class` stays its own leaf, so changing `theme` updates just the class without re-running the switch:

```rescript
@xote.component
let make = () =>
  <div>
    {switch Signal.get(status) {
    | Loading => <span> {"Loading…"} </span>
    | Ready(_) => <strong class={Signal.get(theme)}> {Signal.get(label)} </strong>
    }}
  </div>
```

## PPX details

- **Single annotation**: `@xote.component` on a `let` binding. The PPX rewrites it to `@jsx.component` (so ReScript's built-in JSX transform still derives the props record) and fine-grains the returned JSX. It inherits `@jsx.component`'s **one-component-per-module** rule.
- **Only eager reads are thunked.** A signal read deferred inside a lambda — an existing `() => …` thunk, a `Computed`, or a `Prop.reactive(Computed.make(() => …))` — is already reactive and is left untouched, so `@xote.component` is a safe drop-in on components already written with explicit thunks.
- **Alias-aware detection**: `let g = Signal.get`, `module S = Signal`, `open Signal`, `sig->Signal.get`, and local reactive helpers; the untracked `Signal.peek` is excluded.
- **Control flow tracks only the condition** (including `when` guards), so branch leaves stay independently reactive. A condition that reads no signal gets no `View.tracked`, but its branches are still decomposed.
- **Node position is followed wherever it appears**: children, props whose value is JSX, render callbacks (`View.For`'s `render={row => …}`), block expressions, and constrained or functor modules.
- Runs before the JSX transform; vendors the OCaml 4.06 parsetree (LGPL-2.1 notice shipped in `ppx/LICENSE.OCaml`). An AST magic mismatch fails the build with a message naming both magics rather than passing the AST through.

## Distribution (see #141)

The npm package ships the PPX **prebuilt** for linux-x64, linux-arm64, darwin-x64, darwin-arm64 and win32-x64 under `ppx/bin/`. `ppx/postinstall.js` selects the binary for the current platform at install time, so enabling the annotation is one line in the consumer's own `rescript.json`:

```json
{ "ppx-flags": ["xote/ppx/ppx"] }
```

No OCaml toolchain is required. The install script probes for musl on Linux, runs the installed binary once to confirm it executes, falls back to compiling the bundled `ppx.ml` when `ocamlopt` is available, and never fails a consumer's install.

Xote's own published `rescript.json` carries no `ppx-flags`: `src/` has no annotations, so a flag there would make every consumer build depend on the binary for no benefit. The annotation applies to the consumer's components, so the flag belongs in the consumer's config, the same way the `jsx` configuration is already mirrored.

The guard chain runs from compile to publish: a per-platform smoke test on each native runner, artifact download, on-disk verification, an assertion on the `npm pack --dry-run` file list, a `prepublishOnly` gate, and the release job executing the binary it ships.

## Integration and tests

- **112 library tests** and a **112-assertion PPX end-to-end suite**, both green. The e2e suite tags DOM elements and mutates signals to assert elements keep identity, which is what proves updates are fine-grained rather than wholesale.
- CI compiles and end-to-end-tests the PPX on Linux on every push. The five-platform binary matrix runs at release, on changes to `ppx/**` or its workflow, and weekly as a drift canary.
- **`@xote.component` is the default across the docs site**: the JSX configuration page, every demo (Counter, ComputedOrder, EffectAutosave, TodoList, Tutorial), the code examples, and the example-panel component itself, verified through the full client, SSR and prerender build.

## Fixed during beta testing

Consumer testing against the betas found three defects, all fixed here or tracked:

- Control flow on a **non-reactive condition** left its branches undecomposed, so a bare child inside `{if isActive { <b> {"yes"} </b> } else { … }}` failed to compile.
- **Render callbacks** were never entered, so bare children inside `View.For`'s `render={row => …}` failed to compile and leaves inside stayed static.
- `Computed.make` leaked `Signals.Signal.t` into the public API (#146), making computeds unusable for consumers declaring only `["xote"]`. Fixed separately in #147, since it is a runtime bug unrelated to the PPX.

Both PPX defects shared a root cause: an expression that ends up in node position was not reached by the traversal.

## Limitations (see `ppx/README.md`)

One component per module (inherited from `@jsx.component`); syntactic signal detection (alias- and local-helper-aware, but not through imported helpers or data structures, where the value compiles as static and the escape hatch is to write `() =>` yourself); explicit value-component detection is limited to the qualified `View.Text/Int/Float/Bool`, though bare children make the wrappers unnecessary; a branch swap rebuilds that branch, with no keyed diff between branches, the same as `View.Show`.