### PR TITLE
fix(computed): stop leaking the Signals namespace into the public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Run tests
         run: node tests/Tests.res.mjs
 
+      # Compiles a fixture whose rescript.json declares only ["xote"], as the
+      # README tells consumers to. Catches public signatures that leak a type
+      # owned by a transitive dependency; the other in-repo consumers declare
+      # rescript-signals and so cannot catch it.
+      - name: Consumer surface check
+        run: npm run test:consumer
+
       - name: Vite Build
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ bundle-size-report.md
 bundle-size-*.json
 .vite
 
+# Consumer surface fixture (linked toolchain + build output)
+/tests/consumer/node_modules/
+/tests/consumer/lib/
+
 # Documentation site
 /docs-website/node_modules/
 /docs-website/build/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Then, add it to your ReScript project's `rescript.json`. You'll need to declare 
 
 The compiler flag `-open Xote` is optional, it makes the Xote modules available unqualified inside your source files.
 
+`xote` is the only dependency you need to declare. Xote's reactive primitives come from [rescript-signals](https://github.com/brnrdog/rescript-signals), but `Signal`, `Computed`, and `Effect` are re-exported under `Xote`, so declare `rescript-signals` yourself only if you want to use it directly.
+
 This README uses the application-facing names for public code:
 
 - `View` is the module for building and mounting DOM nodes.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "docs:start": "cd docs-website && npm run dev",
     "docs:build": "cd docs-website && npm run build",
     "docs:serve": "cd docs-website && npm run preview",
-    "test": "npx rescript && node tests/Tests.res.mjs && node tests/JSXRuntime_test.mjs"
+    "test": "npx rescript && node tests/Tests.res.mjs && node tests/JSXRuntime_test.mjs",
+    "test:consumer": "sh tests/consumer/setup.sh && cd tests/consumer && npx rescript build"
   },
   "keywords": [
     "rescript",

--- a/src/Computed.res
+++ b/src/Computed.res
@@ -1,1 +1,27 @@
-include Signals.Computed
+/* Shim over `Signals.Computed`.
+
+   The signatures are written out rather than `include`d. An `include` rewrites
+   paths that point at the included module itself, but not paths that point at
+   *other* modules: `Signals.Computed.make` returns `Signals.Signal.t`, and that
+   path would survive into Xote's public API. Consumers who do not declare
+   rescript-signals in their own `rescript.json` cannot resolve it, so every
+   computed became unusable — `Signal.get(computed)` failed with
+   `Signals.Signal.t` versus `Xote.Signal.t`. Naming Xote's own `Signal.t` here
+   keeps rescript-signals an implementation detail. */
+
+let make = (
+  compute: unit => 'a,
+  ~name: option<string>=?,
+  ~equals: option<('a, 'a) => bool>=?,
+): Signal.t<'a> => Signals.Computed.make(compute, ~name?, ~equals?)
+
+let makeWithoutEquals = (compute: unit => 'a, ~name: option<string>=?): Signal.t<'a> =>
+  Signals.Computed.makeWithoutEquals(compute, ~name?)
+
+let makeWithEquals = (
+  compute: unit => 'a,
+  equalsFn: ('a, 'a) => bool,
+  ~name: option<string>=?,
+): Signal.t<'a> => Signals.Computed.makeWithEquals(compute, equalsFn, ~name?)
+
+let dispose = (signal: Signal.t<'a>): unit => Signals.Computed.dispose(signal)

--- a/tests/consumer/rescript.json
+++ b/tests/consumer/rescript.json
@@ -1,0 +1,9 @@
+{
+  "name": "xote-consumer-surface",
+  "sources": [{ "dir": "src", "subdirs": false }],
+  "package-specs": { "module": "esmodule", "in-source": true },
+  "suffix": ".res.mjs",
+  "dependencies": ["xote"],
+  "jsx": { "version": 4, "module": "XoteJSX" },
+  "compiler-flags": ["-open Xote"]
+}

--- a/tests/consumer/setup.sh
+++ b/tests/consumer/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Links the toolchain and the repo itself into this fixture so `rescript build`
+# resolves `xote` the way an installed consumer would. Idempotent.
+#
+# The point of the fixture is its rescript.json: it declares only `["xote"]`,
+# as the README tells consumers to. rescript-signals is deliberately NOT linked
+# as a declared dependency, so any public signature that leaks a type owned by
+# it fails to compile here.
+set -e
+cd "$(dirname "$0")"
+root=../..
+
+mkdir -p node_modules node_modules/@rescript
+
+ln -sfn ../$root                          node_modules/xote
+ln -sfn ../$root/node_modules/rescript     node_modules/rescript
+ln -sfn ../../$root/node_modules/@rescript/core node_modules/@rescript/core
+
+echo "tests/consumer linked. Now: npx rescript build"

--- a/tests/consumer/src/Surface.res
+++ b/tests/consumer/src/Surface.res
@@ -1,0 +1,89 @@
+/* Type-level surface check, compiled as a real consumer would compile it.
+
+   This file only needs to *type-check*; it is never executed. What it guards is
+   the dependency boundary: this project declares `["xote"]` and nothing else,
+   exactly as the README and the docs site tell consumers to. If a public
+   signature mentions a type owned by a transitive dependency (rescript-signals'
+   `Signals` namespace), that path is unresolvable here and the build fails.
+
+   The in-repo consumers (docs-website, ppx/example) all declare
+   rescript-signals, so they cannot catch that class of leak. This one can.
+
+   Keep this to the public API only, and prefer breadth over depth: one line per
+   primitive is enough, since the failure being guarded is in the signatures. */
+
+let count = Signal.make(0)
+
+/* Computed: the value must be usable everywhere a signal is accepted. Passing
+   it to Signal.get is what regressed — Computed.make returned a type named
+   through rescript-signals' namespace, which a consumer cannot resolve. */
+let doubled = Computed.make(() => Signal.get(count) * 2)
+let doubledNow: int = Signal.get(doubled)
+let doubledPeeked: int = Signal.peek(doubled)
+
+let named = Computed.make(() => Signal.get(count) + 1, ~name="named")
+let withEquals = Computed.make(() => Signal.get(count), ~equals=(a, b) => a === b)
+
+/* Signal */
+Signal.set(count, 1)
+Signal.update(count, n => n + 1)
+let batched: int = Signal.batch(() => Signal.peek(count))
+let untracked: int = Signal.untrack(() => Signal.get(count))
+
+/* Effect */
+Effect.run(() => {
+  let _ = Signal.get(count)
+  None
+})
+let disposer = Effect.runWithDisposer(() => None)
+disposer.dispose()
+
+/* Prop: static and reactive, the latter built from both a signal and a computed */
+let staticProp: Prop.t<int> = Prop.static(1)
+let signalProp: Prop.t<int> = Prop.signal(count)
+let computedProp: Prop.t<int> = Prop.signal(doubled)
+let propValue: int = Prop.get(computedProp)
+
+/* View nodes and attributes driven by a computed */
+let textNode = View.signalText(() => Signal.get(doubled)->Int.toString)
+let intNode = View.signalInt(() => Signal.get(doubled))
+let attribute = View.computedAttr("class", () => Signal.get(doubled) > 0 ? "on" : "off")
+let element = View.element("div", ~attrs=[attribute], ~children=[textNode, intNode], ())
+
+/* JSX: a computed flowing through the components that take Prop.t */
+let items = Signal.make([1, 2, 3])
+let evens = Computed.make(() => Signal.get(items)->Array.filter(n => mod(n, 2) == 0))
+
+let list =
+  <ul>
+    <View.For
+      each={Prop.signal(evens)}
+      render={n => <li> <View.Int> {n} </View.Int> </li>}
+    />
+  </ul>
+
+let conditional =
+  <View.Show when_={Prop.signal(Computed.make(() => Signal.get(count) > 0))}>
+    <p> <View.Text> "positive" </View.Text> </p>
+  </View.Show>
+
+let valueNode =
+  <View.Value value={Prop.signal(doubled)} render={n => <p> <View.Int> {n} </View.Int> </p>} />
+
+/* Disposal takes a computed back, closing the round trip. */
+Computed.dispose(doubled)
+
+/* Keep every binding used so the file compiles without unused warnings. */
+let scalars = [
+  doubledNow,
+  doubledPeeked,
+  Signal.peek(named),
+  Signal.peek(withEquals),
+  batched,
+  untracked,
+  Prop.get(staticProp),
+  Prop.get(signalProp),
+  propValue,
+]
+
+let nodes = [element, list, conditional, valueNode]


### PR DESCRIPTION
Fixes #146.

## The bug

With the setup the README documents, a computed cannot be used anywhere a signal is accepted:

```rescript
let count = Signal.make(0)
let doubled = Computed.make(() => Signal.get(count) * 2)
Signal.get(doubled)
```

```
This has type: Signals.Signal.t<int>
But this function argument is expecting:
  Xote.Signal.t<'a> (defined as "Signal-Signals".t<'a>)
```

Reported by a consumer on 7.1.0-beta.4; reproduced on rescript-signals 3.1.1 and 3.1.0, so it is neither new to the beta nor tied to a rescript-signals version. Every use of a computed is affected (`Signal.get`, `Prop.signal`, `View.For`, `View.Show`, `View.Value`), and within the documented setup there is no escape hatch, because `Signals` is not a declared dependency and so cannot be named to coerce the type.

## Cause

`src/Computed.res` was `include Signals.Computed`. An `include` rewrites paths that point at the included module itself, but not paths that point at *other* modules, and `Signals.Computed.make` returns `Signals.Signal.t`. That path survived into Xote's public API. A consumer whose `rescript.json` declares only `["xote"]` cannot resolve it, so the two names never unify.

`Signal` and `Effect` were unaffected: their own includes rewrote their types (`Xote.Signal.t` resolves to `"Signal-Signals".t`, and `Effect`'s `disposer` is defined in the included module). That left the surface inconsistent, with two primitives working and the third not.

## The fix

Write the shim's signatures out so they name Xote's own `Signal.t`:

```rescript
let make = (
  compute: unit => 'a,
  ~name: option<string>=?,
  ~equals: option<('a, 'a) => bool>=?,
): Signal.t<'a> => Signals.Computed.make(compute, ~name?, ~equals?)
```

This keeps rescript-signals an implementation detail. The alternative, telling consumers to declare `rescript-signals` themselves, also compiles, but it makes only that one configuration work, leaves the inconsistency between the primitives unexplained, and couples consumers to a version range that has to stay compatible with Xote's. After this change both configurations compile, so nothing is taken away from consumers who do want to use rescript-signals directly.

The README gains one line saying `xote` is the only dependency to declare, and that rescript-signals need only be declared for direct use.

## Regression test

`tests/consumer/` is a fixture whose `rescript.json` declares only `["xote"]`, exactly as the README does. `src/Surface.res` type-checks one line per public primitive: computeds through `Signal.get`/`peek`/`dispose`, the `~name` and `~equals` forms, `Signal` and `Effect`, `Prop.static`/`signal`/`get`, `View.signalText`/`signalInt`/`computedAttr`/`element`, and computeds flowing through `View.For`, `View.Show` and `View.Value` in JSX. It is never executed; type-checking is the whole point.

Wired into CI as `npm run test:consumer`, between the unit tests and the Vite build. The existing in-repo consumers (`docs-website`, `ppx/example`) both declare rescript-signals, which is why this class of leak went unnoticed and why they cannot catch the next one.

## Verification

- The fixture **fails** on the old `include Signals.Computed` with the exact error above, and **passes** on the new shim, so it is a real regression test rather than a passing decoration.
- Reproduced and confirmed the fix in a clean project installed from the registry (`xote@7.1.0-beta.4` plus `rescript-signals@3.1.1`) before making any repository change.
- `npm test` and `npm run test:consumer` pass on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VapxenofsCxa3uMMTqiRbi)_