### PR TITLE
refactor(maybe-signal): one coercion, one constructor spelling, deprecations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ The root `xote` entry is client-focused and does not export router, SSR, hydrati
 
 **Reactive Primitives (re-exported from rescript-signals):**
 - **`Xote.Signal`**: Reactive state cells with `make`, `get`, `peek`, `set`, `update`, plus `batch` and `untrack` from the scheduler. `Signal.make` accepts optional `~name` (for debugging) and `~equals` (a custom `('a, 'a) => bool` comparator) parameters. The default equality is JavaScript `===` (reference/strict), not structural — pass `~equals` when you need deep comparison. `set` only notifies dependents when the new value differs from the current one, preventing unnecessary updates and accidental infinite loops.
-- **`Xote.Computed`**: Derived signals that automatically recompute when dependencies change. `Computed.make` accepts optional `~name` (for debugging) and `~equals` (a custom `('a, 'a) => bool` comparator) parameters. As with `Signal.make`, the default equality is JavaScript `===` — pass `~equals` when downstream observers should ignore structurally-equal recomputations. **Lazy with push-based dirty flagging** — when upstream dependencies change, computeds are marked dirty immediately, but only recompute when read (via `Signal.get` or `Signal.peek`). **Auto-disposal**: automatically dispose when they lose all subscribers; use `Computed.dispose(signal)` for manual cleanup.
+- **`Xote.Computed`**: Derived signals that automatically recompute when dependencies change. `Computed.make` accepts optional `~name` (for debugging) and `~equals` (a custom `('a, 'a) => bool` comparator) parameters. As with `Signal.make`, the default equality is JavaScript `===` — pass `~equals` when downstream observers should ignore structurally-equal recomputations. **Lazy with push-based dirty flagging** — when upstream dependencies change, computeds are marked dirty immediately, but only recompute when read (via `Signal.get` or `Signal.peek`). **Disposal is manual**: `rescript-signals` 3.x does not drop a computed when its subscribers reach zero — a computed stays linked to its source signals until `Computed.dispose(signal)` unlinks it.
 - **`Xote.Effect`**: Side effects that run when dependencies change. **Can return cleanup callbacks** — signature is `unit => option<unit => unit>`. Two entry points: `Effect.run` is fire-and-forget and returns `unit`; `Effect.runWithDisposer` returns a `disposer` with a `dispose()` method for manual teardown. Both accept an optional `~name` for debugging.
 
 These three are thin shims (`src/Signal.res`, `src/Computed.res`, `src/Effect.res`) that `include` the corresponding modules from `rescript-signals`.
@@ -65,8 +65,12 @@ These three are thin shims (`src/Signal.res`, `src/Computed.res`, `src/Effect.re
 - **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
 - **`Xote.Html`**: Convenience constructors for common HTML tags (`div`, `span`, `button`, `input`, `h1`-`h3`, `p`, `ul`, `li`, `a`). Thin wrappers over `View.element`. For tags not listed, call `View.element(tag, ...)` directly or use JSX.
 - **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes). Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `View.LazyComponent`.
-- **`Xote.MaybeSignal`**: Static-or-reactive value wrapper exposing the type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` plus `static`, `reactive`, `signal` (alias of `reactive`), `get` (tracked read), `peek` (untracked read), `isStatic`/`isReactive`, `map` (preserves staticness; reactive values map through a lazy `Computed`), and `toSignal` (lifts `Static` into a constant signal). Use it anywhere an API should accept either a plain value or a signal — JSX props are the most common case, not the only one.
-- **`Xote.Prop`**: **Deprecated** alias of `Xote.MaybeSignal`, kept for backwards compatibility. `Prop.t` is a type alias of `MaybeSignal.t` (same constructors, same runtime representation), so values are interchangeable and migrating is a rename: `Prop.static` → `MaybeSignal.static`, `Prop.signal` → `MaybeSignal.signal`, `Prop.get` → `MaybeSignal.get`. Every `Prop` export carries a `@deprecated` attribute (warning 3).
+- **`Xote.MaybeSignal`**: Static-or-reactive value wrapper exposing the type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` plus `static`, `reactive`, `computed` (derives a `Reactive` from a `unit => 'a`), `get` (tracked read), `peek` (untracked read), `isStatic`/`isReactive`, `map`, `toSignal`, and `ofUnknown`. Use it anywhere an API should accept either a plain value or a signal — JSX props are the most common case, not the only one. Notes on the trickier members:
+  - `map` runs its function once immediately in both cases. For a `Reactive` value the result is backed by a `Computed`, which stays subscribed to the source until `Computed.dispose` is called on it, so prefer holding a mapped value over rebuilding it per update.
+  - `toSignal` returns the source signal for `Reactive`, but lifts `Static` into a **fresh, detached** signal — each call allocates a new one and writing to the result does not reach the original. Treat that result as read-only.
+  - `ofUnknown` normalizes an untyped value (raw / `Signal.t` / `unit => 'a` thunk / already-wrapped `t`) into a `t`. It is the single coercion behind every JSX surface that accepts untyped props, in both the ReScript and the hand-written JS runtime. It is unchecked by design — use `static`/`reactive`/`computed` in typed code.
+  - The JS export for `static` is `$$static` (ReScript escapes the reserved word), which matters for consumers importing `xote/maybe-signal` from JavaScript.
+- **`Xote.Prop`**: **Deprecated** alias of `Xote.MaybeSignal`, kept for backwards compatibility. `Prop.t` is a type alias of `MaybeSignal.t` (same constructors, same runtime representation), so values are interchangeable and migrating is a rename: `Prop.static` → `MaybeSignal.static`, `Prop.signal` and `Prop.reactive` → `MaybeSignal.reactive`, `Prop.get` → `MaybeSignal.get`. The deprecations live in `src/Prop.resi`: ReScript only reports warning 3 for values declared in an interface file, so `@deprecated` on the implementation's `let` bindings alone is silently ignored at call sites. `XoteJSX.Prop` and `Router.Link.Prop` re-export this module (not `MaybeSignal`), so those paths warn too.
 - **`Xote.Router`**: Signal-based client-side router with pattern matching, dynamic routes, base path support, scroll position restoration, and a global singleton state (via `Symbol.for()`) that works across multiple bundles.
 - **`Xote.Route`**: Route matching utilities.
 - **`Xote.SSR`**: Server-side rendering to HTML strings with hydration markers (`<!--$-->`, `<!--#-->`, `<!--kl-->`, `<!--k:KEY-->`, `<!--lc-->`).
@@ -95,7 +99,7 @@ All reactive behavior is provided by **rescript-signals**:
 - **Build system**: ReScript compiler v12+ with `esmodule` output format
 - **Output**: In-source compilation (`.res.mjs` files alongside `.res` files)
 - **Namespacing**: `namespace: true` in `rescript.json` automatically scopes every module under `Xote`. Public modules are listed explicitly in `sources.public` (`View`, `Html`, `XoteJSX`, `MaybeSignal`, `Prop`, `Route`, `Router`, `SSR`, `SSRContext`, `SSRState`, `Hydration`, `Mdx`, `Signal`, `Computed`, `Effect`); everything else (e.g. `DOM`/`Reactivity`, which live inside `View.res`) stays internal.
-- **Dependencies**: `rescript-signals` ^2.1.0 (the only runtime dependency)
+- **Dependencies**: `rescript-signals` ^3.1.0 (the only runtime dependency)
 - **JSX**: ReScript JSX v4 configured with `module: "XoteJSX"` (generic JSX transform). Consumers must mirror this in their own `rescript.json`.
 
 ### Component System
@@ -159,7 +163,7 @@ let app = () => {
   - SVG gradient/stop: `offset`, `stopColor`, `stopOpacity`, `gradientUnits`, `gradientTransform`, `spreadMethod`
   - SVG markers: `markerStart`, `markerMid`, `markerEnd`
   - SVG xlink (legacy): `xlinkHref`
-- Props support raw values, `MaybeSignal.t<'a>` (`Static` / `Reactive`), raw `Signal.t<'a>`, or a computed `unit => 'a` function for flexible static/reactive handling
+- Props support raw values, `MaybeSignal.t<'a>` (`Static` / `Reactive`), raw `Signal.t<'a>`, or a computed `unit => 'a` function for flexible static/reactive handling. These element props are untyped by design (each is its own type variable, resolved at runtime by `MaybeSignal.ofUnknown`), so `class={42}` compiles and renders `class="42"` — the trade for not requiring a wrapper. Props with a declared type (`View.Show`, `View.For`, `View.Maybe`, `View.Value`, and user components) take a `MaybeSignal.t` and are checked normally
 - Event handlers: `onClick`, `onInput`, `onChange`, `onSubmit`, `onFocus`, `onBlur`, `onKeyDown`, `onKeyUp`, `onMouseEnter`, `onMouseLeave`, `onMouseDown`, `onMouseMove`, `onMouseUp`, `onContextMenu`, plus drag-and-drop: `onDrag`, `onDragStart`, `onDragEnd`, `onDragOver`, `onDragEnter`, `onDragLeave`, `onDrop`
 - Children are passed via JSX syntax and rendered as nodes
 - Boolean attributes (`disabled`, `checked`, `required`, `readOnly`, `multiple`, `autofocus`, `ariaHidden`, `ariaExpanded`, `ariaSelected`, `draggable`, `hidden`, `contentEditable`, `spellcheck`) are added/removed based on the value rather than stringified
@@ -223,7 +227,7 @@ The `DOM.setAttrOrProp` helper (in `View.res`, via the internal `RuntimeDom` mod
 
 3. **Effect cleanup callbacks**: Effects can return `Some(cleanupFn)` to register cleanup that runs before re-execution and on disposal. Return `None` when no cleanup is needed. Signature is `unit => option<unit => unit>`.
 
-4. **Computed disposal**: `Computed.make` returns a `Signal.t<'a>` directly. For manual disposal, use `Computed.dispose(signal)`. Auto-disposal happens automatically when subscribers drop to zero.
+4. **Computed disposal**: `Computed.make` returns a `Signal.t<'a>` directly, already subscribed to whatever it read during its initial computation. There is no automatic disposal — call `Computed.dispose(signal)` to unlink a computed you no longer need. Xote's owner system tracks `Effect` disposers only, so computeds created during render are not cleaned up for you.
 
 5. **Untracked reads**: Use `Signal.peek(signal)` for a single untracked read, or `Signal.untrack(fn)` to disable dependency capture inside a larger block.
 
@@ -273,7 +277,7 @@ let translated = Computed.make(
   ~equals=(a, b) => a.x === b.x && a.y === b.y,
 )
 
-// Manual disposal (usually not needed - auto-disposes when subscribers drop to zero)
+// Manual disposal - unlinks the computed from the signals it depends on
 Computed.dispose(doubled)
 ```
 
@@ -402,23 +406,39 @@ View.eachWithKey(
 ```
 
 #### Static-or-reactive values with MaybeSignal
+Built-in element attributes and `View.Text`/`Int`/`Float`/`Bool` are untyped and
+accept anything, so no wrapper is needed there:
+
 ```rescript
-// Props can accept either static or reactive values
-<div class={MaybeSignal.static("container")}>
-  {View.text("Static class")}
-</div>
+<div class="container"> {View.text("Static class")} </div>
+<div class={classSignal}> {View.text("Reactive class")} </div>
+<div class={() => Signal.get(isActive) ? "on" : "off"}> {View.text("Derived")} </div>
+```
 
-<div class={MaybeSignal.signal(classSignal)}>
-  {View.text("Reactive class")}
-</div>
+Props with a declared type take a `MaybeSignal.t`, and that is where the wrapper
+earns its keep — `View.Show`, `View.For`, `View.Maybe`, `View.Value`, and any
+component you write:
 
-// MaybeSignal is not prop-specific — use it for any static-or-reactive input
-let label: MaybeSignal.t<string> = MaybeSignal.signal(nameSignal)
+```rescript
+<View.Show when_={MaybeSignal.reactive(isReady)}> ... </View.Show>
+<View.For each={MaybeSignal.static(["Draft", "Ship"])} render={...} />
+
+@jsx.component
+let make = (~className: MaybeSignal.t<string>=MaybeSignal.static("badge"), ~children) =>
+  <span class={className}> {children} </span>
+```
+
+`MaybeSignal` is not prop-specific — use it for any static-or-reactive input:
+
+```rescript
+let label: MaybeSignal.t<string> = MaybeSignal.reactive(nameSignal)
+let title = MaybeSignal.computed(() => Signal.get(first) ++ " " ++ Signal.get(last))
 
 MaybeSignal.get(label)          // tracked read
 MaybeSignal.peek(label)         // untracked read
 MaybeSignal.map(label, String.toUpperCase) // stays static if the input was static
-MaybeSignal.toSignal(label)     // always a Signal.t<string>
+MaybeSignal.toSignal(label)     // Signal.t<string>; a Static input yields a detached signal
+MaybeSignal.ofUnknown(anything) // coercion for untyped input (raw / signal / thunk / t)
 ```
 
 > `Prop` is the deprecated predecessor of `MaybeSignal`. It still works (`Prop.t`
@@ -516,7 +536,7 @@ Guidance for AI coding agents (and humans) making changes to this repository.
 | `src/SSRState.res` | Server-client state transfer |
 | `src/SSRContext.res` | Server/client environment detection |
 | `src/MaybeSignal.res` | Static/Reactive value wrapper |
-| `src/Prop.res` | Deprecated alias of `MaybeSignal` |
+| `src/Prop.res`, `src/Prop.resi` | Deprecated alias of `MaybeSignal` (the interface file is what makes the deprecations warn) |
 | `src/Signal.res`, `src/Computed.res`, `src/Effect.res` | Re-export shims for `rescript-signals` |
 | `rescript.json` | ReScript compiler configuration (`namespace: true`) |
 | `vite.config.js` | Library build configuration |

--- a/README.md
+++ b/README.md
@@ -137,11 +137,14 @@ On top of the reactive primitives with signals, Xote provides a declarative view
 ```rescript
 let className = Signal.make("card")
 
-<div class={MaybeSignal.signal(className)}>
+<div class={className}>
   <View.Text> "Status: " </View.Text>
   <View.Text> {className} </View.Text>
 </div>
 ```
+
+Built-in attributes take a plain value, a signal, or a `unit => 'a` function, so
+a signal can be passed straight through without wrapping it.
 
 For rendering collections in JSX, prefer `View.For`. Add `by` when items have stable identity and should reconcile by key:
 
@@ -154,7 +157,7 @@ let todos = Signal.make([
 ])
 
 <View.For
-  each={MaybeSignal.signal(todos)}
+  each={MaybeSignal.reactive(todos)}
   by={todo => todo.id}
   render={todo => <li> <View.Text> {todo.title} </View.Text> </li>}
 />
@@ -170,24 +173,24 @@ let todos = Signal.make([
 
 <ul>
   <View.For
-    each={MaybeSignal.signal(todos)}
+    each={MaybeSignal.reactive(todos)}
     by={todo => todo.id}
     render={todo => <li> <View.Text> {todo.title} </View.Text> </li>}
   />
 </ul>
 
-<View.Show when_={MaybeSignal.signal(isReady)} fallback={<p> <View.Text> "Loading" </View.Text> </p>}>
+<View.Show when_={MaybeSignal.reactive(isReady)} fallback={<p> <View.Text> "Loading" </View.Text> </p>}>
   <p> <View.Text> "Ready" </View.Text> </p>
 </View.Show>
 
 <View.Maybe
-  value={MaybeSignal.signal(selectedTodo)}
+  value={MaybeSignal.reactive(selectedTodo)}
   fallback={<p> <View.Text> "No selection" </View.Text> </p>}
   render={todo => <p> <View.Text> {todo.title} </View.Text> </p>}
 />
 
 <View.Value
-  value={MaybeSignal.signal(count)}
+  value={MaybeSignal.reactive(count)}
   render={count =>
     <p>
       <View.Text> "Count: " </View.Text>
@@ -206,9 +209,13 @@ let todos = Signal.make([
 
 ### Static or Reactive Values
 
-Use `MaybeSignal` when a value can be either a plain value or a signal. It is
-most visible on component props, but nothing about it is prop-specific — use it
-for any API that should accept both:
+`MaybeSignal` is how a value says whether it is plain or reactive. There is one
+rule for when you need it:
+
+| Where | What it accepts |
+|---|---|
+| Built-in HTML/SVG attributes, `View.Text`/`Int`/`Float`/`Bool` | anything — a plain value, a `Signal.t`, a `unit => 'a` function, or a `MaybeSignal.t`. No wrapper needed. |
+| Props with a declared type — `View.Show`, `View.For`, `View.Maybe`, `View.Value`, and the components you write | a `MaybeSignal.t`, so the wrapper is how the caller says which one they are passing. |
 
 ```rescript
 @jsx.component
@@ -218,20 +225,23 @@ let make = (~className: MaybeSignal.t<string>=MaybeSignal.static("badge"), ~chil
 
 let tone = Signal.make("badge badge-info")
 
-<Badge className={MaybeSignal.signal(tone)}>
+<Badge className={MaybeSignal.reactive(tone)}>
   <View.Text> "Live" </View.Text>
 </Badge>
 ```
 
-`MaybeSignal.t<'a>` is `Reactive(Signal.t<'a>) | Static('a)`. Read it with
-`MaybeSignal.get` (tracked) or `MaybeSignal.peek` (untracked); `MaybeSignal.map`
-transforms it while preserving staticness, and `MaybeSignal.toSignal` normalizes
-it to a plain signal.
+`MaybeSignal.t<'a>` is `Reactive(Signal.t<'a>) | Static('a)`. Build one with
+`MaybeSignal.static`, `MaybeSignal.reactive`, or `MaybeSignal.computed(fn)` for a
+derived value. Read it with `MaybeSignal.get` (tracked) or `MaybeSignal.peek`
+(untracked), and transform it with `MaybeSignal.map`, which preserves staticness.
+
+`MaybeSignal.ofUnknown` is the coercion the JSX runtime applies to untyped props;
+reach for it only when adapting untyped input of your own.
 
 > **Deprecated:** the old `Prop` module is a deprecated alias of `MaybeSignal`.
 > `Prop.t` is a type alias of `MaybeSignal.t`, so migrating is a rename:
-> `Prop.static` → `MaybeSignal.static`, `Prop.signal` → `MaybeSignal.signal`,
-> `Prop.get` → `MaybeSignal.get`.
+> `Prop.static` → `MaybeSignal.static`, `Prop.signal` and `Prop.reactive` →
+> `MaybeSignal.reactive`, `Prop.get` → `MaybeSignal.get`.
 
 ### Router and SSR State
 

--- a/docs-website/src/demos/EffectAutosaveDemo.res
+++ b/docs-website/src/demos/EffectAutosaveDemo.res
@@ -83,7 +83,7 @@ let make = () => {
       </div>
 
       <View.Show
-        when_={MaybeSignal.signal(hasSavedDrafts)}
+        when_={MaybeSignal.reactive(hasSavedDrafts)}
         fallback={
           <div class="effect-autosave-demo-empty">
             {View.text("No saves yet. Type, pause, and the latest draft will be recorded here.")}
@@ -91,7 +91,7 @@ let make = () => {
         }>
         <ol class="effect-autosave-demo-list">
           <View.For
-            each={MaybeSignal.signal(savedDrafts)}
+            each={MaybeSignal.reactive(savedDrafts)}
             by={entry => Int.toString(entry.id)}
             render={entry =>
               <li class="effect-autosave-demo-item">

--- a/docs-website/src/demos/TodoListDemo.res
+++ b/docs-website/src/demos/TodoListDemo.res
@@ -125,7 +125,7 @@ module TodoList = {
   let make = () => {
     <ul class="todo-demo-list">
       <View.For
-        each={MaybeSignal.signal(todos)}
+        each={MaybeSignal.reactive(todos)}
         by={todo => todo.id}
         render={todo => <TodoRow todo />}
       />

--- a/docs-website/src/demos/TutorialDemos.res
+++ b/docs-website/src/demos/TutorialDemos.res
@@ -171,13 +171,10 @@ module DomInspector = {
         )}
       </ol>
       <p
-        class={MaybeSignal.reactive(
-          Computed.make(() =>
-            Array.length(Signal.get(entries)) > 0
-              ? "dom-inspector-empty is-hidden"
-              : "dom-inspector-empty"
-          ),
-        )}>
+        class={() =>
+          Array.length(Signal.get(entries)) > 0
+            ? "dom-inspector-empty is-hidden"
+            : "dom-inspector-empty"}>
         {View.text("Drag the slider. Only the changed text nodes update.")}
       </p>
     </aside>

--- a/docs-website/src/docs/ReactComparisonDoc.mdx
+++ b/docs-website/src/docs/ReactComparisonDoc.mdx
@@ -105,7 +105,7 @@ let todoList = () => {
 
   <ul>
     <View.For
-      each={MaybeSignal.signal(todos)}
+      each={MaybeSignal.reactive(todos)}
       by={todo => todo.id}
       render={todo => <li> <View.Text> {todo.text} </View.Text> </li>}
     />

--- a/docs-website/src/docs/SolidJSComparisonDoc.mdx
+++ b/docs-website/src/docs/SolidJSComparisonDoc.mdx
@@ -120,7 +120,7 @@ let todoList = () => {
 
   <ul>
     <View.For
-      each={MaybeSignal.signal(todos)}
+      each={MaybeSignal.reactive(todos)}
       by={todo => todo.id}
       render={todo => <li> <View.Text> {todo.text} </View.Text> </li>}
     />

--- a/docs-website/src/docs/ViewsDoc.mdx
+++ b/docs-website/src/docs/ViewsDoc.mdx
@@ -89,7 +89,7 @@ let make = (~name: MaybeSignal.t<string>) => {
 
 ### Attributes and Events
 
-In JSX, common HTML props are exposed directly. Pass functions for reactive attributes when the value should be recomputed.
+In JSX, common HTML props are exposed directly. An attribute accepts a plain value, a signal, or a `unit => 'a` function — no wrapper needed. Pass a function when the value is derived from one or more signals; a bare expression like `Signal.get(isActive) ? "a" : "b"` is read once at construction and never updates.
 
 ```rescript
 let isActive = Signal.make(false)
@@ -99,24 +99,32 @@ let toggle = (_evt: Dom.event) => {
 }
 
 <button
-  class={Signal.get(isActive) ? "btn active" : "btn"}
+  class={() => Signal.get(isActive) ? "btn active" : "btn"}
   onClick={toggle}>
   <View.Text> "Toggle" </View.Text>
 </button>
+```
+
+A signal can also be passed straight through when no formatting is needed:
+
+```rescript
+let theme = Signal.make("dark")
+
+<div class={theme}> <View.Text> "Themed" </View.Text> </div>
 ```
 
 In JSX, use `class`, not `className`. Use `type_` for the HTML `type` attribute because `type` is reserved in ReScript.
 
 ### Lists
 
-Use [`View.For`](/docs/api/view#view-for) for simple arrays that can be fully re-rendered. Add `by` when item identity matters. [`View.For`](/docs/api/view#view-for) accepts `MaybeSignal.static(value)` for plain data and `MaybeSignal.signal(signal)` for reactive data.
+Use [`View.For`](/docs/api/view#view-for) for simple arrays that can be fully re-rendered. Add `by` when item identity matters. Unlike element attributes, `each` has a declared type, so it takes a `MaybeSignal.t`: `MaybeSignal.static(value)` for plain data and `MaybeSignal.reactive(signal)` for reactive data. The same is true of every prop with a declared type, including the ones on components you write.
 
 ```rescript
 let items = Signal.make(["Apple", "Banana", "Cherry"])
 
 <ul>
   <View.For
-    each={MaybeSignal.signal(items)}
+    each={MaybeSignal.reactive(items)}
     render={item => <li> <View.Text> {item} </View.Text> </li>}
   />
 </ul>
@@ -131,7 +139,7 @@ let todos = Signal.make([
 
 <ul>
   <View.For
-    each={MaybeSignal.signal(todos)}
+    each={MaybeSignal.reactive(todos)}
     by={todo => todo.id}
     render={todo => <li> <View.Text> {todo.text} </View.Text> </li>}
   />
@@ -145,18 +153,18 @@ Choose stable keys. Database IDs and route slugs are good. Array indexes are not
 Use [`View.Show`](/docs/api/view#view-show) for boolean branches, [`View.Maybe`](/docs/api/view#view-maybe) for option values, and [`View.Value`](/docs/api/view#view-value) when a whole node should be re-rendered from one static or reactive value. Use [`View.Text`](/docs/api/view#view-text-component), [`View.Int`](/docs/api/view#view-int-component), [`View.Float`](/docs/api/view#view-float-component), and [`View.Bool`](/docs/api/view#view-bool-component) for direct value output.
 
 ```rescript
-<View.Show when_={MaybeSignal.signal(isReady)} fallback={<p> <View.Text> "Loading" </View.Text> </p>}>
+<View.Show when_={MaybeSignal.reactive(isReady)} fallback={<p> <View.Text> "Loading" </View.Text> </p>}>
   <p> <View.Text> "Ready" </View.Text> </p>
 </View.Show>
 
 <View.Maybe
-  value={MaybeSignal.signal(selectedTodo)}
+  value={MaybeSignal.reactive(selectedTodo)}
   fallback={<p> <View.Text> "No todo selected" </View.Text> </p>}
   render={todo => <p> <View.Text> {todo.text} </View.Text> </p>}
 />
 
 <View.Value
-  value={MaybeSignal.signal(count)}
+  value={MaybeSignal.reactive(count)}
   render={count =>
     <p>
       <View.Text> "Count: " </View.Text>
@@ -234,7 +242,7 @@ let make = () => {
     <TodoComposer />
     <ul>
       <View.For
-        each={MaybeSignal.signal(todos)}
+        each={MaybeSignal.reactive(todos)}
         by={todo => todo.id}
         render={todo => <TodoRow todo />}
       />

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -114,7 +114,7 @@ SSR mirrors the same boolean attribute behavior when rendering strings.
 - `jsx`, `jsxs`, `jsxKeyed`, and `jsxsKeyed` are entry points for the JSX transform.
 - Lowercase HTML tags are implemented in `XoteJSX.Elements`.
 - JSX components are wrapped in `View.LazyComponent` so component evaluation happens during render/hydration rather than inside an unrelated computed context.
-- JSX attributes accept raw values, `MaybeSignal.t<'a>`, raw `Signal.t<'a>`, or computed functions for compatibility.
+- JSX attributes accept raw values, `MaybeSignal.t<'a>`, raw `Signal.t<'a>`, or computed functions for compatibility. `MaybeSignal.ofUnknown` is the single coercion behind that flexibility, shared by `RuntimeJsxProp`, `View.valuePrimitive`, and the hand-written `src/jsx-runtime.mjs`.
 
 `MaybeSignal.t<'a>` is:
 
@@ -122,9 +122,13 @@ SSR mirrors the same boolean attribute behavior when rendering strings.
 type t<'a> = Reactive(Signal.t<'a>) | Static('a)
 ```
 
-Use `MaybeSignal.static(value)` or `MaybeSignal.signal(signal)` (alias of `MaybeSignal.reactive`) when an API should support either static or reactive input. Read it with `MaybeSignal.get` (tracked) or `MaybeSignal.peek` (untracked); `MaybeSignal.map` maps it while preserving staticness, `MaybeSignal.toSignal` normalizes it to a `Signal.t`, and `MaybeSignal.isStatic`/`isReactive` classify it.
+Build one with `MaybeSignal.static(value)`, `MaybeSignal.reactive(signal)`, or `MaybeSignal.computed(fn)` when an API should support either static or reactive input. Read it with `MaybeSignal.get` (tracked) or `MaybeSignal.peek` (untracked); `MaybeSignal.map` maps it while preserving staticness, and `MaybeSignal.isStatic`/`isReactive` classify it.
 
-`Xote.Prop` is a deprecated alias of `Xote.MaybeSignal`. `Prop.t` is a type alias of `MaybeSignal.t` with the same constructors and runtime representation, so the two are interchangeable and migrating is a rename.
+Wrapping is only required where a prop has a declared type — `View.Show`, `View.For`, `View.Maybe`, `View.Value`, and user-written components. Built-in element attributes and `View.Text`/`Int`/`Float`/`Bool` take untyped values and coerce them at runtime, so a raw signal or thunk can be passed straight through.
+
+Two sharp edges worth knowing: `MaybeSignal.map` runs its function once immediately and, for reactive values, leaves a `Computed` subscribed to the source until `Computed.dispose`; and `MaybeSignal.toSignal` lifts a `Static` into a fresh detached signal, so writes to the result do not reach the original.
+
+`Xote.Prop` is a deprecated alias of `Xote.MaybeSignal`. `Prop.t` is a type alias of `MaybeSignal.t` with the same constructors and runtime representation, so the two are interchangeable and migrating is a rename. The deprecations are declared in `src/Prop.resi`, because ReScript only reports warning 3 for values declared in an interface file. `XoteJSX.Prop` and `Router.Link.Prop` re-export the deprecated module, so those paths warn as well.
 
 ### Router
 

--- a/src/MaybeSignal.res
+++ b/src/MaybeSignal.res
@@ -4,7 +4,16 @@
  This is the general "static or reactive" wrapper used across Xote. It is not
  tied to component props — use it anywhere an API should accept both a plain
  value and a signal (function arguments, record fields, configuration, JSX
- props, ...). */
+ props, ...).
+
+ Where you do and do not need it in JSX:
+
+ - built-in HTML/SVG attributes and `View.Text`/`Int`/`Float`/`Bool` accept a
+   raw value, a `Signal.t`, a `unit => 'a` thunk, or a `t` — wrapping is
+   optional there and usually just noise
+ - props with a declared type — `View.Show`, `View.For`, `View.Maybe`,
+   `View.Value`, and the components you write — take a `t`, so the wrapper is
+   how the caller says which one they are passing */
 type t<'a> = Reactive(Signal.t<'a>) | Static('a)
 
 /* Constructors */
@@ -12,8 +21,10 @@ let static = value => Static(value)
 
 let reactive = signal => Reactive(signal)
 
-/* Alias of `reactive`, reads better when the argument is already a signal */
-let signal = reactive
+/* Derives a reactive value from a computation, so callers do not have to spell
+ out `reactive(Computed.make(fn))`. Like `Computed.make`, `fn` runs once
+ immediately to establish its dependencies. */
+let computed = fn => Reactive(Computed.make(fn))
 
 /* Reads the current value. Inside an observer, a `Reactive` value registers a
  dependency; a `Static` value never does. */
@@ -39,18 +50,49 @@ let isReactive = value =>
 
 let isStatic = value => !isReactive(value)
 
-/* Transforms the wrapped value, preserving staticness. `Reactive` values are
- mapped through a lazy `Computed`, so `fn` only runs when the result is read. */
+/* Transforms the wrapped value, preserving staticness.
+
+ `fn` runs once immediately in both cases — for `Reactive` values the result is
+ backed by a `Computed`, which performs an initial computation to establish its
+ dependencies and recomputes lazily from then on. That `Computed` stays
+ subscribed to the source signal until `Computed.dispose` is called on it, so
+ hold on to long-lived mapped values rather than rebuilding them per update. */
 let map = (value, fn) =>
   switch value {
   | Reactive(signal) => Reactive(Computed.make(() => fn(Signal.get(signal))))
   | Static(value) => Static(fn(value))
   }
 
-/* Normalizes to a signal. `Static` values are lifted into a constant signal, so
- the result is always readable with `Signal.get`. */
+/* Normalizes to a signal, so the result is always readable with `Signal.get`.
+
+ A `Reactive` value returns its own signal. A `Static` value is lifted into a
+ *fresh, detached* signal: each call allocates a new one, and writing to the
+ result does not change the original — treat it as read-only. */
 let toSignal = value =>
   switch value {
   | Reactive(signal) => signal
   | Static(value) => Signal.make(value)
+  }
+
+/* Normalizes an untyped value into a `t`. This is the coercion the JSX runtimes
+ apply to props, which may arrive as a raw value, a `Signal.t`, a `unit => 'a`
+ thunk, or an already-wrapped `t`:
+
+ - a `t` is returned as-is
+ - a `Signal.t` becomes `Reactive`
+ - a `unit => 'a` thunk becomes `Reactive` over a `Computed`
+ - anything else — including null and undefined — becomes `Static`
+
+ It is deliberately unchecked: nothing verifies that the value really holds an
+ `'a`. Reach for it when adapting untyped JSX-shaped input; in typed code use
+ `static`, `reactive`, or `computed` instead. */
+let ofUnknown = (value: 'input): t<'a> =>
+  if RuntimeValue.isMaybeSignal(value) {
+    Obj.magic(value)
+  } else if RuntimeValue.isSignalLike(value) {
+    Reactive(Obj.magic(value))
+  } else if RuntimeValue.isFunction(value) {
+    computed(Obj.magic(value))
+  } else {
+    Static(Obj.magic(value))
   }

--- a/src/Prop.res
+++ b/src/Prop.res
@@ -6,8 +6,9 @@
 
  `Prop.t` is a type alias of `MaybeSignal.t` (same constructors, same runtime
  representation), so migrating is a rename: `Prop.static` -> `MaybeSignal.static`,
- `Prop.signal` -> `MaybeSignal.signal`, `Prop.get` -> `MaybeSignal.get`. Values
- built with one module can be passed to APIs expecting the other. */
+ `Prop.signal` and `Prop.reactive` -> `MaybeSignal.reactive`, `Prop.get` ->
+ `MaybeSignal.get`. Values built with one module can be passed to APIs expecting
+ the other. */
 
 @deprecated("Use MaybeSignal.t instead. Prop.t is an alias of MaybeSignal.t.")
 type t<'a> = MaybeSignal.t<'a> = Reactive(Signal.t<'a>) | Static('a)
@@ -21,5 +22,5 @@ let static = MaybeSignal.static
 @deprecated("Use MaybeSignal.reactive instead.")
 let reactive = MaybeSignal.reactive
 
-@deprecated("Use MaybeSignal.signal instead.")
-let signal = MaybeSignal.signal
+@deprecated("Use MaybeSignal.reactive instead.")
+let signal = MaybeSignal.reactive

--- a/src/Prop.resi
+++ b/src/Prop.resi
@@ -1,0 +1,21 @@
+/* Deprecated: use `MaybeSignal` instead. See `Prop.res` for the migration notes.
+
+ This interface exists so the deprecations actually fire: ReScript only reports
+ warning 3 for values when they are declared in an interface file. Without it,
+ `@deprecated` on the implementation's `let` bindings is silently ignored at
+ call sites. */
+
+@deprecated("Use MaybeSignal.t instead. Prop.t is an alias of MaybeSignal.t.")
+type t<'a> = MaybeSignal.t<'a> = Reactive(Signal.t<'a>) | Static('a)
+
+@deprecated("Use MaybeSignal.get instead.")
+let get: MaybeSignal.t<'a> => 'a
+
+@deprecated("Use MaybeSignal.static instead.")
+let static: 'a => MaybeSignal.t<'a>
+
+@deprecated("Use MaybeSignal.reactive instead.")
+let reactive: Signal.t<'a> => MaybeSignal.t<'a>
+
+@deprecated("Use MaybeSignal.reactive instead.")
+let signal: Signal.t<'a> => MaybeSignal.t<'a>

--- a/src/Router.res
+++ b/src/Router.res
@@ -424,10 +424,9 @@ let link = (
 
 // JSX Link component
 module Link = {
-  module MaybeSignal = MaybeSignal
-
-  /* Deprecated alias — use `MaybeSignal` */
-  module Prop = MaybeSignal
+  /* Deprecated re-export, kept for existing `Router.Link.Prop.*` call sites.
+   Use `MaybeSignal` directly. */
+  module Prop = Prop
 
   type props<'class, 'id, 'style, 'target, 'ariaLabel> = {
     /* Required navigation prop */

--- a/src/RuntimeJsxProp.res
+++ b/src/RuntimeJsxProp.res
@@ -1,43 +1,26 @@
-let isMaybeSignal = RuntimeValue.isMaybeSignal
+/* Attribute values arrive untyped from JSX. `MaybeSignal.ofUnknown` owns the
+ raw / signal / thunk / `MaybeSignal.t` classification; the only case handled
+ here is the thunk, because `attrValue` can carry it lazily as `Compute` and
+ avoid allocating a `Computed`. */
 
-let toStringAttr = (key: string, value: 'a): (string, View.attrValue) => {
-  if isMaybeSignal(value) {
-    let maybeSignal: MaybeSignal.t<string> = Obj.magic(value)
-    switch maybeSignal {
+let toStringAttr = (key: string, value: 'a): (string, View.attrValue) =>
+  if RuntimeValue.isFunction(value) {
+    let compute: unit => string = Obj.magic(value)
+    View.computedAttr(key, compute)
+  } else {
+    switch MaybeSignal.ofUnknown(value) {
     | Static(value) => View.attr(key, value)
     | Reactive(signal) => View.signalAttr(key, signal)
     }
-  } else if value->RuntimeValue.isFunction {
-    let compute: unit => string = Obj.magic(value)
-    View.computedAttr(key, compute)
-  } else if value->RuntimeValue.isObject {
-    let signal: Signal.t<string> = Obj.magic(value)
-    View.signalAttr(key, signal)
-  } else {
-    let value: string = Obj.magic(value)
-    View.attr(key, value)
   }
-}
 
-let toBoolAttr = (key: string, value: 'a): (string, View.attrValue) => {
-  if isMaybeSignal(value) {
-    let maybeSignal: MaybeSignal.t<bool> = Obj.magic(value)
-    switch maybeSignal {
-    | Static(value) => View.attr(key, RuntimeAttr.boolToString(value))
-    | Reactive(signal) => {
-        let stringSignal = Computed.make(() => RuntimeAttr.boolToString(Signal.get(signal)))
-        View.signalAttr(key, stringSignal)
-      }
-    }
-  } else if value->RuntimeValue.isFunction {
+let toBoolAttr = (key: string, value: 'a): (string, View.attrValue) =>
+  if RuntimeValue.isFunction(value) {
     let compute: unit => bool = Obj.magic(value)
     View.computedAttr(key, () => RuntimeAttr.boolToString(compute()))
-  } else if value->RuntimeValue.isObject {
-    let signal: Signal.t<bool> = Obj.magic(value)
-    let stringSignal = Computed.make(() => RuntimeAttr.boolToString(Signal.get(signal)))
-    View.signalAttr(key, stringSignal)
   } else {
-    let value: bool = Obj.magic(value)
-    View.attr(key, RuntimeAttr.boolToString(value))
+    switch MaybeSignal.ofUnknown(value)->MaybeSignal.map(RuntimeAttr.boolToString) {
+    | Static(value) => View.attr(key, value)
+    | Reactive(signal) => View.signalAttr(key, signal)
+    }
   }
-}

--- a/src/RuntimeValue.res
+++ b/src/RuntimeValue.res
@@ -25,9 +25,20 @@ let isFunction = (value: 'value): bool =>
   | _ => false
   }
 
-let isObject = (value: 'value): bool =>
+/* Detects a `Signal.t` by its shape. Structural rather than "any object", so a
+ plain record handed to an untyped prop is treated as a value instead of being
+ silently read as a signal. */
+let isSignalLike = (value: 'value): bool =>
   switch value->Core.Type.Classify.classify {
-  | Object(_) => true
+  | Object(obj) => {
+      let obj: {..} = Obj.magic(obj)
+      obj->Core.Object.hasOwnProperty("subs") &&
+      obj->Core.Object.hasOwnProperty("value") &&
+      switch obj->Core.Object.get("equals") {
+      | Some(equals) => isFunction(equals)
+      | None => false
+      }
+    }
   | _ => false
   }
 

--- a/src/View.res
+++ b/src/View.res
@@ -710,36 +710,18 @@ let mountById = (node: node, containerId: string): unit => {
   }
 }
 
-let isMaybeSignal = RuntimeValue.isMaybeSignal
+@deprecated("Internal helper. Use MaybeSignal.ofUnknown to normalize an untyped value.")
+let isReactiveProp = RuntimeValue.isMaybeSignal
 
-@deprecated("Use View.isMaybeSignal instead.")
-let isReactiveProp = isMaybeSignal
-
-let valuePrimitive = (value: 'input, stringify: 'value => string): node => {
-  if isMaybeSignal(value) {
-    let maybeSignal: MaybeSignal.t<'value> = Obj.magic(value)
-    switch maybeSignal {
-    | Static(value) => text(stringify(value))
-    | Reactive(signal) => SignalText(Computed.make(() => stringify(Signal.get(signal))))
-    }
-  } else {
-    switch value->Core.Type.Classify.classify {
-    | Function(_) => {
-        let compute: unit => 'value = Obj.magic(value)
-        signalText(() => stringify(compute()))
-      }
-    | Object(_) => {
-        let signal: Signal.t<'value> = Obj.magic(value)
-        SignalText(Computed.make(() => stringify(Signal.get(signal))))
-      }
-    | Null | Undefined => null()
-    | _ => {
-        let value: 'value = Obj.magic(value)
-        text(stringify(value))
-      }
+let valuePrimitive = (value: 'input, stringify: 'value => string): node =>
+  switch value->Core.Type.Classify.classify {
+  | Null | Undefined => null()
+  | _ =>
+    switch MaybeSignal.ofUnknown(value)->MaybeSignal.map(stringify) {
+    | Static(value) => text(value)
+    | Reactive(signal) => SignalText(signal)
     }
   }
-}
 
 let renderValuePrimitiveProps = (props: 'props, stringify: 'scalar => string): node => {
   switch (props->RuntimeValue.getField("children"), props->RuntimeValue.getField("value")) {

--- a/src/XoteJSX.res
+++ b/src/XoteJSX.res
@@ -1,7 +1,7 @@
-module MaybeSignal = MaybeSignal
-
-/* Deprecated alias — use `MaybeSignal` */
-module Prop = MaybeSignal
+/* Deprecated re-export of the top-level `Prop` module, kept so existing
+ `XoteJSX.Prop.*` call sites keep compiling — they now raise the same
+ deprecation warnings as `Prop` itself. Use `MaybeSignal` directly. */
+module Prop = Prop
 
 /* ReScript JSX transform type aliases */
 type element = View.node
@@ -159,7 +159,7 @@ module Elements = {
     'markerEnd,
     'xlinkHref,
   > = {
-    /* Standard attributes - accept raw strings or Prop.t<string> */
+    /* Standard attributes - accept raw strings or MaybeSignal.t<string> */
     id?: 'id,
     class?: 'class,
     style?: 'style,

--- a/src/jsx-runtime.mjs
+++ b/src/jsx-runtime.mjs
@@ -1,5 +1,4 @@
-import * as Computed from "./Computed.res.mjs";
-import * as Signal from "./Signal.res.mjs";
+import * as MaybeSignal from "./MaybeSignal.res.mjs";
 import * as View from "./View.res.mjs";
 
 export const Fragment = Symbol.for("xote.fragment");
@@ -78,25 +77,6 @@ function isXoteNode(value) {
   return value && typeof value === "object" && nodeTags.has(value.TAG);
 }
 
-// Detects a MaybeSignal.t (Static / Reactive) handed to us as an untyped prop.
-function isMaybeSignal(value) {
-  return (
-    value &&
-    typeof value === "object" &&
-    (value.TAG === "Static" || value.TAG === "Reactive")
-  );
-}
-
-function isSignal(value) {
-  return (
-    value &&
-    typeof value === "object" &&
-    "subs" in value &&
-    "value" in value &&
-    typeof value.equals === "function"
-  );
-}
-
 function toKebab(name) {
   return name.replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
 }
@@ -136,31 +116,21 @@ function stringifyAttrValue(name, value) {
   return String(value);
 }
 
+// Thunks stay lazy as a `Compute` attribute; everything else (raw value, signal,
+// MaybeSignal.t) is classified by MaybeSignal.ofUnknown so this runtime and the
+// ReScript one agree on what counts as reactive.
 function attrFromValue(name, value) {
-  if (isMaybeSignal(value)) {
-    if (value.TAG === "Static") {
-      return View.attr(name, stringifyAttrValue(name, value._0));
-    }
-
-    const signal = value._0;
-    return View.signalAttr(
-      name,
-      Computed.make(() => stringifyAttrValue(name, Signal.get(signal)), undefined, undefined),
-    );
-  }
-
-  if (isSignal(value)) {
-    return View.signalAttr(
-      name,
-      Computed.make(() => stringifyAttrValue(name, Signal.get(value)), undefined, undefined),
-    );
-  }
-
   if (typeof value === "function") {
     return View.computedAttr(name, () => stringifyAttrValue(name, value()));
   }
 
-  return View.attr(name, stringifyAttrValue(name, value));
+  const normalized = MaybeSignal.map(MaybeSignal.ofUnknown(value), inner =>
+    stringifyAttrValue(name, inner),
+  );
+
+  return normalized.TAG === "Static"
+    ? View.attr(name, normalized._0)
+    : View.signalAttr(name, normalized._0);
 }
 
 function eventNameFromProp(name, value) {

--- a/tests/JSX_test.res
+++ b/tests/JSX_test.res
@@ -102,7 +102,7 @@ let suite = Zekr.suite(
       let _ = mountTo(
         <ul>
           <View.For
-            each={MaybeSignal.signal(items)}
+            each={MaybeSignal.reactive(items)}
             render={label => <li> {View.text(label)} </li>}
           />
         </ul>,
@@ -125,7 +125,7 @@ let suite = Zekr.suite(
       let {container} = Dom.render("")
       let visible = Signal.make(false)
       let _ = mountTo(
-        <View.Show when_={MaybeSignal.signal(visible)} fallback={<p> {View.text("Hidden")} </p>}>
+        <View.Show when_={MaybeSignal.reactive(visible)} fallback={<p> {View.text("Hidden")} </p>}>
           <p> {View.text("Visible")} </p>
         </View.Show>,
         container,
@@ -144,7 +144,7 @@ let suite = Zekr.suite(
       let selected = Signal.make(None)
       let _ = mountTo(
         <View.Maybe
-          value={MaybeSignal.signal(selected)}
+          value={MaybeSignal.reactive(selected)}
           fallback={<p> {View.text("None")} </p>}
           render={value => <p> {View.text("Selected: " ++ value)} </p>}
         />,
@@ -164,7 +164,7 @@ let suite = Zekr.suite(
       let count = Signal.make(1)
       let _ = mountTo(
         <View.Value
-          value={MaybeSignal.signal(count)}
+          value={MaybeSignal.reactive(count)}
           render={value => <p> {View.text("Count: " ++ value->Int.toString)} </p>}
         />,
         container,
@@ -199,10 +199,10 @@ let suite = Zekr.suite(
       let ready = Signal.make(false)
       let _ = mountTo(
         <p>
-          <View.Text value={MaybeSignal.signal(label)} />
-          <View.Int value={MaybeSignal.signal(count)} />
+          <View.Text value={MaybeSignal.reactive(label)} />
+          <View.Int value={MaybeSignal.reactive(count)} />
           <View.Text value={MaybeSignal.static(", ready: ")} />
-          <View.Bool value={MaybeSignal.signal(ready)} />
+          <View.Bool value={MaybeSignal.reactive(ready)} />
         </p>,
         container,
       )
@@ -258,7 +258,7 @@ let suite = Zekr.suite(
       let {container} = Dom.render("")
       let count = Signal.make(1)
       let label: MaybeSignal.t<string> = MaybeSignal.static("Count: ")
-      let value: MaybeSignal.t<int> = MaybeSignal.signal(count)
+      let value: MaybeSignal.t<int> = MaybeSignal.reactive(count)
       let _ = mountTo(
         <p>
           <View.Text> {label} </View.Text>
@@ -317,7 +317,7 @@ let suite = Zekr.suite(
     test("View.Text renders formatted MaybeSignal children", () => {
       let {container} = Dom.render("")
       let nameSignal = Signal.make("Ada")
-      let reactiveName: MaybeSignal.t<string> = MaybeSignal.signal(nameSignal)
+      let reactiveName: MaybeSignal.t<string> = MaybeSignal.reactive(nameSignal)
       let _ = mountTo(
         <p>
           <View.Text> {() => `Hello, ${MaybeSignal.get(reactiveName)}`} </View.Text>
@@ -339,7 +339,7 @@ let suite = Zekr.suite(
 
       let _ = mountTo(
         <View.Value
-          value={MaybeSignal.signal(selected)}
+          value={MaybeSignal.reactive(selected)}
           render={isFirst =>
             if isFirst {
               <p> <View.Text> {first} </View.Text> </p>
@@ -606,7 +606,7 @@ let suite = Zekr.suite(
       let _ = mountTo(
         <ul>
           <View.For
-            each={MaybeSignal.signal(items)}
+            each={MaybeSignal.reactive(items)}
             by={item => item.id}
             render={item => <li> {View.text(item.label)} </li>}
           />
@@ -664,7 +664,7 @@ let suite = Zekr.suite(
       let _ = mountTo(
         <ul>
           <View.KeyedFor
-            each={MaybeSignal.signal(items)}
+            each={MaybeSignal.reactive(items)}
             by={item => item.id}
             render={item => <li> {View.text(item.label)} </li>}
           />

--- a/tests/MaybeSignal_test.res
+++ b/tests/MaybeSignal_test.res
@@ -22,12 +22,18 @@ let suite = Zekr.suite(
         assertEqual(MaybeSignal.get(reactiveValue), 2),
       ])
     }),
-    test("signal is an alias of reactive", () => {
-      let name = Signal.make("xote")
+    test("computed derives a reactive value from a computation", () => {
+      let first = Signal.make("Ada")
+      let last = Signal.make("Lovelace")
+      let full = MaybeSignal.computed(() => Signal.get(first) ++ " " ++ Signal.get(last))
+
+      let before = MaybeSignal.get(full)
+      Signal.set(last, "Byron")
 
       combineResults([
-        assertEqual(MaybeSignal.get(MaybeSignal.signal(name)), "xote"),
-        assertTrue(MaybeSignal.isReactive(MaybeSignal.signal(name))),
+        assertTrue(MaybeSignal.isReactive(full)),
+        assertEqual(before, "Ada Lovelace"),
+        assertEqual(MaybeSignal.get(full), "Ada Byron"),
       ])
     }),
     test("peek reads without tracking", () => {
@@ -76,16 +82,90 @@ let suite = Zekr.suite(
         assertEqual(MaybeSignal.get(doubledReactive), 10),
       ])
     }),
-    test("toSignal normalizes both variants to a signal", () => {
+    test("map runs the function once up front, then lazily", () => {
+      let count = Signal.make(2)
+      let runs = ref(0)
+      let doubled = MaybeSignal.reactive(count)->MaybeSignal.map(n => {
+        runs := runs.contents + 1
+        n * 2
+      })
+
+      let runsBeforeRead = runs.contents
+      let value = MaybeSignal.get(doubled)
+
+      combineResults([
+        /* Computed.make performs an initial computation to establish deps */
+        assertEqual(runsBeforeRead, 1),
+        assertEqual(runs.contents, 1),
+        assertEqual(value, 4),
+      ])
+    }),
+    test("map stays tracked inside an effect", () => {
+      let count = Signal.make(1)
+      let doubled = MaybeSignal.reactive(count)->MaybeSignal.map(n => n * 2)
+      let seen = ref([])
+
+      Effect.run(() => {
+        seen := Array.concat(seen.contents, [MaybeSignal.get(doubled)])
+        None
+      })
+
+      Signal.set(count, 3)
+
+      assertEqual(seen.contents, [2, 6])
+    }),
+    test("toSignal returns the source signal for reactive values", () => {
       let count = Signal.make(3)
-      let fromStatic = MaybeSignal.static(7)->MaybeSignal.toSignal
-      let fromReactive = MaybeSignal.reactive(count)->MaybeSignal.toSignal
+      let value = MaybeSignal.reactive(count)
+      let lifted = value->MaybeSignal.toSignal
 
       Signal.set(count, 4)
 
+      combineResults([assertTrue(lifted === count), assertEqual(Signal.get(lifted), 4)])
+    }),
+    test("toSignal lifts static values into a fresh detached signal", () => {
+      let value = MaybeSignal.static(7)
+      let first = value->MaybeSignal.toSignal
+      let second = value->MaybeSignal.toSignal
+
+      Signal.set(first, 99)
+
       combineResults([
-        assertEqual(Signal.get(fromStatic), 7),
-        assertEqual(Signal.get(fromReactive), 4),
+        /* Each call allocates its own signal ... */
+        assertFalse(first === second),
+        /* ... and writing to it does not reach the original or its siblings */
+        assertEqual(Signal.get(first), 99),
+        assertEqual(MaybeSignal.get(value), 7),
+        assertEqual(Signal.get(second), 7),
+      ])
+    }),
+    test("ofUnknown normalizes raw values, signals, thunks and wrapped values", () => {
+      let count = Signal.make(1)
+      let fromRaw: MaybeSignal.t<int> = MaybeSignal.ofUnknown(41)
+      let fromSignal: MaybeSignal.t<int> = MaybeSignal.ofUnknown(count)
+      let fromThunk: MaybeSignal.t<int> = MaybeSignal.ofUnknown(() => Signal.get(count) * 10)
+      let fromWrapped: MaybeSignal.t<int> = MaybeSignal.ofUnknown(MaybeSignal.static(7))
+
+      Signal.set(count, 2)
+
+      combineResults([
+        assertTrue(MaybeSignal.isStatic(fromRaw)),
+        assertEqual(MaybeSignal.get(fromRaw), 41),
+        assertTrue(MaybeSignal.isReactive(fromSignal)),
+        assertEqual(MaybeSignal.get(fromSignal), 2),
+        assertTrue(MaybeSignal.isReactive(fromThunk)),
+        assertEqual(MaybeSignal.get(fromThunk), 20),
+        assertTrue(MaybeSignal.isStatic(fromWrapped)),
+        assertEqual(MaybeSignal.get(fromWrapped), 7),
+      ])
+    }),
+    test("ofUnknown treats a plain object as a value, not a signal", () => {
+      let record = {"label": "plain"}
+      let value: MaybeSignal.t<{"label": string}> = MaybeSignal.ofUnknown(record)
+
+      combineResults([
+        assertTrue(MaybeSignal.isStatic(value)),
+        assertEqual(MaybeSignal.get(value)["label"], "plain"),
       ])
     }),
     test("works as a JSX prop on View primitives", () => {
@@ -94,7 +174,7 @@ let suite = Zekr.suite(
       let _ = mountTo(
         <p>
           <View.Text value={MaybeSignal.static("Hello, ")} />
-          <View.Text value={MaybeSignal.signal(label)} />
+          <View.Text value={MaybeSignal.reactive(label)} />
         </p>,
         container,
       )
@@ -106,6 +186,32 @@ let suite = Zekr.suite(
         assertEqual(before, "Hello, Ada"),
         assertEqual(Zekr__DomBindings.textContent(container), "Hello, Grace"),
       ])
+    }),
+    /* Element attributes accept untyped values, so no wrapper is needed there. */
+    test("element attributes accept a raw signal without a wrapper", () => {
+      let {container} = Dom.render("")
+      let cls = Signal.make("initial")
+      let _ = mountTo(<div class={cls}> {View.text("raw")} </div>, container)
+
+      let el = Dom.Query.getByText(container, "raw")
+      let before = Dom.Assert.toHaveClass(el, "initial")
+      Signal.set(cls, "updated")
+
+      combineResults([before, Dom.Assert.toHaveClass(el, "updated")])
+    }),
+    test("element attributes accept a thunk without a wrapper", () => {
+      let {container} = Dom.render("")
+      let active = Signal.make(false)
+      let _ = mountTo(
+        <div class={() => Signal.get(active) ? "on" : "off"}> {View.text("thunk")} </div>,
+        container,
+      )
+
+      let el = Dom.Query.getByText(container, "thunk")
+      let before = Dom.Assert.toHaveClass(el, "off")
+      Signal.set(active, true)
+
+      combineResults([before, Dom.Assert.toHaveClass(el, "on")])
     }),
     /* Prop is deprecated but must stay interchangeable with MaybeSignal. */
     test("deprecated Prop module is an alias of MaybeSignal", () => {
@@ -121,6 +227,16 @@ let suite = Zekr.suite(
         assertEqual(MaybeSignal.get(fromMaybeSignal), "legacy"),
         assertEqual(read, "legacy"),
       ])
+    }),
+    test("a Prop.t value is accepted by a prop typed MaybeSignal.t", () => {
+      let {container} = Dom.render("")
+      let visible = @warning("-3") Prop.signal(Signal.make(true))
+      let _ = mountTo(
+        <View.Show when_={visible}> <p> {View.text("shown")} </p> </View.Show>,
+        container,
+      )
+
+      assertEqual(Zekr__DomBindings.textContent(container), "shown")
     }),
   ],
 )

--- a/tests/PublicApi_test.res
+++ b/tests/PublicApi_test.res
@@ -12,7 +12,7 @@ let suite = Zekr.suite(
         None
       })
 
-      let maybeSignal = MaybeSignal.signal(name)
+      let maybeSignal = MaybeSignal.reactive(name)
       let node: View.node = Html.div(
         ~attrs=[View.Attr.string("class", "app")],
         ~children=[View.text(MaybeSignal.get(maybeSignal))],


### PR DESCRIPTION
Follow-up to the MaybeSignal rename, addressing API-level feedback.

Simplify the API surface:
- drop `MaybeSignal.signal`, keeping `reactive` as the single spelling that matches the `Reactive` constructor and `isReactive`
- add `MaybeSignal.computed(fn)` so callers stop writing `reactive(Computed.make(fn))`
- drop the newly added `XoteJSX.MaybeSignal`, `Router.Link.MaybeSignal`, and `View.isMaybeSignal` aliases rather than growing the surface

Collapse the duplicated coercion into `MaybeSignal.ofUnknown`, now shared by `RuntimeJsxProp`, `View.valuePrimitive`, and the hand-written `jsx-runtime.mjs`, which each reimplemented the raw / signal / thunk / wrapped ladder. Signal detection is now structural (`RuntimeValue.isSignalLike`) instead of "any object", so a plain record passed to an untyped prop is treated as a value rather than silently read as a signal, and both runtimes agree on what counts as reactive. Attribute thunks keep the lazy `Compute` encoding.

Make the deprecation actually work. ReScript only reports warning 3 for values declared in an interface file, so `@deprecated` on Prop.res's let bindings was inert; the deprecations now live in `src/Prop.resi`. `XoteJSX.Prop` and `Router.Link.Prop` re-export the deprecated module instead of aliasing `MaybeSignal` directly, so those paths warn too.

Correct the documentation that did not match the runtime:
- `map` runs its function once immediately (Computed.make performs an initial computation); it is not fully lazy, and it leaves a computed subscribed to the source until disposed
- `toSignal` lifts a `Static` into a fresh detached signal, not a constant one: each call allocates, and writes to the result never reach the original
- computeds do not auto-dispose in rescript-signals 3.x, and the declared dependency is ^3.1.0, not ^2.1.0

Document when the wrapper is needed at all: element attributes and View.Text/Int/Float/Bool accept raw values, signals and thunks directly, so the README no longer teaches `class={MaybeSignal.reactive(sig)}` where a bare signal works. The wrapper is for props with a declared type. Also fixes a docs example that read a signal once at construction while claiming to be reactive.

Tests cover the corrected semantics, `ofUnknown`, unwrapped signal and thunk attributes, and a `Prop.t` value flowing into a `MaybeSignal.t` prop.


