### PR TITLE
feat(jsx): add attrs escape hatch and removable attributes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,9 @@ The root `xote` entry is client-focused and does not export router, SSR, hydrati
 These three are thin shims (`src/Signal.res`, `src/Computed.res`, `src/Effect.res`) that `include` the corresponding modules from `rescript-signals`.
 
 **Xote Modules:**
-- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
+- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
 - **`Xote.Html`**: Convenience constructors for common HTML tags (`div`, `span`, `button`, `input`, `h1`-`h3`, `p`, `ul`, `li`, `a`). Thin wrappers over `View.element`. For tags not listed, call `View.element(tag, ...)` directly or use JSX.
-- **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes). Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `View.LazyComponent`.
+- **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes) plus an `attrs` escape hatch for anything else. Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `View.LazyComponent`.
 - **`Xote.MaybeSignal`**: Static-or-reactive value wrapper exposing the type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` plus `static`, `reactive`, `computed` (derives a `Reactive` from a `unit => 'a`), `get` (tracked read), `peek` (untracked read), `isStatic`/`isReactive`, `map`, `toSignal`, and `ofUnknown`. Use it anywhere an API should accept either a plain value or a signal — JSX props are the most common case, not the only one. Notes on the trickier members:
   - `map` runs its function once immediately in both cases. For a `Reactive` value the result is backed by a `Computed`, which stays subscribed to the source until `Computed.dispose` is called on it, so prefer holding a mapped value over rebuilding it per update.
   - `toSignal` returns the source signal for `Reactive`, but lifts `Static` into a **fresh, detached** signal — each call allocates a new one and writing to the result does not reach the original. Treat that result as read-only.
@@ -123,6 +123,7 @@ Xote supports **two syntax styles**:
    - `attr("key", "value")` - static string attribute
    - `signalAttr("key", signal)` - reactive attribute from a signal
    - `computedAttr("key", () => ...)` - reactive attribute from a computed function
+   - `optionalAttr("key", option)`, `optionalSignalAttr("key", signal)`, `optionalComputedAttr("key", () => ...)` - the same three over `option<string>`, where `None` **removes** the attribute (see "Attribute & Property Handling")
 5. **Lists**:
    - `each(signal, renderItem)` - simple reactive list (re-renders all items on change)
    - `eachWithKey(signal, keyFn, renderItem)` - efficient keyed list with DOM reconciliation (preserves element identity, only updates changed items)
@@ -155,6 +156,7 @@ let app = () => {
   - Global: `draggable`, `hidden`, `contentEditable`, `spellcheck`
   - Accessibility: `role`, `tabIndex`, `ariaLabel`, `ariaHidden`, `ariaExpanded`, `ariaSelected`
   - Data: `data` (an `Obj.t`/`Dict.t` expanded into `data-*` attributes)
+  - Escape hatch: `attrs` (see below) for anything without a typed prop
   - SVG root: `xmlns`, `xmlnsXlink`, `version`, `viewBox`, `preserveAspectRatio`
   - SVG geometry: `d`, `pathLength`, `cx`, `cy`, `r`, `rx`, `ry`, `x`, `y`, `x1`, `y1`, `x2`, `y2`, `fx`, `fy`, `dx`, `dy`, `points`, `transform`, `transformOrigin`
   - SVG presentation: `fill`, `fillOpacity`, `fillRule`, `stroke`, `strokeWidth`, `strokeLinecap`, `strokeLinejoin`, `strokeDasharray`, `strokeDashoffset`, `strokeOpacity`, `strokeMiterlimit`, `opacity`, `color`, `visibility`, `vectorEffect`, `pointerEvents`
@@ -166,7 +168,8 @@ let app = () => {
 - Props support raw values, `MaybeSignal.t<'a>` (`Static` / `Reactive`), raw `Signal.t<'a>`, or a computed `unit => 'a` function for flexible static/reactive handling. These element props are untyped by design (each is its own type variable, resolved at runtime by `MaybeSignal.ofUnknown`), so `class={42}` compiles and renders `class="42"` — the trade for not requiring a wrapper. Props with a declared type (`View.Show`, `View.For`, `View.Maybe`, `View.Value`, and user components) take a `MaybeSignal.t` and are checked normally
 - Event handlers: `onClick`, `onInput`, `onChange`, `onSubmit`, `onFocus`, `onBlur`, `onKeyDown`, `onKeyUp`, `onMouseEnter`, `onMouseLeave`, `onMouseDown`, `onMouseMove`, `onMouseUp`, `onContextMenu`, plus drag-and-drop: `onDrag`, `onDragStart`, `onDragEnd`, `onDragOver`, `onDragEnter`, `onDragLeave`, `onDrop`
 - Children are passed via JSX syntax and rendered as nodes
-- Boolean attributes (`disabled`, `checked`, `required`, `readOnly`, `multiple`, `autofocus`, `ariaHidden`, `ariaExpanded`, `ariaSelected`, `draggable`, `hidden`, `contentEditable`, `spellcheck`) are added/removed based on the value rather than stringified
+- Boolean attributes (`disabled`, `checked`, `required`, `readOnly`, `multiple`, `autofocus`, `draggable`, `hidden`, `contentEditable`, `spellcheck`) are added/removed based on the value rather than stringified. `ariaHidden`/`ariaExpanded`/`ariaSelected` are not: ARIA is enumerated, so they render `aria-expanded="false"` rather than dropping the attribute
+- `attrs` is the escape hatch for attributes the typed props do not cover — `aria-controls`, `aria-labelledby`, `aria-valuenow`, presence-toggled state attributes, and anything else. Entries are `(key, value)` pairs merged **after** the typed props, so an entry overrides a prop with the same key (the prop is dropped, not rendered twice). A value accepts everything a typed attribute prop accepts (raw value, `Signal.t`, `unit => 'a` thunk, `MaybeSignal.t`, `None`) as well as a `View.attrValue` built with `View.attr`/`View.optionalComputedAttr`/… — which is also how one array mixes static and reactive entries, since the array's values share a single type. `Router.Link` takes the same `attrs` prop
 
 ### Router
 
@@ -179,7 +182,7 @@ Signal-based client-side router with:
 - **Scroll restoration**: Saves/restores scroll position on back/forward navigation via `history.state`
 - **Global singleton**: Uses `Symbol.for("xote.router.state")` on `globalThis` so all Xote bundles share router state
 - **Link component**: `Router.link(~to, ~attrs, ~children, ())` for navigation without page reload
-- **JSX Link**: `<Router.Link to="/path" class="nav-link">` for declarative navigation in JSX
+- **JSX Link**: `<Router.Link to="/path" class="nav-link">` for declarative navigation in JSX; takes the same `attrs` escape hatch as HTML elements (`attrs=[("aria-current", "page")]`)
 
 ### SSR & Hydration
 
@@ -216,8 +219,11 @@ Full server-side rendering with client-side hydration:
 
 The `DOM.setAttrOrProp` helper (in `View.res`, via the internal `RuntimeDom` module) handles the distinction between HTML attributes and DOM properties:
 - `value`, `checked`, `disabled` are set as DOM properties (not attributes)
-- Boolean attributes (`required`, `readonly`, `multiple`, `aria-hidden`, `aria-expanded`, `aria-selected`, `draggable`, `hidden`, `contenteditable`, `spellcheck`, `autofocus`) are added or removed based on whether the serialized value is `"true"`
+- Boolean attributes (`checked`, `disabled`, `required`, `readonly`, `multiple`, `draggable`, `hidden`, `contenteditable`, `spellcheck`, `autofocus`) are added or removed based on whether the serialized value is `"true"`. ARIA attributes are deliberately **not** on that list — they are enumerated, so `aria-expanded`, `aria-selected`, and `aria-hidden` render their literal `"true"`/`"false"` value
+- A **missing value removes the attribute**: `None` from an optional attribute, or a `null`/`undefined` coming out of an untyped JSX value, calls `removeAttribute` (or resets the property for `value`/`checked`/`disabled`) instead of writing the string `"undefined"`. This is what presence-based styling needs — `data-checked:bg-primary` compiles to `[data-checked]`, so an attribute that is always present, even as `""`, always matches
 - All other attributes use `setAttribute`
+
+`View.attrValue` therefore has six variants: `Static`/`SignalValue`/`Compute` over `string`, and `OptionalStatic`/`OptionalSignalValue`/`OptionalCompute` over `option<string>`. Renderers do not match on them directly — `View.resolveAttr` reduces any of them to `ReadStatic(Nullable.t<string>)` (a value known up front) or `ReadReactive(unit => Nullable.t<string>)` (a read that must run inside an effect), and `View.peekAttr` returns the current value untracked for SSR. Client render, hydration, and SSR all go through those two, so a new variant only has to be handled once.
 
 ## Key Concepts for Development
 
@@ -366,6 +372,18 @@ Html.button(
   ],
   ()
 )
+
+// Optional: None removes the attribute instead of writing a value.
+// Presence-based styling ([data-checked], [data-open]) needs the removal.
+Html.button(
+  ~attrs=[
+    View.optionalComputedAttr("data-checked", () =>
+      Signal.get(isChecked) ? Some("") : None
+    ),
+    View.optionalAttr("aria-describedby", descriptionId),  // option<string>
+  ],
+  ()
+)
 ```
 
 ### Lists
@@ -404,6 +422,30 @@ View.eachWithKey(
   onInput={handleInput}
 />
 ```
+
+#### Attributes without a typed prop (`attrs`)
+
+```rescript
+// Untyped entries — same values as any other JSX attribute
+<div role="tablist" attrs=[("aria-controls", "panel-1"), ("aria-orientation", "horizontal")]>
+  ...
+</div>
+
+// View.attrValue entries — typed, and the way to mix static and reactive
+<button
+  role="switch"
+  attrs=[
+    View.attr("aria-controls", panelId),
+    View.computedAttr("aria-checked", () => Signal.get(checked) ? "true" : "false"),
+    // present as `data-checked` only while checked, so [data-checked] matches
+    View.optionalComputedAttr("data-checked", () => Signal.get(checked) ? Some("") : None),
+  ]>
+  {View.text("Toggle")}
+</button>
+```
+
+`attrs` is merged after the typed props, so `<div class="a" attrs=[("class", "b")] />`
+renders `class="b"` once.
 
 #### Static-or-reactive values with MaybeSignal
 Built-in element attributes and `View.Text`/`Int`/`Float`/`Bool` are untyped and
@@ -548,7 +590,7 @@ Guidance for AI coding agents (and humans) making changes to this repository.
 - **Signal reads in effects**: Use `Signal.get` (creates dependency) vs `Signal.peek` (no dependency). Using `get` inside an effect will re-run the effect when the signal changes.
 - **Owner disposal**: When removing DOM elements with reactive state, ensure the owner system cleans up (handled automatically by `Render.disposeElement`)
 - **Router init**: `Router.init()` must be called before any routing functions on the client. For SSR, use `Router.initSSR(~pathname, ())` instead to avoid accessing browser APIs.
-- **Boolean attributes**: Use string `"true"`/`"false"` - the `setAttrOrProp` function handles the conversion to proper DOM behavior
+- **Boolean attributes**: Use string `"true"`/`"false"` - the `setAttrOrProp` function handles the conversion to proper DOM behavior. To *remove* an attribute reactively, use the optional helpers (`View.optionalComputedAttr(key, () => ... ? Some("") : None)`) rather than adding the key to `RuntimeAttr.booleanAttributes`
 - **SSR state cleanup**: Call `SSRState.clear()` between multiple renders on the server to reset the state registry
 
 ### Code Style

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -97,15 +97,19 @@ Attributes are represented as `(string, View.attrValue)` pairs:
 - `View.Attr.string(key, value)` for static string attributes.
 - `View.Attr.signal(key, signal)` for reactive string attributes.
 - `View.Attr.compute(key, fn)` for computed string attributes.
-- `View.attr`, `View.signalAttr`, and `View.computedAttr` are equivalent shorthands for the `View.Attr.*` helpers.
+- `View.Attr.optional(key, value)`, `View.Attr.optionalSignal(key, signal)`, and `View.Attr.optionalCompute(key, fn)` for `option<string>` values, where `None` removes the attribute.
+- `View.attr`, `View.signalAttr`, `View.computedAttr`, `View.optionalAttr`, `View.optionalSignalAttr`, and `View.optionalComputedAttr` are equivalent shorthands for the `View.Attr.*` helpers.
+
+`View.resolveAttr` reduces any of those to how it must be applied — `ReadStatic(value)` for a value known up front, `ReadReactive(read)` for one that has to run inside an effect — and `View.peekAttr` reads the current value untracked. The DOM renderer, hydration, and SSR all go through them, so all six variants behave identically across the three.
 
 The DOM renderer maps selected names to DOM properties or boolean attribute behavior:
 
 - `value`, `checked`, and `disabled` are set as properties.
-- Boolean attributes such as `required`, `readonly`, `multiple`, `hidden`, `autofocus`, and selected ARIA/global attributes are added for `"true"` and removed otherwise.
+- Boolean attributes such as `required`, `readonly`, `multiple`, `hidden`, `autofocus`, `draggable`, `contenteditable`, and `spellcheck` are added for `"true"` and removed otherwise. ARIA attributes are *not* in that list: they are enumerated, so `aria-expanded` keeps its literal `"true"`/`"false"` value.
+- A missing value (`None`, `null`, `undefined`) removes the attribute — `removeAttribute`, or resetting the property for `value`/`checked`/`disabled` — instead of writing the string `"undefined"`. That is what presence-based selectors such as `[data-open]` need.
 - Other attributes use `setAttribute`.
 
-SSR mirrors the same boolean attribute behavior when rendering strings.
+SSR mirrors the same behavior when rendering strings: boolean attributes render bare, and an attribute with no value is not rendered at all.
 
 ### JSX Support
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "src/**/*.resi",
     "src/**/*.res.mjs",
     "src/*.mjs",
-    "rescript.json"
+    "rescript.json",
+    "AGENTS.md"
   ],
   "scripts": {
     "res:build": "rescript",

--- a/src/Hydration.res
+++ b/src/Hydration.res
@@ -257,21 +257,12 @@ let rec hydrateNode = (node: View.node, domNode: Dom.element): unit => {
       Reactivity.runWithOwner(owner, () => {
         /* Hydrate reactive attributes */
         attrs->Array.forEach(((key, value)) => {
-          switch value {
-          | View.Static(_) => () /* Already rendered, nothing to do */
-          | View.SignalValue(signal) => {
+          switch View.resolveAttr(value) {
+          | View.ReadStatic(_) => () /* Already rendered, nothing to do */
+          | View.ReadReactive(read) => {
               let disposer = Effect.runWithDisposer(
                 () => {
-                  DOM.setAttrOrProp(domNode, key, Signal.get(signal))
-                  None
-                },
-              )
-              Reactivity.addDisposer(owner, disposer)
-            }
-          | View.Compute(compute) => {
-              let disposer = Effect.runWithDisposer(
-                () => {
-                  DOM.setAttrOrProp(domNode, key, compute())
+                  DOM.setAttrOrProp(domNode, key, read())
                   None
                 },
               )
@@ -589,21 +580,12 @@ and hydrateNodeWithWalker = (node: View.node, walker: DOMWalker.t): unit => {
         Reactivity.runWithOwner(owner, () => {
           /* Hydrate reactive attributes */
           attrs->Array.forEach(((key, value)) => {
-            switch value {
-            | View.Static(_) => ()
-            | View.SignalValue(signal) => {
+            switch View.resolveAttr(value) {
+            | View.ReadStatic(_) => ()
+            | View.ReadReactive(read) => {
                 let disposer = Effect.runWithDisposer(
                   () => {
-                    DOM.setAttrOrProp(domNode, key, Signal.get(signal))
-                    None
-                  },
-                )
-                Reactivity.addDisposer(owner, disposer)
-              }
-            | View.Compute(compute) => {
-                let disposer = Effect.runWithDisposer(
-                  () => {
-                    DOM.setAttrOrProp(domNode, key, compute())
+                    DOM.setAttrOrProp(domNode, key, read())
                     None
                   },
                 )

--- a/src/Router.res
+++ b/src/Router.res
@@ -428,7 +428,7 @@ module Link = {
    Use `MaybeSignal` directly. */
   module Prop = Prop
 
-  type props<'class, 'id, 'style, 'target, 'ariaLabel> = {
+  type props<'class, 'id, 'style, 'target, 'ariaLabel, 'attrs> = {
     /* Required navigation prop */
     to: string,
     /* Common attributes - can be static or reactive */
@@ -437,6 +437,10 @@ module Link = {
     style?: 'style,
     target?: 'target,
     @as("aria-label") ariaLabel?: 'ariaLabel,
+    /* Escape hatch for attributes with no prop of their own (`aria-current`,
+     `rel`, `data-*`, ...), merged after them. Same values as
+     `XoteJSX.Elements`'s `attrs`. */
+    attrs?: array<(string, 'attrs)>,
     /* Event handlers */
     onClick?: Dom.event => unit,
     /* Children */
@@ -472,7 +476,14 @@ module Link = {
     | None => ()
     }
 
-    attrs
+    switch props.attrs {
+    | Some(entries) =>
+      RuntimeJsxProp.mergeAttrs(
+        attrs,
+        entries->Array.map(((key, value)) => RuntimeJsxProp.toAttrEntry(key, value)),
+      )
+    | None => attrs
+    }
   }
 
   /* Extract children from props */

--- a/src/RuntimeAttr.res
+++ b/src/RuntimeAttr.res
@@ -1,12 +1,17 @@
+/* Attributes whose presence carries the meaning: they are written with an empty
+ value when true and removed when false.
+
+ ARIA state is deliberately absent from this list. `aria-expanded`,
+ `aria-checked`, `aria-selected`, ... are enumerated attributes, so they carry a
+ literal "true"/"false" string — rendering them as bare presence loses the
+ "false" state. Removing any attribute, ARIA or not, is expressed with an
+ optional attribute value (`View.optionalAttr(key, None)` and friends). */
 let booleanAttributes = [
   "checked",
   "disabled",
   "required",
   "readonly",
   "multiple",
-  "aria-hidden",
-  "aria-expanded",
-  "aria-selected",
   "draggable",
   "hidden",
   "contenteditable",

--- a/src/RuntimeDom.res
+++ b/src/RuntimeDom.res
@@ -86,17 +86,35 @@ external addEventListener: (Dom.element, string, Dom.event => unit) => unit = "a
 let createElementForTag = (tag: string): Dom.element =>
   isSvgTag(tag) ? createElementNS(svgNamespace, tag) : createElement(tag)
 
-let setAttrOrProp = (el: Dom.element, key: string, value: string): unit => {
+let removeAttrOrProp = (el: Dom.element, key: string): unit => {
   switch key {
-  | "value" => setValue(el, value)
-  | "checked" => setChecked(el, value == "true")
-  | "disabled" => setDisabled(el, value == "true")
-  | _ if RuntimeAttr.isBoolean(key) =>
-    if RuntimeAttr.shouldRenderBoolean(value) {
-      setAttribute(el, key, "")
-    } else {
-      removeAttribute(el, key)
+  | "value" => setValue(el, "")
+  | "checked" => setChecked(el, false)
+  | "disabled" => setDisabled(el, false)
+  | _ => removeAttribute(el, key)
+  }
+}
+
+/* The value is nullable: `null`/`undefined` (a `None` coming out of an optional
+ attribute, or an untyped JSX value that resolved to nothing) removes the
+ attribute instead of writing the string "undefined". That is what
+ presence-based selectors such as `[data-open]` need — an attribute that is
+ always present, even as `""`, is always matched. */
+let setAttrOrProp = (el: Dom.element, key: string, value: Nullable.t<string>): unit => {
+  switch value->Nullable.toOption {
+  | None => removeAttrOrProp(el, key)
+  | Some(value) =>
+    switch key {
+    | "value" => setValue(el, value)
+    | "checked" => setChecked(el, value == "true")
+    | "disabled" => setDisabled(el, value == "true")
+    | _ if RuntimeAttr.isBoolean(key) =>
+      if RuntimeAttr.shouldRenderBoolean(value) {
+        setAttribute(el, key, "")
+      } else {
+        removeAttribute(el, key)
+      }
+    | _ => setAttribute(el, key, value)
     }
-  | _ => setAttribute(el, key, value)
   }
 }

--- a/src/RuntimeJsxProp.res
+++ b/src/RuntimeJsxProp.res
@@ -24,3 +24,42 @@ let toBoolAttr = (key: string, value: 'a): (string, View.attrValue) =>
     | Reactive(signal) => View.signalAttr(key, signal)
     }
   }
+
+/* Tags of `View.attrValue`, so an `attrs` escape-hatch entry already built with
+ `View.attr` & friends passes straight through instead of being coerced again.
+ `Static` is left out on purpose: it is also `MaybeSignal.Static`, and both mean
+ the same thing here — a plain value for `key` — so it takes the shared path. */
+let attrValueTags = [
+  "SignalValue",
+  "Compute",
+  "OptionalStatic",
+  "OptionalSignalValue",
+  "OptionalCompute",
+]
+
+/* One entry of the untyped `attrs` escape hatch. The value may be a
+ `View.attrValue`, or the same shapes every other JSX attribute accepts: a raw
+ value, a `Signal.t`, a `unit => 'a` thunk, a `MaybeSignal.t`, or nothing at all
+ (`None`/null, which removes the attribute). */
+let toAttrEntry = (key: string, value: 'a): (string, View.attrValue) =>
+  switch RuntimeValue.getTag(value) {
+  | Some(tag) if attrValueTags->Array.includes(tag) => (key, Obj.magic(value))
+  | _ => toStringAttr(key, value)
+  }
+
+/* Escape-hatch entries are merged after the typed props and the last entry for
+ a key wins. Keeping both would render the attribute twice, which is invalid
+ HTML on the server and, in the browser, leaves whichever effect ran last in
+ charge of a value the other one keeps overwriting. */
+let mergeAttrs = (
+  base: array<(string, View.attrValue)>,
+  extra: array<(string, View.attrValue)>,
+): array<(string, View.attrValue)> =>
+  if extra->Array.length == 0 {
+    base
+  } else {
+    let combined = base->Array.concat(extra)
+    let lastIndex = Dict.make()
+    combined->Array.forEachWithIndex(((key, _), index) => lastIndex->Dict.set(key, index))
+    combined->Array.filterWithIndex(((key, _), index) => lastIndex->Dict.get(key) == Some(index))
+  }

--- a/src/RuntimeValue.res
+++ b/src/RuntimeValue.res
@@ -19,6 +19,17 @@ let isMaybeSignal = (value: 'value): bool => {
   }
 }
 
+/* Variant tag of a value, when it is a tagged variant at all. Used to tell one
+ runtime-shaped variant from another where JSX hands us untyped values. */
+let getTag = (value: 'value): option<string> =>
+  switch value->Core.Type.Classify.classify {
+  | Object(obj) => {
+      let obj: {..} = Obj.magic(obj)
+      obj->Core.Object.get("TAG")
+    }
+  | _ => None
+  }
+
 let isFunction = (value: 'value): bool =>
   switch value->Core.Type.Classify.classify {
   | Function(_) => true

--- a/src/SSR.res
+++ b/src/SSR.res
@@ -17,20 +17,20 @@ type renderOptions = {
 module Attributes = {
   /* Render a single attribute to string */
   let renderAttr = ((key, value): (string, View.attrValue)): string => {
-    let attrValue = switch value {
-    | View.Static(v) => v
-    | View.SignalValue(signal) => Signal.peek(signal)
-    | View.Compute(fn) => fn()
-    }
-
-    if RuntimeAttr.isBoolean(key) {
-      if RuntimeAttr.shouldRenderBoolean(attrValue) {
-        key
+    /* A missing value means the attribute is not rendered at all, matching the
+     `removeAttribute` the client does for the same value. */
+    switch View.peekAttr(value)->Nullable.toOption {
+    | None => ""
+    | Some(attrValue) =>
+      if RuntimeAttr.isBoolean(key) {
+        if RuntimeAttr.shouldRenderBoolean(attrValue) {
+          key
+        } else {
+          ""
+        }
       } else {
-        ""
+        `${key}="${Html.escape(attrValue)}"`
       }
-    } else {
-      `${key}="${Html.escape(attrValue)}"`
     }
   }
 

--- a/src/View.res
+++ b/src/View.res
@@ -6,11 +6,19 @@ module Core = RescriptCore
  * Type Definitions
  * ============================================================================ */
 
-/* Attribute value source */
+/* Attribute value source.
+
+ The `Optional*` variants carry an `option<string>`, where `None` means "remove
+ this attribute" rather than "write an empty value". Presence-based styling
+ (`[data-open]`, `[data-checked]`) needs that distinction: an attribute that is
+ always present, even as `""`, always matches. */
 type attrValue =
   | Static(string)
   | SignalValue(Signal.t<string>)
   | Compute(unit => string)
+  | OptionalStatic(option<string>)
+  | OptionalSignalValue(Signal.t<option<string>>)
+  | OptionalCompute(unit => option<string>)
 
 /* Virtual node types */
 type rec node =
@@ -44,18 +52,64 @@ module Attributes = {
     key,
     Compute(compute),
   )
+
+  let optional = (key: string, value: option<string>): (string, attrValue) => (
+    key,
+    OptionalStatic(value),
+  )
+
+  let optionalSignal = (key: string, signal: Signal.t<option<string>>): (string, attrValue) => (
+    key,
+    OptionalSignalValue(signal),
+  )
+
+  let optionalComputed = (key: string, compute: unit => option<string>): (string, attrValue) => (
+    key,
+    OptionalCompute(compute),
+  )
 }
 
 /* Public API for attributes */
 let attr = Attributes.static
 let signalAttr = Attributes.signal
 let computedAttr = Attributes.computed
+let optionalAttr = Attributes.optional
+let optionalSignalAttr = Attributes.optionalSignal
+let optionalComputedAttr = Attributes.optionalComputed
 
 module Attr = {
   let string = attr
   let signal = signalAttr
   let compute = computedAttr
+  let optional = optionalAttr
+  let optionalSignal = optionalSignalAttr
+  let optionalCompute = optionalComputedAttr
 }
+
+/* An `attrValue` reduced to how it has to be applied: a value that is known up
+ front, or a read that must run inside an effect. Both are nullable because a
+ missing value removes the attribute. */
+type attrRead =
+  | ReadStatic(Nullable.t<string>)
+  | ReadReactive(unit => Nullable.t<string>)
+
+let resolveAttr = (value: attrValue): attrRead =>
+  switch value {
+  | Static(value) => ReadStatic(Nullable.make(value))
+  | OptionalStatic(value) => ReadStatic(Nullable.fromOption(value))
+  | SignalValue(signal) => ReadReactive(() => Nullable.make(Signal.get(signal)))
+  | OptionalSignalValue(signal) => ReadReactive(() => Nullable.fromOption(Signal.get(signal)))
+  | Compute(compute) => ReadReactive(() => Nullable.make(compute()))
+  | OptionalCompute(compute) => ReadReactive(() => Nullable.fromOption(compute()))
+  }
+
+/* Current value of an attribute without subscribing to it — SSR renders a
+ snapshot, so it must not register dependencies. */
+let peekAttr = (value: attrValue): Nullable.t<string> =>
+  switch resolveAttr(value) {
+  | ReadStatic(value) => value
+  | ReadReactive(read) => Signal.untrack(read)
+  }
 
 /* ============================================================================
  * Rendering
@@ -321,22 +375,12 @@ module Render = {
             tag == "select" && key == "value"
 
           let applyAttr = ((key, value)) => {
-            switch value {
-            | Static(v) => DOM.setAttrOrProp(el, key, v)
-            | SignalValue(signal) => {
-                DOM.setAttrOrProp(el, key, Signal.peek(signal))
+            switch resolveAttr(value) {
+            | ReadStatic(value) => DOM.setAttrOrProp(el, key, value)
+            | ReadReactive(read) => {
                 let disposer = Effect.runWithDisposer(
                   () => {
-                    DOM.setAttrOrProp(el, key, Signal.get(signal))
-                    None
-                  },
-                )
-                addDisposer(owner, disposer)
-              }
-            | Compute(compute) => {
-                let disposer = Effect.runWithDisposer(
-                  () => {
-                    DOM.setAttrOrProp(el, key, compute())
+                    DOM.setAttrOrProp(el, key, read())
                     None
                   },
                 )

--- a/src/XoteJSX.res
+++ b/src/XoteJSX.res
@@ -158,6 +158,8 @@ module Elements = {
     'markerMid,
     'markerEnd,
     'xlinkHref,
+    /* Escape hatch */
+    'attrs,
   > = {
     /* Standard attributes - accept raw strings or MaybeSignal.t<string> */
     id?: 'id,
@@ -211,6 +213,15 @@ module Elements = {
     @as("aria-selected") ariaSelected?: 'ariaSelected,
     /* Data attributes */
     data?: Obj.t,
+    /* Escape hatch for attributes with no typed prop — `aria-controls`,
+     `aria-valuenow`, presence-toggled state attributes, ... Entries are merged
+     after the typed props, so an entry here overrides a prop with the same key.
+     Values accept everything a typed attribute prop accepts (raw value,
+     `Signal.t`, `unit => 'a` thunk, `MaybeSignal.t`, `None`) as well as a
+     `View.attrValue` built with `View.attr`/`View.optionalComputedAttr`/... —
+     which is also how a single array mixes static and reactive entries, since
+     they then share one type. */
+    attrs?: array<(string, 'attrs)>,
     /* SVG attributes - root */
     xmlns?: 'xmlns,
     @as("xmlns:xlink") xmlnsXlink?: 'xmlnsXlink,
@@ -488,7 +499,15 @@ module Elements = {
     | None => ()
     }
 
-    attrs
+    /* Escape hatch, merged last so it wins over the typed props */
+    switch props.attrs {
+    | Some(entries) =>
+      RuntimeJsxProp.mergeAttrs(
+        attrs,
+        entries->Array.map(((key, value)) => RuntimeJsxProp.toAttrEntry(key, value)),
+      )
+    | None => attrs
+    }
   }
 
   /* Helper to add optional event handler to events array */

--- a/src/jsx-runtime.mjs
+++ b/src/jsx-runtime.mjs
@@ -108,7 +108,13 @@ function normalizeStyle(style) {
     .join(";");
 }
 
+// `undefined` means "no attribute": View removes it instead of writing the
+// string "undefined", which is what presence-based selectors need.
 function stringifyAttrValue(name, value) {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
   if (name === "style") {
     return normalizeStyle(value);
   }
@@ -131,6 +137,39 @@ function attrFromValue(name, value) {
   return normalized.TAG === "Static"
     ? View.attr(name, normalized._0)
     : View.signalAttr(name, normalized._0);
+}
+
+// Tags of View.attrValue, so an `attrs` entry already built with View.attr &
+// friends passes through untouched. "Static" is absent for the same reason as
+// in RuntimeJsxProp: it is also MaybeSignal.Static, and both take the same path.
+const attrValueTags = new Set([
+  "SignalValue",
+  "Compute",
+  "OptionalStatic",
+  "OptionalSignalValue",
+  "OptionalCompute",
+]);
+
+function toAttrEntry(name, value) {
+  if (value && typeof value === "object" && attrValueTags.has(value.TAG)) {
+    return [name, value];
+  }
+
+  return attrFromValue(name, value);
+}
+
+// Later entries win, so an escape-hatch attribute replaces the prop of the same
+// name rather than rendering twice.
+function mergeAttrs(base, extra) {
+  if (extra.length === 0) {
+    return base;
+  }
+
+  const combined = base.concat(extra);
+  const lastIndex = new Map();
+  combined.forEach(([name], index) => lastIndex.set(name, index));
+
+  return combined.filter(([name], index) => lastIndex.get(name) === index);
 }
 
 function eventNameFromProp(name, value) {
@@ -167,10 +206,19 @@ function normalizeNode(value) {
 
 function buildElement(tag, props = {}) {
   const attrs = [];
+  const extraAttrs = [];
   const events = [];
 
   for (const [rawName, value] of Object.entries(props)) {
     if (internalProps.has(rawName) || value === null || value === undefined) {
+      continue;
+    }
+
+    // Escape hatch: [[name, value], ...] for attributes with no prop of their own.
+    if (rawName === "attrs") {
+      for (const [name, attrValue] of value) {
+        extraAttrs.push(toAttrEntry(name, attrValue));
+      }
       continue;
     }
 
@@ -184,7 +232,13 @@ function buildElement(tag, props = {}) {
     attrs.push(attrFromValue(attrName, value));
   }
 
-  return View.element(tag, attrs, events, normalizeChildren(props.children), undefined);
+  return View.element(
+    tag,
+    mergeAttrs(attrs, extraAttrs),
+    events,
+    normalizeChildren(props.children),
+    undefined,
+  );
 }
 
 function getReservedKey(props, key) {

--- a/tests/Component_test.res
+++ b/tests/Component_test.res
@@ -165,6 +165,58 @@ let suite = Zekr.suite(
       let r2 = Dom.Assert.toHaveTextContent(container, "AppleBananaCherry")
       combineResults([r1, r2])
     }),
+    test("optional attribute is not rendered when None", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        Html.div(
+          ~attrs=[View.optionalAttr("data-open", None), View.optionalAttr("data-state", Some(""))],
+          ~children=[View.text("panel")],
+          (),
+        ),
+        container,
+      )
+      let el = Dom.Query.getByText(container, "panel")
+      combineResults([
+        Dom.Assert.toNotHaveAttribute(el, "data-open"),
+        Dom.Assert.toHaveAttribute(el, "data-state", ~value=""),
+      ])
+    }),
+    test("optional computed attribute is removed when it becomes None", () => {
+      let {container} = Dom.render("")
+      let open_ = Signal.make(true)
+      let _ = mountTo(
+        Html.div(
+          ~attrs=[
+            View.optionalComputedAttr("data-open", () => Signal.get(open_) ? Some("") : None),
+          ],
+          ~children=[View.text("panel")],
+          (),
+        ),
+        container,
+      )
+      let el = Dom.Query.getByText(container, "panel")
+      let r1 = Dom.Assert.toHaveAttribute(el, "data-open", ~value="")
+      Signal.set(open_, false)
+      let r2 = Dom.Assert.toNotHaveAttribute(el, "data-open")
+      Signal.set(open_, true)
+      combineResults([r1, r2, Dom.Assert.toHaveAttribute(el, "data-open", ~value="")])
+    }),
+    test("optional signal attribute is removed when it becomes None", () => {
+      let {container} = Dom.render("")
+      let state = Signal.make(Some("open"))
+      let _ = mountTo(
+        Html.div(
+          ~attrs=[View.optionalSignalAttr("data-state", state)],
+          ~children=[View.text("panel")],
+          (),
+        ),
+        container,
+      )
+      let el = Dom.Query.getByText(container, "panel")
+      let r1 = Dom.Assert.toHaveAttribute(el, "data-state", ~value="open")
+      Signal.set(state, None)
+      combineResults([r1, Dom.Assert.toNotHaveAttribute(el, "data-state")])
+    }),
     test("lazy component defers evaluation", () => {
       let {container} = Dom.render("")
       let evaluated = ref(false)

--- a/tests/Hydration_test.res
+++ b/tests/Hydration_test.res
@@ -54,6 +54,26 @@ let suite = Zekr.suite(
       let r2 = Dom.Assert.toHaveClass(el, "updated")
       combineResults([r1, r2])
     }),
+    test("optional attributes toggle presence after hydration", () => {
+      let open_ = Signal.make(true)
+      let component = () =>
+        Html.div(
+          ~attrs=[View.optionalComputedAttr("data-open", () => Signal.get(open_) ? Some("") : None)],
+          ~children=[View.text("panel")],
+          (),
+        )
+      let ssrHtml = SSR.renderToString(component)
+      let {container} = Dom.render(ssrHtml)
+      Hydration.hydrate(component, container)
+      let el = Dom.Query.getByText(container, "panel")
+      let r1 = Dom.Assert.toHaveAttribute(el, "data-open", ~value="")
+      Signal.set(open_, false)
+      combineResults([
+        assertContains(ssrHtml, `data-open=""`),
+        r1,
+        Dom.Assert.toNotHaveAttribute(el, "data-open"),
+      ])
+    }),
     test("nested elements hydrate correctly", () => {
       let visible = Signal.make(true)
       let component = () =>

--- a/tests/JSXRuntime_test.mjs
+++ b/tests/JSXRuntime_test.mjs
@@ -77,6 +77,41 @@ assert.equal(
   '<svg viewBox="0 0 10 10" markerWidth="4"><path markerHeight="5"></path></svg>',
 );
 
+// Escape hatch: attributes with no prop of their own, merged after the props.
+assert.equal(
+  renderToString(
+    jsx("div", {
+      className: "from-prop",
+      attrs: [
+        ["aria-controls", "panel-1"],
+        ["class", "from-attrs"],
+        // View.attr returns the [name, value] pair an entry already is
+        View.attr("aria-valuenow", "50"),
+        View.optionalAttr("aria-valuetext", undefined),
+      ],
+      children: "ok",
+    }),
+  ),
+  '<div aria-controls="panel-1" class="from-attrs" aria-valuenow="50">ok</div>',
+);
+
+// A value that resolves to nothing removes the attribute instead of writing
+// the string "undefined".
+const open_ = Signal.make(true);
+const presence = jsx("div", {
+  attrs: [["data-open", () => (Signal.get(open_) ? "" : undefined)]],
+  children: "panel",
+});
+
+assert.equal(renderToString(presence), '<div data-open="">panel</div>');
+
+const presenceContainer = document.createElement("div");
+View.mount(presence, presenceContainer);
+const panel = presenceContainer.querySelector("div");
+assert.equal(panel.getAttribute("data-open"), "");
+Signal.set(open_, false);
+assert.equal(panel.hasAttribute("data-open"), false);
+
 const keyedFromProps = jsx("span", { key: "spread-key", children: "keyed" });
 assert.equal(keyedFromProps.TAG, "Keyed");
 assert.equal(keyedFromProps.key, "spread-key");

--- a/tests/JSX_test.res
+++ b/tests/JSX_test.res
@@ -694,6 +694,118 @@ let suite = Zekr.suite(
         assertTrue(objectIs(updatedApple, appleNode)),
       ])
     }),
+    test("attrs escape hatch renders attributes without a typed prop", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        <div
+          role="tablist"
+          attrs=[("aria-controls", "panel-1"), ("aria-orientation", "horizontal")]>
+          {View.text("Tabs")}
+        </div>,
+        container,
+      )
+      let el = Dom.Query.getByRole(container, "tablist")
+      combineResults([
+        Dom.Assert.toHaveAttribute(el, "aria-controls", ~value="panel-1"),
+        Dom.Assert.toHaveAttribute(el, "aria-orientation", ~value="horizontal"),
+      ])
+    }),
+    test("attrs escape hatch accepts View attribute values", () => {
+      let {container} = Dom.render("")
+      let level = Signal.make("50")
+      let _ = mountTo(
+        <div
+          role="slider"
+          attrs=[
+            View.attr("aria-valuemin", "0"),
+            View.attr("aria-valuemax", "100"),
+            View.signalAttr("aria-valuenow", level),
+          ]>
+          {View.text("Volume")}
+        </div>,
+        container,
+      )
+      let el = Dom.Query.getByRole(container, "slider")
+      let r1 = Dom.Assert.toHaveAttribute(el, "aria-valuenow", ~value="50")
+      Signal.set(level, "80")
+      combineResults([
+        r1,
+        Dom.Assert.toHaveAttribute(el, "aria-valuemin", ~value="0"),
+        Dom.Assert.toHaveAttribute(el, "aria-valuenow", ~value="80"),
+      ])
+    }),
+    test("attrs escape hatch overrides a typed prop with the same key", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        <div class="from-prop" attrs=[("class", "from-attrs")]> {View.text("Box")} </div>,
+        container,
+      )
+      let el = Dom.Query.getByText(container, "Box")
+      combineResults([
+        Dom.Assert.toHaveClass(el, "from-attrs"),
+        Dom.Assert.toNotHaveClass(el, "from-prop"),
+        /* The typed prop is dropped rather than rendered twice */
+        assertEqual(
+          SSR.renderToString(() =>
+            <div class="from-prop" attrs=[("class", "from-attrs")]> {View.text("Box")} </div>
+          ),
+          `<div class="from-attrs">Box</div>`,
+        ),
+      ])
+    }),
+    test("attrs escape hatch toggles presence-based state attributes", () => {
+      let {container} = Dom.render("")
+      let checked = Signal.make(false)
+      let _ = mountTo(
+        <button
+          role="switch"
+          attrs=[
+            View.optionalComputedAttr("data-checked", () => Signal.get(checked) ? Some("") : None),
+            View.optionalComputedAttr("aria-checked", () =>
+              Some(Signal.get(checked) ? "true" : "false")
+            ),
+          ]>
+          {View.text("Toggle")}
+        </button>,
+        container,
+      )
+      let el = Dom.Query.getByRole(container, "switch")
+      let r1 = Dom.Assert.toNotHaveAttribute(el, "data-checked")
+      let r2 = Dom.Assert.toHaveAttribute(el, "aria-checked", ~value="false")
+      Signal.set(checked, true)
+      combineResults([
+        r1,
+        r2,
+        Dom.Assert.toHaveAttribute(el, "data-checked", ~value=""),
+        Dom.Assert.toHaveAttribute(el, "aria-checked", ~value="true"),
+      ])
+    }),
+    test("a thunk returning None removes the attribute", () => {
+      let {container} = Dom.render("")
+      let open_ = Signal.make(true)
+      let _ = mountTo(
+        <div attrs=[("data-open", () => Signal.get(open_) ? Some("") : None)]>
+          {View.text("Panel")}
+        </div>,
+        container,
+      )
+      let el = Dom.Query.getByText(container, "Panel")
+      let r1 = Dom.Assert.toHaveAttribute(el, "data-open", ~value="")
+      Signal.set(open_, false)
+      combineResults([r1, Dom.Assert.toNotHaveAttribute(el, "data-open")])
+    }),
+    test("aria state props keep their true/false value", () => {
+      let {container} = Dom.render("")
+      let _ = mountTo(
+        <button ariaExpanded={false} ariaSelected={true}> {View.text("Menu")} </button>,
+        container,
+      )
+      let el = Dom.Query.getByRole(container, "button")
+      combineResults([
+        Dom.Assert.toHaveAttribute(el, "aria-expanded", ~value="false"),
+        Dom.Assert.toHaveAttribute(el, "aria-selected", ~value="true"),
+      ])
+    }),
   ],
   ~afterEach=() => Dom.cleanup(),
 )

--- a/tests/Route_test.res
+++ b/tests/Route_test.res
@@ -175,6 +175,34 @@ let suite = Zekr.suite(
         assertEqual(current.hash, "#computed-make"),
       ])
     }),
+    test("Router.Link renders attributes from the attrs escape hatch", () => {
+      Router.init()
+      let {container} = Dom.render("")
+
+      View.mount(
+        <Router.Link
+          to="/docs"
+          attrs=[
+            View.attr("rel", "prefetch"),
+            View.optionalComputedAttr("aria-current", () =>
+              Signal.get(Router.location()).pathname == "/docs" ? Some("page") : None
+            ),
+          ]>
+          {View.text("Docs")}
+        </Router.Link>,
+        container,
+      )
+
+      let link = Dom.Query.getByText(container, "Docs")
+      let r1 = combineResults([
+        assertEqual(getAttr(link, "rel"), "prefetch"),
+        Dom.Assert.toNotHaveAttribute(link, "aria-current"),
+      ])
+
+      Dom.Event.click(link)
+
+      combineResults([r1, Dom.Assert.toHaveAttribute(link, "aria-current", ~value="page")])
+    }),
     test("Router.link scrolls to hash targets after navigation", () => {
       Router.init()
       useImmediateMicrotask()

--- a/tests/SSR_test.res
+++ b/tests/SSR_test.res
@@ -108,6 +108,24 @@ let suite = Zekr.suite(
         assertFalse(String.includes(html, `disabled="true"`)),
       ])
     }),
+    test("skips optional attributes with no value", () => {
+      let html = SSR.renderToString(() =>
+        Html.div(
+          ~attrs=[
+            View.optionalAttr("data-open", None),
+            View.optionalComputedAttr("data-state", () => Some("closed")),
+          ],
+          (),
+        )
+      )
+      assertEqual(html, `<div data-state="closed"></div>`)
+    }),
+    test("renders aria state attributes with their value", () => {
+      let html = SSR.renderToString(() =>
+        Html.div(~attrs=[View.attr("aria-expanded", "false"), View.attr("aria-hidden", "true")], ())
+      )
+      assertEqual(html, `<div aria-expanded="false" aria-hidden="true"></div>`)
+    }),
     test("escapes attribute values", () => {
       let html = SSR.renderToString(() =>
         Html.div(~attrs=[View.attr("title", `say "hello" & goodbye`)], ())


### PR DESCRIPTION
Adds an `attrs` prop to JSX elements and `Router.Link` for attributes with no typed prop (`aria-controls`, `aria-valuenow`, etc), merged after the typed props. 

Adds `View.optionalAttr`/`optionalSignalAttr`/ `optionalComputedAttr`, where `None` removes the attribute instead of writing a value, so presence-based state attributes (`[data-open]`) work.

ARIA attributes now render their `"true"`/`"false"` value rather than being treated as presence-only booleans.