### PR TITLE
fix: remove @rescript/core dependency

### DIFF
--- a/docs-website/package-lock.json
+++ b/docs-website/package-lock.json
@@ -8,7 +8,6 @@
       "name": "xote-website",
       "version": "1.0.0",
       "dependencies": {
-        "@rescript/core": "^1.6.1",
         "highlight.js": "^11.11.1",
         "posthog-js": "^1.372.1",
         "rescript-signals": "^3.1.0",
@@ -23,11 +22,9 @@
       }
     },
     "..": {
-      "name": "xote",
       "version": "0.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@rescript/core": "^1.6.1",
         "rescript-signals": "^3.1.0"
       },
       "devDependencies": {
@@ -181,15 +178,6 @@
       "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.387.0.tgz",
       "integrity": "sha512-XR0B1geABbnUlSNv4RuFWvk19D870B668C/XzcKDctAZ+xCH5gmGM0oltGbA9yj+2ia9Y65nOrDYKN6Whu1oBw==",
       "license": "MIT"
-    },
-    "node_modules/@rescript/core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@rescript/core/-/core-1.6.1.tgz",
-      "integrity": "sha512-vyb5k90ck+65Fgui+5vCja/mUfzKaK3kOPT4Z6aAJdHLH1eljEi1zKhXroCiCtpNLSWp8k4ulh1bdB5WS0hvqA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "rescript": ">=11.1.0"
-      }
     },
     "node_modules/@rescript/darwin-arm64": {
       "version": "12.2.0",

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -17,7 +17,6 @@
     "preview": "NODE_ENV=production node server.mjs"
   },
   "dependencies": {
-    "@rescript/core": "^1.6.1",
     "highlight.js": "^11.11.1",
     "posthog-js": "^1.372.1",
     "rescript-signals": "^3.1.0",

--- a/docs-website/rescript.json
+++ b/docs-website/rescript.json
@@ -13,10 +13,10 @@
     }
   ],
   "suffix": ".res.mjs",
-  "dependencies": ["@rescript/core", "rescript-signals", "xote"],
+  "dependencies": ["rescript-signals", "xote"],
   "jsx": {
     "version": 4,
     "module": "XoteJSX"
   },
-  "compiler-flags": ["-open RescriptCore", "-open Xote"]
+  "compiler-flags": ["-open Xote"]
 }

--- a/docs-website/yarn.lock
+++ b/docs-website/yarn.lock
@@ -2,28 +2,6 @@
 # yarn lockfile v1
 
 
-"@emnapi/core@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
-  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
-  dependencies:
-    "@emnapi/wasi-threads" "1.2.1"
-    tslib "^2.4.0"
-
-"@emnapi/runtime@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
-  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
-  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
-  dependencies:
-    tslib "^2.4.0"
-
 "@mdx-js/mdx@^3.0.0":
   version "3.1.1"
   resolved "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz"
@@ -65,13 +43,6 @@
     source-map "^0.7.0"
     vfile "^6.0.0"
 
-"@napi-rs/wasm-runtime@^1.1.4":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz#cccd6ebc40b991dea6936f9126b1b8155b6c4c95"
-  integrity sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==
-  dependencies:
-    "@tybys/wasm-util" "^0.10.2"
-
 "@oxc-project/types@=0.133.0":
   version "0.133.0"
   resolved "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz"
@@ -89,119 +60,20 @@
   resolved "https://registry.npmjs.org/@posthog/types/-/types-1.387.0.tgz"
   integrity sha512-XR0B1geABbnUlSNv4RuFWvk19D870B668C/XzcKDctAZ+xCH5gmGM0oltGbA9yj+2ia9Y65nOrDYKN6Whu1oBw==
 
-"@rescript/core@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/@rescript/core/-/core-1.6.1.tgz"
-  integrity sha512-vyb5k90ck+65Fgui+5vCja/mUfzKaK3kOPT4Z6aAJdHLH1eljEi1zKhXroCiCtpNLSWp8k4ulh1bdB5WS0hvqA==
-
-"@rescript/darwin-arm64@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.npmjs.org/@rescript/darwin-arm64/-/darwin-arm64-12.2.0.tgz"
-  integrity sha512-xc3K/J7Ujl1vPiFY2009mRf3kWRlUe/VZyJWprseKxlcEtUQv89ter7r6pY+YFbtYvA/fcaEncL9CVGEdattAg==
-
 "@rescript/darwin-x64@12.2.0":
   version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@rescript/darwin-x64/-/darwin-x64-12.2.0.tgz#2a767d396ca97a599281e3cfd9f3be24da61774c"
+  resolved "https://registry.npmjs.org/@rescript/darwin-x64/-/darwin-x64-12.2.0.tgz"
   integrity sha512-qqcTvnlSeoKkywLjG7cXfYvKZ1e4Gz2kUKcD6SiqDgCqm8TF+spwlFAiM6sloRUOFsc0bpC/0R0B3yr01FCB1A==
-
-"@rescript/linux-arm64@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@rescript/linux-arm64/-/linux-arm64-12.2.0.tgz#1c02ac0ef1fbf8daf71adbdbba87a9b7fd8819de"
-  integrity sha512-ODmpG3ji+Nj/8d5yvXkeHlfKkmbw1Q4t1iIjVuNwtmFpz7TiEa7n/sQqoYdE+WzbDX3DoJfmJNbp3Ob7qCUoOg==
-
-"@rescript/linux-x64@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@rescript/linux-x64/-/linux-x64-12.2.0.tgz#0ec7f94edf013b7872f6fbac943b5d6e1b5477e3"
-  integrity sha512-2W9Y9/g19Y4F/subl8yV3T8QBG2oRaP+HciNRcBjptyEdw9LmCKH8+rhWO6sp3E+nZLwoE2IAkwH0WKV3wqlxQ==
 
 "@rescript/runtime@12.2.0":
   version "12.2.0"
   resolved "https://registry.npmjs.org/@rescript/runtime/-/runtime-12.2.0.tgz"
   integrity sha512-NwfljDRq1rjFPHUaca1nzFz13xsa9ZGkBkLvMhvVgavJT5+A4rMcLu8XAaVTi/oAhO/tlHf9ZDoOTF1AfyAk9Q==
 
-"@rescript/win32-x64@12.2.0":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@rescript/win32-x64/-/win32-x64-12.2.0.tgz#27b9facb08ceb6d3306f5f85ce428541d0943bf1"
-  integrity sha512-fhf8CBj3p1lkIXPeNko3mVTKQfXXm4BoxJtR1xAXxUn43wDpd8Lox4w8/EPBbbW6C/YFQW6H7rtpY+2AKuNaDA==
-
-"@rolldown/binding-android-arm64@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz#54ce8f8382213f4a314a0c2f7ba83f81ffeae592"
-  integrity sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==
-
-"@rolldown/binding-darwin-arm64@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz"
-  integrity sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==
-
 "@rolldown/binding-darwin-x64@1.0.3":
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz#53f57de1f599ecf1db13823cfc88c18fb80954ad"
+  resolved "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz"
   integrity sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==
-
-"@rolldown/binding-freebsd-x64@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz#6f3fdda1b7aeaac9d268a526804b4fb96e4e35f1"
-  integrity sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==
-
-"@rolldown/binding-linux-arm-gnueabihf@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz#d87a454bf585cc9676849377e91d6e375297326f"
-  integrity sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==
-
-"@rolldown/binding-linux-arm64-gnu@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz#419fd6bf612cf348f10528cbcd94ebab9607d8d1"
-  integrity sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==
-
-"@rolldown/binding-linux-arm64-musl@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz#fcc6918696bb76844877e1e4930a18fd0d374069"
-  integrity sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==
-
-"@rolldown/binding-linux-ppc64-gnu@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz#32aecb7c8dae5d4f2a8cde57a058ec86991542f8"
-  integrity sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==
-
-"@rolldown/binding-linux-s390x-gnu@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz#bed9346ea81e6bb8b93cf11f5d88b77db890b763"
-  integrity sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==
-
-"@rolldown/binding-linux-x64-gnu@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz#64c2d26f75dffd9b5a1f97557a00ae77250c8cb7"
-  integrity sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==
-
-"@rolldown/binding-linux-x64-musl@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz#5a45132e8a47659eeaaf3b540c2954a97c860ff3"
-  integrity sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==
-
-"@rolldown/binding-openharmony-arm64@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz#290513068c55e849dc8457a32afee1d7b0acb309"
-  integrity sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==
-
-"@rolldown/binding-wasm32-wasi@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz#3d9972dbf1a953d3c7afaa4a0f20ef2b2e39f31b"
-  integrity sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==
-  dependencies:
-    "@emnapi/core" "1.10.0"
-    "@emnapi/runtime" "1.10.0"
-    "@napi-rs/wasm-runtime" "^1.1.4"
-
-"@rolldown/binding-win32-arm64-msvc@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz#a004ab607a16d6f03bcb555728ff888af75773ad"
-  integrity sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==
-
-"@rolldown/binding-win32-x64-msvc@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz#e2a25b34691a1cc8a1209d7de709063026dd0cdb"
-  integrity sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==
 
 "@rolldown/pluginutils@^1.0.0":
   version "1.0.1"
@@ -216,13 +88,6 @@
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
-
-"@tybys/wasm-util@^0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
-  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
-  dependencies:
-    tslib "^2.4.0"
 
 "@types/debug@^4.0.0":
   version "4.1.13"
@@ -596,60 +461,10 @@ is-plain-obj@^4.0.0:
   resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
-lightningcss-android-arm64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz#f033885116dfefd9c6f54787523e3514b61e1968"
-  integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
-
-lightningcss-darwin-arm64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz"
-  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
-
 lightningcss-darwin-x64@1.32.0:
   version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz#35f3e97332d130b9ca181e11b568ded6aebc6d5e"
+  resolved "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz"
   integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
-
-lightningcss-freebsd-x64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz#9777a76472b64ed6ff94342ad64c7bafd794a575"
-  integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
-
-lightningcss-linux-arm-gnueabihf@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz#13ae652e1ab73b9135d7b7da172f666c410ad53d"
-  integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
-
-lightningcss-linux-arm64-gnu@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz#417858795a94592f680123a1b1f9da8a0e1ef335"
-  integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
-
-lightningcss-linux-arm64-musl@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz#6be36692e810b718040802fd809623cffe732133"
-  integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
-
-lightningcss-linux-x64-gnu@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz#0b7803af4eb21cfd38dd39fe2abbb53c7dd091f6"
-  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
-
-lightningcss-linux-x64-musl@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz#88dc8ba865ddddb1ac5ef04b0f161804418c163b"
-  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
-
-lightningcss-win32-arm64-msvc@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz#4f30ba3fa5e925f5b79f945e8cc0d176c3b1ab38"
-  integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
-
-lightningcss-win32-x64-msvc@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz#141aa5605645064928902bb4af045fa7d9f4220a"
-  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
 
 lightningcss@^1.32.0:
   version "1.32.0"
@@ -1250,7 +1065,7 @@ ms@^2.1.3:
 
 nanoid@^3.3.16:
   version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 parse-entities@^4.0.0:
@@ -1278,7 +1093,7 @@ picomatch@^4.0.2, picomatch@^4.0.4:
 
 postcss@^8.5.15:
   version "8.5.25"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz"
   integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
   dependencies:
     nanoid "^3.3.16"
@@ -1426,7 +1241,7 @@ remark-stringify@^11.0.0:
 
 rescript-signals@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/rescript-signals/-/rescript-signals-3.1.1.tgz#b77a0f190e112e9fc8be3f4f5a2fea983c2badb5"
+  resolved "https://registry.npmjs.org/rescript-signals/-/rescript-signals-3.1.1.tgz"
   integrity sha512-r7xDLb+xXHWPPGbxtcfVU0ny8lE5kl7VwYGnLRcBj+mhewRjneABHeQNyLSYbP3e5LmAZR2j6oavCgp8OGfuJg==
 
 rescript@^12.2.0:
@@ -1520,11 +1335,6 @@ trough@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz"
   integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
-
-tslib@^2.4.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 unified@^11.0.0:
   version "11.0.5"
@@ -1620,8 +1430,8 @@ web-vitals@^5.1.0:
 
 "xote@file:..":
   version "0.0.0"
+  resolved "file:.."
   dependencies:
-    "@rescript/core" "^1.6.1"
     rescript-signals "^3.1.0"
 
 zwitch@^2.0.0:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@rescript/core": "^1.6.1",
         "rescript-signals": "^3.1.0"
       },
       "devDependencies": {
@@ -249,6 +248,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -289,33 +289,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -325,7 +301,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -538,6 +513,7 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -733,15 +709,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@rescript/core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@rescript/core/-/core-1.6.1.tgz",
-      "integrity": "sha512-vyb5k90ck+65Fgui+5vCja/mUfzKaK3kOPT4Z6aAJdHLH1eljEi1zKhXroCiCtpNLSWp8k4ulh1bdB5WS0hvqA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "rescript": ">=11.1.0"
-      }
-    },
     "node_modules/@rescript/darwin-arm64": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@rescript/darwin-arm64/-/darwin-arm64-12.0.0.tgz",
@@ -749,6 +716,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -764,6 +732,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -779,6 +748,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -794,6 +764,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -805,7 +776,8 @@
     "node_modules/@rescript/runtime": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@rescript/runtime/-/runtime-12.0.0.tgz",
-      "integrity": "sha512-STRbYHT5rnW61vWn2+Bdtj620XaprnoBSbPbkvOYZ+Zs8nfqtpBjhNw+JNpGQLXf73crk6MhxFGPxL2o5vb8TQ=="
+      "integrity": "sha512-STRbYHT5rnW61vWn2+Bdtj620XaprnoBSbPbkvOYZ+Zs8nfqtpBjhNw+JNpGQLXf73crk6MhxFGPxL2o5vb8TQ==",
+      "dev": true
     },
     "node_modules/@rescript/win32-x64": {
       "version": "12.0.0",
@@ -814,6 +786,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1162,8 +1135,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -1177,8 +1149,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -1192,8 +1163,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -1207,8 +1177,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -1222,8 +1191,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -1237,8 +1205,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -1252,8 +1219,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -1267,8 +1233,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -1282,8 +1247,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -1297,8 +1261,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -1312,8 +1275,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -1327,8 +1289,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -1342,8 +1303,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -1357,8 +1317,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -1372,8 +1331,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -1387,8 +1345,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -1402,8 +1359,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -1417,8 +1373,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -1432,8 +1387,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -1447,8 +1401,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -1462,8 +1415,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -1477,8 +1429,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -1492,8 +1443,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -1507,8 +1457,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -1522,8 +1471,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -2114,6 +2062,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4661,6 +4610,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7818,6 +7768,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8628,7 +8579,9 @@
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/rescript/-/rescript-12.0.0.tgz",
       "integrity": "sha512-DGcZI2L5W0c6FuEnspLE0MIe1UtTt1VsW/vQfzBFCEBxSsQtoA6YRHUB8Puwnb30PHqZiFK1ADhn6UgA8LWK0A==",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "workspaces": [
         "packages/playground",
         "packages/@rescript/*",
@@ -8782,6 +8735,7 @@
       "integrity": "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "zekr": "^1.7.0"
   },
   "dependencies": {
-    "@rescript/core": "^1.6.1",
     "rescript-signals": "^3.1.0"
   }
 }

--- a/rescript.json
+++ b/rescript.json
@@ -40,7 +40,6 @@
   },
   "suffix": ".res.mjs",
   "dependencies": [
-    "@rescript/core",
     "rescript-signals"
   ],
   "dev-dependencies": [

--- a/src/RuntimeDom.res
+++ b/src/RuntimeDom.res
@@ -1,5 +1,3 @@
-module Core = RescriptCore
-
 let svgNamespace = "http://www.w3.org/2000/svg"
 
 let svgTags = [
@@ -66,7 +64,8 @@ external getElementById: string => Nullable.t<Dom.element> = "getElementById"
 @get external childNodes: Dom.element => Array.arrayLike<Dom.element> = "childNodes"
 
 let childNodesToArray = (el: Dom.element): array<Dom.element> => {
-  el->childNodes->Core.Array.fromArrayLike
+  ignore(el)
+  %raw(`Array.from(el.childNodes || [])`)
 }
 
 @send

--- a/src/RuntimeValue.res
+++ b/src/RuntimeValue.res
@@ -1,59 +1,61 @@
-module Core = RescriptCore
+let isNullish = (value: 'value): bool => {
+  ignore(value)
+  %raw(`value == null`)
+}
 
-let objectHasTag = (obj: {..}, tag: string): bool =>
-  switch obj->Core.Object.get("TAG") {
-  | Some(value) => value == tag
-  | None => false
-  }
+let isObject = (value: 'value): bool => {
+  ignore(value)
+  %raw(`value !== null && typeof value === "object"`)
+}
+
+let objectHasTag = (obj: {..}, tag: string): bool => {
+  let dict: Dict.t<string> = Obj.magic(obj)
+  dict->Dict.get("TAG") == Some(tag)
+}
 
 /* Detects a `MaybeSignal.t` at runtime by its variant tag. Used where JSX hands
  us untyped values that may be raw, a signal, a function, or a `MaybeSignal.t`. */
 let isMaybeSignal = (value: 'value): bool => {
-  switch value->Core.Type.Classify.classify {
-  | Object(obj) => {
-      let obj: {..} = Obj.magic(obj)
-      obj->Core.Object.hasOwnProperty("TAG") &&
-        (obj->objectHasTag("Static") || obj->objectHasTag("Reactive"))
-    }
-  | _ => false
+  if isObject(value) {
+    let obj: {..} = Obj.magic(value)
+    obj->objectHasTag("Static") || obj->objectHasTag("Reactive")
+  } else {
+    false
   }
 }
 
 /* Variant tag of a value, when it is a tagged variant at all. Used to tell one
  runtime-shaped variant from another where JSX hands us untyped values. */
 let getTag = (value: 'value): option<string> =>
-  switch value->Core.Type.Classify.classify {
-  | Object(obj) => {
-      let obj: {..} = Obj.magic(obj)
-      obj->Core.Object.get("TAG")
-    }
-  | _ => None
+  if isObject(value) {
+    let dict: Dict.t<string> = Obj.magic(value)
+    dict->Dict.get("TAG")
+  } else {
+    None
   }
 
-let isFunction = (value: 'value): bool =>
-  switch value->Core.Type.Classify.classify {
-  | Function(_) => true
-  | _ => false
-  }
+let isFunction = (value: 'value): bool => {
+  ignore(value)
+  %raw(`typeof value === "function"`)
+}
 
 /* Detects a `Signal.t` by its shape. Structural rather than "any object", so a
  plain record handed to an untyped prop is treated as a value instead of being
  silently read as a signal. */
 let isSignalLike = (value: 'value): bool =>
-  switch value->Core.Type.Classify.classify {
-  | Object(obj) => {
-      let obj: {..} = Obj.magic(obj)
-      obj->Core.Object.hasOwnProperty("subs") &&
-      obj->Core.Object.hasOwnProperty("value") &&
-      switch obj->Core.Object.get("equals") {
-      | Some(equals) => isFunction(equals)
-      | None => false
-      }
+  if isObject(value) {
+    let dict: Dict.t<Obj.t> = Obj.magic(value)
+    dict->Dict.get("subs")->Option.isSome &&
+    dict->Dict.get("value")->Option.isSome &&
+    switch dict->Dict.get("equals") {
+    | Some(equals) => isFunction(equals)
+    | None => false
     }
-  | _ => false
+  } else {
+    false
   }
 
 let getField = (props: 'props, key: string): option<'value> => {
-  let props: {..} = Obj.magic(props)
-  props->Core.Object.get(key)
+  let dict: Dict.t<'value> = Obj.magic(props)
+  dict->Dict.get(key)
 }

--- a/src/View.res
+++ b/src/View.res
@@ -1,6 +1,5 @@
 module DOM = RuntimeDom
 module Reactivity = RuntimeOwner
-module Core = RescriptCore
 
 /* ============================================================================
  * Type Definitions
@@ -147,25 +146,24 @@ module Render = {
     if a === b {
       true
     } else {
-      switch (a->Core.Type.Classify.classify, b->Core.Type.Classify.classify) {
-      | (Object(objA), Object(objB)) => {
-          let dictA: Dict.t<Obj.t> = Obj.magic(objA)
-          let dictB: Dict.t<Obj.t> = Obj.magic(objB)
-          let keysA = dictA->Dict.keysToArray
-          let keysB = dictB->Dict.keysToArray
+      if RuntimeValue.isObject(a) && RuntimeValue.isObject(b) {
+        let dictA: Dict.t<Obj.t> = Obj.magic(a)
+        let dictB: Dict.t<Obj.t> = Obj.magic(b)
+        let keysA = dictA->Dict.keysToArray
+        let keysB = dictB->Dict.keysToArray
 
-          if keysA->Array.length !== keysB->Array.length {
-            false
-          } else {
-            keysA->Array.every(key =>
-              switch (dictA->Dict.get(key), dictB->Dict.get(key)) {
-              | (Some(valueA), Some(valueB)) => valueA === valueB
-              | _ => false
-              }
-            )
-          }
+        if keysA->Array.length !== keysB->Array.length {
+          false
+        } else {
+          keysA->Array.every(key =>
+            switch (dictA->Dict.get(key), dictB->Dict.get(key)) {
+            | (Some(valueA), Some(valueB)) => valueA === valueB
+            | _ => false
+            }
+          )
         }
-      | _ => false
+      } else {
+        false
       }
     }
 
@@ -174,17 +172,17 @@ module Render = {
   }
 
   let getKeyedChildren = (children: array<node>): option<array<keyedChild>> => {
-    if children->Core.Array.length == 0 {
+    if children->Array.length == 0 {
       None
     } else {
-      let keyedChildren = children->Core.Array.filterMap(child => {
+      let keyedChildren = children->Array.filterMap(child => {
         switch child {
         | Keyed({key, identity, child}) => Some({key, identity, child})
         | _ => None
         }
       })
 
-      if keyedChildren->Core.Array.length == children->Core.Array.length {
+      if keyedChildren->Array.length == children->Array.length {
         Some(keyedChildren)
       } else {
         None
@@ -758,9 +756,9 @@ let mountById = (node: node, containerId: string): unit => {
 let isReactiveProp = RuntimeValue.isMaybeSignal
 
 let valuePrimitive = (value: 'input, stringify: 'value => string): node =>
-  switch value->Core.Type.Classify.classify {
-  | Null | Undefined => null()
-  | _ =>
+  if RuntimeValue.isNullish(value) {
+    null()
+  } else {
     switch MaybeSignal.ofUnknown(value)->MaybeSignal.map(stringify) {
     | Static(value) => text(value)
     | Reactive(signal) => SignalText(signal)


### PR DESCRIPTION
ReScript v11+ includes the standard library by default, so Xote no longer needs to depend on @rescript/core.

This updates the root package, docs site config, and remaining internal helpers accordingly.