### PR TITLE
feat(ppx): detect MaybeSignal reads and report the ones detection can…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ The root `xote` entry is client-focused and does not export router, SSR, hydrati
 These three are thin shims (`src/Signal.res`, `src/Computed.res`, `src/Effect.res`) that `include` the corresponding modules from `rescript-signals`.
 
 **Xote Modules:**
-- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `tracked`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. The owner-based reactivity system for resource cleanup also lives here.
+- **`Xote.View`**: Core rendering primitives. Defines the virtual node types (`Element`, `Text`, `SignalText`, `Fragment`, `SignalFragment`, `Keyed`, `LazyComponent`, `KeyedList`) and exposes node constructors (`text`, `signalText`, `signalInt`, `signalFloat`, `int`, `float`, `bool`, `fragment`, `signalFragment`, `tracked`, `each`, `eachWithKey`, `element`), the JSX rendering components (`For`, `Show`, `Maybe`, `Value`, `Text`, `Int`, `Float`, `Bool`), attribute helpers (`attr`, `signalAttr`, `computedAttr`, `optionalAttr`, `optionalSignalAttr`, `optionalComputedAttr`, `Attr`), the `null`/`empty` placeholders, and `mount`/`mountById`. It also exposes the two helpers `@xote.component` emits: `child` (runtime coercion of a bare JSX child) and `probe` (hidden-read detection — see the PPX section below). The owner-based reactivity system for resource cleanup also lives here.
 - **`Xote.Html`**: Convenience constructors for common HTML tags (`div`, `span`, `button`, `input`, `h1`-`h3`, `p`, `ul`, `li`, `a`). Thin wrappers over `View.element`. For tags not listed, call `View.element(tag, ...)` directly or use JSX.
 - **`Xote.XoteJSX`**: Generic JSX v4 implementation that enables JSX syntax for creating Xote components. Provides `jsx`, `jsxs`, `jsxKeyed`, `jsxsKeyed` functions and an `Elements` module for lowercase HTML tags with a broad set of supported attributes (standard, form/input, link, media, accessibility, drag-and-drop, and data attributes) plus an `attrs` escape hatch for anything else. Named `XoteJSX` (not `JSX`) to avoid colliding with unrelated modules when consumers use `open Xote`. Note: to defer side-effecting component evaluation out of any surrounding `Computed` context, `XoteJSX.jsx` wraps user-defined components in `View.LazyComponent`.
 - **`Xote.MaybeSignal`**: Static-or-reactive value wrapper exposing the type `t<'a> = Reactive(Signal.t<'a>) | Static('a)` plus `static`, `reactive`, `computed` (derives a `Reactive` from a `unit => 'a`), `get` (tracked read), `peek` (untracked read), `isStatic`/`isReactive`, `map`, `toSignal`, and `ofUnknown`. Use it anywhere an API should accept either a plain value or a signal — JSX props are the most common case, not the only one. Notes on the trickier members:
@@ -148,7 +148,9 @@ Xote supports **two syntax styles**:
 - values that are already reactive (a `() => …` thunk, a `Computed`, `Prop.reactive(…)`) are left alone — the annotation is a safe drop-in;
 - **user-component props are never thunked**: `<Card label={Signal.get(x)} />` is a deliberate one-shot read; pass the signal itself for a reactive prop. Children and JSX-valued props of user components are still decomposed.
 
-Detection follows local aliases (`let g = Signal.get`, `module S = Signal`, `open Signal`, local reactive helpers) but is syntactic: reads hidden behind imported helpers, or hoisted into a plain `let` binding (`let label = Signal.get(count)->Int.toString`), compile to *static one-shot values with no error*. The escape hatch is to wrap the value in `() => …` yourself. Full rules and limitations: `ppx/README.md`. The npm package ships the PPX as prebuilt per-platform binaries selected by `ppx/postinstall.js`; Xote's own `src/` never uses the annotation.
+Detection covers `Signal.get` **and** `MaybeSignal.get`/`Prop.get`, and follows aliases (`let g = Signal.get`, `module S = Signal`, `open Signal`), local reactive helpers, and helpers in a module declared in the same file. It is still syntactic, so reads hidden behind an **imported** helper, or hoisted into a plain `let` binding (`let label = Signal.get(count)->Int.toString`), compile to static one-shot values; the escape hatch is to wrap the value in `() => …` yourself.
+
+Those remaining cases are no longer silent. A value leaf whose expression contains a call the PPX cannot resolve is emitted wrapped in `View.probe`: on its **first** evaluation it runs inside a throwaway computed and, if that computed subscribed to anything, a warning naming the source location is logged (and the value is read back through the computed, so an enclosing `tracked` block's dependencies are unchanged). No dependencies means no warning and no behaviour change, so there are no false positives. Each site is probed once — later evaluations are a plain call — and probing is skipped entirely when `globalThis.__XOTE_DEV__` or `process.env.NODE_ENV` says production. Full rules and limitations: `ppx/README.md`. The npm package ships the PPX as prebuilt per-platform binaries selected by `ppx/postinstall.js`; Xote's own `src/` never uses the annotation.
 
 #### JSX Syntax
 Xote supports ReScript's generic JSX v4 for a declarative component syntax:
@@ -615,7 +617,7 @@ Guidance for AI coding agents (and humans) making changes to this repository.
 | `src/Prop.res`, `src/Prop.resi` | Deprecated alias of `MaybeSignal` (the interface file is what makes the deprecations warn) |
 | `src/Signal.res`, `src/Computed.res`, `src/Effect.res` | Re-export shims for `rescript-signals` |
 | `ppx/ppx.ml` | The `@xote.component` fine-grained PPX (vendored OCaml 4.06 AST + rewriter) |
-| `ppx/example/` | Standalone PPX consumer project; `verify.mjs` is its jsdom regression suite (`npm run ppx:test`) |
+| `ppx/example/` | Standalone PPX consumer project; `verify.mjs` is its jsdom regression suite (`npm run ppx:test`). `src/Store.res` is deliberately a *second* file, so its helpers model the cross-module reads detection cannot follow |
 | `ppx/postinstall.js` | Selects/installs the prebuilt PPX binary at npm install time |
 | `rescript.json` | ReScript compiler configuration (`namespace: true`) |
 | `vite.config.js` | Library build configuration |
@@ -658,6 +660,7 @@ The project has a test suite using the [zekr](https://github.com/nicholasgasior/
 | `tests/JSX_test.res` | JSX transform |
 | `tests/MaybeSignal_test.res` | `MaybeSignal` helpers and the deprecated `Prop` alias |
 | `tests/KeyedList_test.res` | Keyed list reconciliation |
+| `tests/Probe_test.res` | `View.probe` hidden-read detection (reports, false positives, dedupe) |
 | `tests/Route_test.res` | Route matching |
 | `tests/SSR_test.res` | Server-side rendering |
 | `tests/SSRState_test.res` | State serialization |

--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ The explicit value primitives are still there for code that does not use the PPX
 Built-in attributes take a plain value, a signal, or a `unit => 'a` function, so
 a signal can be passed straight through without wrapping it.
 
+#### Keep signal reads visible
+
+`@xote.component` decides what to make reactive by *reading your source*. It
+follows `Signal.get` and `MaybeSignal.get`, aliases (`let g = Signal.get`,
+`module S = Signal`, `open Signal`), local helpers that read a signal, and
+helpers in a module in the same file. It cannot follow a call into **another
+module** — nothing in `Store.waitingCount(store)` says "signal" — so that leaf is
+compiled as a plain value and renders its first result forever:
+
+```rescript
+<p> {Store.waitingCount(store)} </p>   // ⚠️ one-shot: never updates
+<p> {() => Store.waitingCount(store)} </p>   // ✅ reactive
+```
+
+The same applies to a read hoisted into a `let` (`let n = Signal.get(count)`,
+then `{n}`): reactivity follows the expression written in JSX position. In both
+cases the fix is a thunk — `() => …` — and the PPX never double-wraps one you
+wrote yourself.
+
+You do not have to catch these by eye. A leaf whose expression contains a call
+the PPX cannot resolve is emitted wrapped in `View.probe`, which checks at
+runtime whether evaluating it actually subscribed to a signal and, if it did,
+logs the source location once:
+
+```
+[Xote] Queue.res:42:19: this value reads a signal through a call
+@xote.component cannot see … Wrap it in a thunk (`{() => ...}`).
+```
+
+There are no false positives — the check is on what the evaluation really read,
+not on how it looks — and probing is skipped in production builds. Full rules:
+[`ppx/README.md`](ppx/README.md#hidden-reads).
+
 For rendering collections in JSX, prefer `View.For`. Add `by` when items have stable identity and should reconcile by key:
 
 ```rescript

--- a/ppx/README.md
+++ b/ppx/README.md
@@ -91,6 +91,7 @@ Applied recursively to the component's returned JSX:
 | Attribute value | no | left as-is (static attribute) |
 | `<View.Text/Int/Float/Bool>` child | yes | thunked → reactive text node (leaf) |
 | `<View.Text/…>` child | no | left as-is (static text) |
+| Any value leaf | can't tell — the expression contains a call the PPX cannot resolve | wrapped in `View.probe`, which decides at runtime and reports a read it finds — see [Hidden reads](#hidden-reads) |
 | Element / nested JSX | — | recurse into attributes and children |
 | Fragment (`<>…</>`) | — | recurse into each child independently (so nested reactive regions stay separate — not collapsed into one thunk) |
 | User-component prop (`<Card label={…}>`) | — | left untouched — see [User-component props](#user-component-props) |
@@ -230,23 +231,96 @@ shadowing it with a non-alias removes it) recognises all of these:
 | Form | Example | Detected via |
 |---|---|---|
 | Direct | `Signal.get(sig)` / `X.Signal.get(sig)` | literal match |
+| Through the wrapper | `MaybeSignal.get(v)`, `Prop.get(v)` | same — reading a `MaybeSignal` subscribes exactly like `Signal.get` |
 | Pipe | `sig->Signal.get` | desugars to `Signal.get(sig)` before the PPX |
 | Value alias | `let g = Signal.get` … `g(sig)` | binding tracked in scope |
 | Module alias | `module S = Signal` … `S.get(sig)` | binding tracked in scope |
 | Open | `open Signal` … `get(sig)` | bare `get` under an open |
 | Local reactive helper | `let cls = () => Signal.get(x) ? …` … `cls()` | function binding whose body eagerly reads a signal; its *call* counts |
+| Same-file module helper | `module Store = { let count = s => Signal.get(s) }` … `Store.count(s)` | the module body is walked, and its reactive names qualified |
 
-`Signal.peek` is intentionally **not** a read — it is an untracked read, so a
-value that only peeks stays static (verified by the example's `PeekShadow`
-case, where a reactive helper rebound to a `peek`-based function is dropped
-from the alias environment and its attribute is left as a plain, once-evaluated
-string).
+`Signal.peek` (and `MaybeSignal.peek`) is intentionally **not** a read — it is an
+untracked read, so a value that only peeks stays static (verified by the
+example's `PeekShadow` case, where a reactive helper rebound to a `peek`-based
+function is dropped from the alias environment and its attribute is left as a
+plain, once-evaluated string).
 
 Only *eager* reads trigger a thunk. A read deferred inside a nested lambda — a
 `() => …` you wrote yourself, a `Computed`, a `MaybeSignal.reactive(Computed.make(…))`,
 or a helper that merely *returns* a thunk — is already reactive and left as-is.
-Because of that, when detection can't see a read (below), the safe fix is always
-to wrap the value in `() =>` yourself: it will not be double-wrapped.
+Because of that, when detection can't see a read, the safe fix is always to wrap
+the value in `() =>` yourself: it will not be double-wrapped.
+
+### Hidden reads
+
+Everything above is *syntactic*: the PPX follows a read only as far as it can
+see the definition. One indirection it cannot follow is a call into **another
+module** — `Store.waitingCount(store)`, or a local closure that ends in one:
+
+```rescript
+@xote.component
+let make = (~store) =>
+  <p class={Store.tone(store)}>       /* reads a signal — invisible to the ppx */
+    {Store.waitingCount(store)}
+  </p>
+```
+
+Nothing here says "signal", so nothing is thunked, and the leaf renders its
+first value forever. That was the library's one genuinely silent failure — and
+it is worse than a frozen leaf when the markup sits inside a `tracked` block or
+a tracked branch: the hidden read is captured by *that* scope instead, quietly
+widening it, so one unrelated update re-renders the whole region. A screen can
+look like it works for exactly that reason while the screen next to it breaks.
+
+The PPX still cannot resolve the call — but it can see that a call it cannot
+resolve is *there*. An expression built only from constants, identifiers, field
+accesses, lambdas, operators and Xote's own constructors provably calls nothing;
+anything else might. Leaves in that second group are emitted wrapped in
+[`View.probe`](../src/View.res), which settles the question at runtime: the first
+time the leaf is evaluated it runs inside a throwaway computed, and what that
+computed subscribed to gives the answer.
+
+- **Nothing subscribed** — the leaf really is static. The computed is disposed
+  and the value returned: `probe` was the identity function, and there is no
+  warning. An unresolvable call is not evidence of a read, so a false positive
+  is impossible.
+- **Something subscribed** — the read was hidden. The value is read back
+  *through* the computed, so an enclosing tracked block subscribes exactly as it
+  did before (behaviour is unchanged), and a one-time warning naming the source
+  location is logged:
+
+```
+[Xote] Queue.res:42:19: this value reads a signal through a call @xote.component
+cannot see (a helper from another module, MaybeSignal.get, a read stored in a
+data structure), so it compiled to a one-shot value that will never update — and
+inside a tracked block it widens that block and re-renders it wholesale. Wrap it
+in a thunk (`{() => ...}`) or inline the Signal.get.
+```
+
+The fix at the call site is the same escape hatch as always — make the read
+deferred, and the PPX leaves your thunk alone:
+
+```rescript
+<p class={() => Store.tone(store)}>
+  {() => Store.waitingCount(store)}
+</p>
+```
+
+Untracked control flow is probed the same way, on its condition/scrutinee and
+`when` guards: a read hidden there does not just freeze a value, it freezes the
+whole branch.
+
+Each site is probed **once** — the answer belongs to the source expression, not
+to a particular render — so a probed leaf costs one throwaway computed the first
+time it is evaluated and a plain call every time after, and the report appears
+once however often the component renders. Probing is skipped altogether in
+production builds: `globalThis.__XOTE_DEV__` decides when set, otherwise
+`process.env.NODE_ENV` (which bundlers inline) does. With neither available the
+probe stays on — a silently stale UI is worse than an allocation.
+
+What is *not* probed, because it can never be a hidden scalar read: event
+handlers and the `attrs` escape-hatch array, values containing JSX, and calls
+into `View`/`Html`/`Signal`/`Computed`/`MaybeSignal` themselves.
 
 ## How it works
 
@@ -365,14 +439,22 @@ npm run verify          # jsdom runtime check (every case above, asserted on rea
 ## Known limitations
 
 - **Signal detection is syntactic** (though alias- and helper-aware — see the
-  table above). It follows `let`/`module`/`open` aliases and *local* reactive
-  helpers, but not indirection it cannot see the definition of: a signal read
-  behind an **imported / cross-module** helper, or reached through a data
-  structure, is not detected. Such a value compiles to a **static, once-evaluated
-  attribute/text with no error** — the one genuinely silent failure. The escape
-  hatch is reliable: wrap it in `() =>` yourself and it becomes reactive (the
-  eager check leaves your thunk alone, so it is never double-wrapped). An
-  over-eager match only produces a harmless extra `computedAttr`.
+  table above). It follows `let`/`module`/`open` aliases, local reactive helpers
+  and same-file module helpers, but not indirection it cannot see the definition
+  of: a signal read behind an **imported / cross-module** helper, or reached
+  through a data structure, is not detected, and such a value still compiles to a
+  **static, once-evaluated attribute/text**. It is no longer *silent*:
+  [`View.probe`](#hidden-reads) reports it at runtime, once, with its source
+  location. The escape hatch is unchanged — wrap it in `() =>` yourself and it
+  becomes reactive (the eager check leaves your thunk alone, so it is never
+  double-wrapped). An over-eager match only produces a harmless extra
+  `computedAttr`.
+- **The probe reports, it does not repair.** It cannot: by the time the value
+  exists, the leaf has already been emitted as a static one. It also only fires
+  on the *first* evaluation of a site, and only for a *scalar* result — the shape
+  that silently renders a stale number or class name. A hidden read behind a
+  branch you never render in development is not reported, and neither is one
+  that a leaf only performs on a later evaluation.
 - **Hoisting a read into a `let` makes it a one-shot read.** Reactivity follows
   the *expression in JSX position*: `<div> {Signal.get(count)} </div>` is a
   reactive leaf, but

--- a/ppx/example/src/Demo.res
+++ b/ppx/example/src/Demo.res
@@ -486,3 +486,64 @@ module HelperHost = {
   @xote.component
   let make = () => <div id="helper-host"> {helperButton("Press")} </div>
 }
+
+/* Case 26: `MaybeSignal.get` is a tracked read exactly like `Signal.get`, and
+   so is `Prop.get` (its deprecated alias). Reading through the static-or-
+   reactive wrapper subscribes just the same, so these leaves must be thunked. */
+let maybeName: MaybeSignal.t<string> = MaybeSignal.reactive(name)
+let maybeTheme: MaybeSignal.t<string> = MaybeSignal.reactive(theme)
+
+module MaybeSignalRead = {
+  @xote.component
+  let make = () =>
+    <p id="maybe-signal" class={MaybeSignal.get(maybeTheme)}> {MaybeSignal.get(maybeName)} </p>
+}
+
+/* Case 27: a reactive helper reached through a module *in this file*. The ppx
+   walks the module body, so `Counter.doubled()` is a read; `Counter.plain(…)`
+   is not, and stays a plain static value. */
+module Counter = {
+  let doubled = () => Signal.get(count) * 2
+  let plain = (n: int) => n + 1
+}
+
+module ModuleHelper = {
+  @xote.component
+  let make = () =>
+    <p id="module-helper" class={Counter.doubled() > 0 ? "positive" : "zero"}>
+      {Counter.doubled()}
+    </p>
+}
+
+/* Case 28: the hidden read. `Store` lives in another file, so the ppx sees only
+   a call it cannot resolve and cannot know a signal is read behind it. Both
+   leaves are wrapped in `View.probe`, which reports them at runtime instead of
+   rendering a frozen value in silence. */
+module Hidden = {
+  @xote.component
+  let make = () =>
+    <p id="hidden-read" class={Store.themeClass()}> {Store.waitingCount()} </p>
+}
+
+/* Case 28b: the same indirection in a *condition*. A read hidden in the
+   scrutinee freezes the whole branch, so untracked control flow probes it. */
+module HiddenBranch = {
+  @xote.component
+  let make = () =>
+    <div id="hidden-branch">
+      {if Store.isBusy() {
+        <span id="hb-busy"> {"busy"} </span>
+      } else {
+        <span id="hb-idle"> {"idle"} </span>
+      }}
+    </div>
+}
+
+/* Case 29: the probe must not cry wolf. An unresolvable call that reads no
+   signal is a perfectly ordinary static value — no warning, no reactivity, and
+   `View.probe` returns it untouched. */
+module HiddenClean = {
+  @xote.component
+  let make = () =>
+    <p id="hidden-clean" class={Store.title("row")}> {Counter.plain(41)} </p>
+}

--- a/ppx/example/src/Store.res
+++ b/ppx/example/src/Store.res
@@ -1,0 +1,16 @@
+/* A plain module in *another file*. The ppx only ever sees the call at the use
+   site (`Store.waitingCount()`), never this body, so a signal read in here is
+   the one form detection cannot follow. Used by Demo's hidden-read cases:
+   `waitingCount`/`themeClass`/`isBusy` read signals; `title` does not, and must
+   not be reported. */
+
+let waiting = Signal.make(4)
+let busy = Signal.make(false)
+let tone = Signal.make("calm")
+
+let waitingCount = () => Signal.get(waiting)
+let themeClass = () => "tone-" ++ Signal.get(tone)
+let isBusy = () => Signal.get(busy)
+
+/* No signal read at all — the probe must stay silent on this one. */
+let title = (prefix: string) => prefix ++ "!"

--- a/ppx/example/verify.mjs
+++ b/ppx/example/verify.mjs
@@ -15,6 +15,14 @@ globalThis.Node = dom.window.Node;
 const View = await import('xote/src/View.res.mjs');
 const Signal = await import('xote/src/Signal.res.mjs');
 const Demo = await import('./src/Demo.res.mjs');
+const Store = await import('./src/Store.res.mjs');
+
+// `View.probe` reports hidden reads through console.warn. Capture from the very
+// first mount so the hidden-read section can assert both what was reported and
+// what was not — a false positive is as much a failure as a missed read.
+const warnings = [];
+const realWarn = console.warn;
+console.warn = (...args) => { warnings.push(args.join(' ')); };
 
 let pass = 0, fail = 0;
 const check = (name, cond) => {
@@ -465,6 +473,76 @@ check('let-bound JSX renders bare child', ns.querySelector('#ns-heading').textCo
 check('array literal inside View.fragment', ns.querySelector('#ns-arr').textContent.includes('array'));
 check('pipe + map callback decomposed', ns.querySelectorAll('.ns-map').length === 2);
 check('local helper items rendered', ns.textContent.includes('one') && ns.textContent.includes('two'));
+
+// --- MaybeSignal.get is a tracked read --------------------------------------
+// Reading through the static-or-reactive wrapper subscribes exactly like
+// Signal.get, so both leaves below must be reactive, not one-shot.
+console.log('MaybeSignal.get is a tracked read:');
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.name, 'Ada');
+const ms = mount(() => Demo.MaybeSignalRead.make({}));
+ms.__marker = 'MS';
+check('MaybeSignal.get attribute rendered', ms.className === 'light');
+check('MaybeSignal.get bare child rendered', ms.textContent.includes('Ada'));
+Signal.set(Demo.theme, 'dark');
+Signal.set(Demo.name, 'Bo');
+check('MaybeSignal.get attribute updates', document.querySelector('#maybe-signal').className === 'dark');
+check('MaybeSignal.get bare child updates', document.querySelector('#maybe-signal').textContent.includes('Bo'));
+check('MaybeSignal leaf kept element identity', document.querySelector('#maybe-signal').__marker === 'MS');
+
+// --- A reactive helper behind a same-file module -----------------------------
+console.log('same-file module helper is a tracked read:');
+Signal.set(Demo.count, 2);
+const mh = mount(() => Demo.ModuleHelper.make({}));
+mh.__marker = 'MH';
+check('module helper bare child rendered', mh.textContent.includes('4'));
+check('module helper attribute rendered', mh.className === 'positive');
+Signal.set(Demo.count, 0);
+check('module helper bare child updates', document.querySelector('#module-helper').textContent.trim() === '0');
+check('module helper attribute updates', document.querySelector('#module-helper').className === 'zero');
+check('module helper kept element identity', document.querySelector('#module-helper').__marker === 'MH');
+
+// --- Hidden reads: what detection cannot follow, reported at runtime ---------
+// `Store` is another file, so the ppx sees only a call it cannot resolve. The
+// leaf is wrapped in `View.probe`, which evaluates it inside a throwaway
+// computed and reports it if that computed subscribed to anything.
+console.log('hidden reads (an unresolvable call that does read a signal):');
+const hidden = mount(() => Demo.Hidden.make({}));
+check('hidden read still renders its initial value', hidden.textContent.includes('4'));
+check('hidden read attribute still renders', hidden.className === 'tone-calm');
+check('hidden read reported with its source location', warnings.some((w) => w.includes('Demo.res:525:54')));
+check('hidden read attribute reported', warnings.some((w) => w.includes('Demo.res:525:32')));
+check('warning names the fix', warnings.some((w) => w.includes('() => ...')));
+
+// This is precisely what the warning is for: the leaf is frozen at its first
+// value. Detection cannot fix it, so it has to say so.
+Signal.set(Store.waiting, 9);
+check('hidden read is indeed frozen (the failure the warning describes)', document.querySelector('#hidden-read').textContent.includes('4'));
+
+const hiddenBranch = mount(() => Demo.HiddenBranch.make({}));
+check('hidden condition renders a branch', hiddenBranch.querySelector('#hb-idle') !== null);
+check('hidden condition reported', warnings.some((w) => w.includes('Demo.res:534:11')));
+
+// Only once per site, however many times the component mounts.
+const repeats = warnings.filter((w) => w.includes('Demo.res:525:54')).length;
+mount(() => Demo.Hidden.make({}));
+check('each site is reported once, not per render', warnings.filter((w) => w.includes('Demo.res:525:54')).length === repeats);
+
+// --- ...and silent when there is nothing to report ---------------------------
+// An unresolvable call is not evidence of a read. Probing decides by what the
+// evaluation actually subscribed to, so a false positive is impossible.
+console.log('probe stays silent when nothing is read:');
+const quiet = warnings.length;
+const clean = mount(() => Demo.HiddenClean.make({}));
+check('unresolvable-but-static bare child renders', clean.textContent.includes('42'));
+check('unresolvable-but-static attribute renders', clean.className === 'row!');
+check('no warning for a call that reads nothing', warnings.length === quiet);
+// Case 25 (PeekShadow) is probed too: `Signal.peek` registers no dependency, so
+// a deliberate one-shot peek must not be reported either.
+check('no warning for a deliberate peek-based helper', !warnings.some((w) => w.includes('Demo.res:357')));
+check('no warning from any other case', warnings.every((w) => /Demo\.res:(525|534):/.test(w)));
+
+console.warn = realWarn;
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -992,26 +992,42 @@ let view_child = Longident.Ldot (Longident.Lident "View", "child")
 let wrap_child e = apply (ident view_child) [ e ]
 
 (* ---- signal-read detection ----------------------------------------------
-   A read is any occurrence of `Signal.get` (applied or not). Beyond the
-   literal `Signal.get` / `X.Signal.get`, an alias environment threaded through
-   the traversal also recognises indirect reads:
+   A read is a tracked `get`: `Signal.get`, and equally `MaybeSignal.get` /
+   `Prop.get` (the deprecated alias), which read through the static-or-reactive
+   wrapper and subscribe just the same. Beyond the literal `Signal.get` /
+   `X.MaybeSignal.get`, an alias environment threaded through the traversal also
+   recognises indirect reads:
      - a value alias:    `let g = Signal.get` then `g(sig)`
      - a module alias:   `module S = Signal` then `S.get(sig)`
      - an open:          `open Signal` then a bare `get(sig)`
      - a reactive helper: `let cls = () => Signal.get(x) ? …` then `cls()` —
        a local function whose body eagerly reads a signal; calling it is a read.
+     - a same-file module helper: `module Store = { let count = s => Signal.get(s) }`
+       then `Store.count(s)` — collected per module while walking the structure.
    The environment is scoped by the traversal (bindings visible only after they
    appear); shadowing a name with a non-reactive binding removes it. *)
-type env = { vals : string list; mods : string list; funcs : string list; open_signal : bool }
-let empty_env = { vals = []; mods = []; funcs = []; open_signal = false }
+type env = {
+  vals : string list;
+  mods : string list;
+  funcs : string list;
+  (* reactive helpers reached through a same-file module, as "Store.count" *)
+  qfuncs : string list;
+  open_signal : bool;
+}
+let empty_env = { vals = []; mods = []; funcs = []; qfuncs = []; open_signal = false }
 
-let is_signal_get (env : env) (e : expression) : bool =
+(* Modules whose `get` is a *tracked* read. `peek` is deliberately absent from
+   every one of them: it is the untracked read. *)
+let is_read_module_name = function
+  | "Signal" | "MaybeSignal" | "Prop" -> true
+  | _ -> false
+
+let is_read_fn (env : env) (e : expression) : bool =
   match e.pexp_desc with
   | Pexp_ident { txt = Longident.Ldot (m, "get"); _ } ->
     (match m with
-     | Longident.Lident "Signal" -> true
-     | Longident.Ldot (_, "Signal") -> true
-     | Longident.Lident name -> List.mem name env.mods
+     | Longident.Lident name -> is_read_module_name name || List.mem name env.mods
+     | Longident.Ldot (_, name) -> is_read_module_name name
      | _ -> false)
   | Pexp_ident { txt = Longident.Lident name; _ } ->
     List.mem name env.vals || (env.open_signal && name = "get")
@@ -1087,6 +1103,9 @@ let is_reactive_call (env : env) (e : expression) : bool =
   match e.pexp_desc with
   | Pexp_apply ({ pexp_desc = Pexp_ident { txt = Longident.Lident f; _ }; _ }, _) ->
     List.mem f env.funcs
+  | Pexp_apply
+      ({ pexp_desc = Pexp_ident { txt = Longident.Ldot (Longident.Lident m, f); _ }; _ }, _) ->
+    List.mem (m ^ "." ^ f) env.qfuncs
   | _ -> false
 
 (* An *eager* read: a `Signal.get` (or reactive-helper call) that runs when this
@@ -1099,7 +1118,7 @@ let rec reads_signal_eager (env : env) (e : expression) : bool =
   | Pexp_fun _ -> false
   | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some _) -> false
   | _ ->
-    is_reactive_call env e || is_signal_get env e
+    is_reactive_call env e || is_read_fn env e
     || List.exists (reads_signal_eager env) (sub_exprs e)
 
 (* Does `e` denote a function whose body eagerly reads a signal? Strip the
@@ -1126,7 +1145,7 @@ let collect_val_aliases (env : env) (vbs : value_binding list) : env =
       match vb.pvb_pat.ppat_desc with
       | Ppat_var { txt = name; _ } ->
         let drop = List.filter (fun n -> n <> name) in
-        if is_signal_get env vb.pvb_expr then
+        if is_read_fn env vb.pvb_expr then
           { env with vals = name :: env.vals; funcs = drop env.funcs }
         else if func_reads env vb.pvb_expr then
           { env with funcs = name :: env.funcs; vals = drop env.vals }
@@ -1134,22 +1153,22 @@ let collect_val_aliases (env : env) (vbs : value_binding list) : env =
       | _ -> env)
     env vbs
 
-let is_signal_module (me : module_expr) : bool =
+let is_read_module (me : module_expr) : bool =
   match me.pmod_desc with
-  | Pmod_ident { txt = Longident.Lident "Signal"; _ } -> true
-  | Pmod_ident { txt = Longident.Ldot (_, "Signal"); _ } -> true
+  | Pmod_ident { txt = Longident.Lident name; _ } -> is_read_module_name name
+  | Pmod_ident { txt = Longident.Ldot (_, name); _ } -> is_read_module_name name
   | _ -> false
 
 let collect_mod_alias (env : env) (name : string Location.loc) (me : module_expr) : env =
-  if is_signal_module me then { env with mods = name.Location.txt :: env.mods } else env
+  if is_read_module me then { env with mods = name.Location.txt :: env.mods } else env
 
-let is_signal_lid = function
-  | Longident.Lident "Signal" -> true
-  | Longident.Ldot (_, "Signal") -> true
+let is_read_lid = function
+  | Longident.Lident name -> is_read_module_name name
+  | Longident.Ldot (_, name) -> is_read_module_name name
   | _ -> false
 
 let collect_open (env : env) (lid : Longident.t) : env =
-  if is_signal_lid lid then { env with open_signal = true } else env
+  if is_read_lid lid then { env with open_signal = true } else env
 
 (* ---- JSX shape helpers -------------------------------------------------- *)
 let has_jsx (e : expression) : bool =
@@ -1181,6 +1200,100 @@ let is_value_component (f : expression) : bool =
   | Pexp_ident { txt = Longident.Ldot (Longident.Lident "View", ("Text" | "Int" | "Float" | "Bool")); _ } ->
     true
   | _ -> false
+
+(* Does this expression contain JSX anywhere? A value that builds nodes is not a
+   scalar leaf, so it is never probed for a hidden read (the JSX inside it is
+   decomposed on its own). *)
+let rec contains_jsx (e : expression) : bool =
+  jsx_parts e <> None || is_jsx_fragment e || List.exists contains_jsx (sub_exprs e)
+
+(* ---- hidden reads --------------------------------------------------------
+   Detection is syntactic, so a read behind a call the ppx cannot see the
+   definition of — `Store.waitingCount(store)` from another module, a read
+   pulled out of a data structure — looks exactly like a static value and
+   compiles to one. That was the single silent failure mode.
+
+   The ppx cannot resolve such a call, but it can *tell that one is there*: an
+   expression made only of constants, identifiers, field accesses, lambdas and
+   structural combinations of those provably calls nothing, and anything else
+   might. Leaves in the second group are wrapped in `View.probe`, which decides
+   at runtime — it evaluates the expression inside a throwaway computed and
+   warns, naming this source location, if the evaluation actually subscribed to
+   a signal. Inert leaves are emitted untouched, so the common cases (a literal,
+   a prop, `item.name`) cost nothing. *)
+
+(* A symbolic identifier (`>`, `++`, `===`) is a ReScript primitive operator, so
+   applying one is as inert as its arguments. *)
+let is_operator_name (s : string) : bool =
+  String.length s > 0
+  && (match s.[0] with 'a' .. 'z' | 'A' .. 'Z' | '_' -> false | _ -> true)
+
+(* Xote's and rescript-signals' own entry points never hide a tracked read: they
+   build nodes (`View.text`, `Html.div`) or reactive values that carry their own
+   subscription (`Computed.make`, `MaybeSignal.reactive`), and the one function
+   here that *is* a read — `Signal.get`/`MaybeSignal.get` — is recognised and
+   thunked before probing is ever considered. `Signal.peek` is untracked by
+   design. So a call into one of them is as inert as its arguments, and probing
+   it would only report node-shaped values nobody can act on. *)
+let is_library_module = function
+  | "View" | "Html" | "XoteJSX" | "Signal" | "Computed" | "Effect" | "MaybeSignal" | "Prop" ->
+    true
+  | _ -> false
+
+let is_library_call_path (lid : Longident.t) : bool =
+  match lid with
+  | Longident.Ldot (Longident.Lident m, _) | Longident.Ldot (Longident.Ldot (_, m), _) ->
+    is_library_module m
+  | _ -> false
+
+let rec is_inert (e : expression) : bool =
+  match e.pexp_desc with
+  | Pexp_constant _ | Pexp_ident _ | Pexp_fun _ | Pexp_function _ | Pexp_unreachable -> true
+  (* a thunk defers its body: whatever it reads, it reads reactively *)
+  | Pexp_construct ({ txt = Longident.Lident "Function$"; _ }, Some _) -> true
+  | Pexp_construct (_, eo) | Pexp_variant (_, eo) ->
+    (match eo with Some x -> is_inert x | None -> true)
+  | Pexp_field (x, _) | Pexp_constraint (x, _) | Pexp_coerce (x, _, _) | Pexp_lazy x -> is_inert x
+  | Pexp_tuple xs | Pexp_array xs -> List.for_all is_inert xs
+  | Pexp_record (fields, base) ->
+    List.for_all (fun (_, v) -> is_inert v) fields
+    && (match base with Some b -> is_inert b | None -> true)
+  | Pexp_ifthenelse (c, t, eo) ->
+    is_inert c && is_inert t && (match eo with Some x -> is_inert x | None -> true)
+  | Pexp_match (s, cases) ->
+    is_inert s
+    && List.for_all
+         (fun c ->
+           is_inert c.pc_rhs && match c.pc_guard with Some g -> is_inert g | None -> true)
+         cases
+  | Pexp_sequence (a, b) -> is_inert a && is_inert b
+  | Pexp_let (_, vbs, body) ->
+    List.for_all (fun vb -> is_inert vb.pvb_expr) vbs && is_inert body
+  | Pexp_open (_, _, x) -> is_inert x
+  | Pexp_apply ({ pexp_desc = Pexp_ident { txt = Longident.Lident op; _ }; _ }, args)
+    when is_operator_name op ->
+    List.for_all (fun (_, a) -> is_inert a) args
+  | Pexp_apply ({ pexp_desc = Pexp_ident { txt = lid; _ }; _ }, args)
+    when is_library_call_path lid ->
+    List.for_all (fun (_, a) -> is_inert a) args
+  | _ -> false
+
+(* The file being rewritten, used when an expression carries no location. *)
+let source_file = ref ""
+
+let site_of (loc : Location.t) : string =
+  let p = loc.Location.loc_start in
+  let file =
+    if p.Lexing.pos_fname = "" then !source_file else Filename.basename p.Lexing.pos_fname
+  in
+  let file = if file = "" then "@xote.component" else file in
+  if p.Lexing.pos_lnum <= 0 then file
+  else Printf.sprintf "%s:%d:%d" file p.Lexing.pos_lnum (p.Lexing.pos_cnum - p.Lexing.pos_bol + 1)
+
+let view_probe = Longident.Ldot (Longident.Lident "View", "probe")
+let str_const s = mkexp (Pexp_constant (Pconst_string (s, None)))
+let wrap_probe (e : expression) : expression =
+  apply (ident view_probe) [ str_const (site_of e.pexp_loc); thunk e ]
 
 (* ---- render callbacks ----------------------------------------------------
    A prop whose value is a *function returning JSX* — `render={item => <li>…}`
@@ -1229,6 +1342,17 @@ let is_children_label = function
   | Labelled "children" | Optional "children" -> true
   | _ -> false
 
+let label_name = function Labelled n | Optional n -> Some n | Nolabel -> None
+
+(* Labels that are never a reactive value leaf, so never worth probing: an event
+   handler is a callback, and `attrs` is the escape-hatch array whose entries
+   carry their own `View.attr`/`View.computedAttr` reactivity. *)
+let is_non_leaf_label (lbl : arg_label) : bool =
+  match label_name lbl with
+  | Some "attrs" -> true
+  | Some n -> String.length n > 2 && n.[0] = 'o' && n.[1] = 'n' && n.[2] >= 'A' && n.[2] <= 'Z'
+  | None -> false
+
 (* A value-position expression should be thunked iff it *eagerly* reads a signal
    and isn't already JSX. Using the eager check means values that are already
    reactive on their own — a `() => …` thunk, a `Computed`, a `Prop.reactive(…)`
@@ -1236,6 +1360,18 @@ let is_children_label = function
    @xote.component is a safe drop-in on components already written that way. *)
 let should_thunk (env : env) (v : expression) : bool =
   reads_signal_eager env v && jsx_parts v = None
+
+(* A value-position expression whose read status the ppx cannot decide: it is
+   not a visible read (that is already thunked), and it is not provably
+   call-free either. `View.probe` settles it at runtime. Node-shaped values are
+   excluded — they are decomposed, not read. *)
+let should_probe (env : env) (v : expression) : bool =
+  (not (should_thunk env v)) && (not (is_inert v)) && not (contains_jsx v)
+
+(* A value-position leaf: thunk a visible read, probe an unresolvable call,
+   leave everything else exactly as written. *)
+let leaf_value (env : env) (v : expression) : expression =
+  if should_thunk env v then thunk v else if should_probe env v then wrap_probe v else v
 
 (* `@xote.component` is the single annotation: it derives props exactly like
    `@jsx.component` (which we emit for the JSX transform to expand) *and*
@@ -1295,7 +1431,13 @@ let rec fine_node (env : env) (e : expression) : expression =
           a local) is ordinary UI code, so this path matters as much as the
           reactive one. *)
        let branches = decompose_branches env e in
-       if reads_signal_eager env e then wrap_tracked branches else branches
+       if reads_signal_eager env e then wrap_tracked branches
+       else
+         (* No visible read, so no `View.tracked`. If the condition/scrutinee is
+            not provably call-free, the structure may in fact depend on a signal
+            the ppx cannot see; probe it so that failure is reported instead of
+            silently rendering one frozen branch. *)
+         probe_condition env branches
      | Pexp_let (r, vbs, body) ->
        (* A block expression in node position — `{let x = …; <span/>}`. Recurse
           into the tail so the JSX inside keeps fine-grained leaves instead of
@@ -1327,7 +1469,7 @@ let rec fine_node (env : env) (e : expression) : expression =
           contains is node position too. So descend first (see
           decompose_node_shaped), then coerce the result. *)
        let e = decompose_node_shaped env e in
-       wrap_child (if should_thunk env e then thunk e else e))
+       wrap_child (leaf_value env e))
 
 (* Descend through a node-position expression that is not itself JSX, and
    decompose the node-shaped things inside it: JSX, and functions returning
@@ -1347,6 +1489,20 @@ and decompose_node_shaped (env : env) (e : expression) : expression =
       else decompose_node_shaped env sub)
     e
 
+(* Wrap the condition/scrutinee (and any `when` guards) of an *untracked*
+   control-flow child in `View.probe`. These drive the structural swap, so a
+   read hidden in one of them freezes the whole branch, not just one value. *)
+and probe_condition (env : env) (e : expression) : expression =
+  let p (v : expression) = if should_probe env v then wrap_probe v else v in
+  match e.pexp_desc with
+  | Pexp_ifthenelse (c, t, eo) -> { e with pexp_desc = Pexp_ifthenelse (p c, t, eo) }
+  | Pexp_match (s, cases) ->
+    { e with
+      pexp_desc =
+        Pexp_match
+          (p s, List.map (fun cs -> { cs with pc_guard = Option.map p cs.pc_guard }) cases) }
+  | _ -> e
+
 (* Recurse fine_node into the *node-position* bodies of control flow (the
    condition/scrutinee and any guards stay untouched — they are value position
    and should drive the structural swap). *)
@@ -1365,7 +1521,8 @@ and element_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * ex
     | Labelled _ | Optional _ ->
       (* attribute: value position. Thunk it if reactive so it lowers to a
          computed attribute; leave plain JSX/static/already-function values. *)
-      if should_thunk env v then (lbl, thunk v) else (lbl, v)
+      if is_non_leaf_label lbl then (lbl, if should_thunk env v then thunk v else v)
+      else (lbl, leaf_value env v)
     | Nolabel -> (lbl, v)
 
 and component_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expression =
@@ -1395,12 +1552,11 @@ and value_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * expr
   if is_children_label lbl then (lbl, map_children (value_leaf env) v)
   else
     match lbl with
-    | Labelled "value" -> (lbl, if should_thunk env v then thunk v else v)
+    | Labelled "value" -> (lbl, leaf_value env v)
     | _ -> (lbl, v)
 
 (* child of a value component (View.Text ...): value position -> thunk. *)
-and value_leaf (env : env) (v : expression) : expression =
-  if should_thunk env v then thunk v else v
+and value_leaf (env : env) (v : expression) : expression = leaf_value env v
 
 (* Map [f] over a JSX children list (a `::`/`[]` spine); tolerate a bare
    single child that is not wrapped in a list. *)
@@ -1543,8 +1699,24 @@ let rec map_structure (env : env) (s : structure) : structure =
 and update_env_si (env : env) si =
   match si.pstr_desc with
   | Pstr_value (_, vbs) -> collect_val_aliases env vbs
-  | Pstr_module mb -> collect_mod_alias env mb.pmb_name mb.pmb_expr
+  | Pstr_module mb ->
+    let env = collect_mod_alias env mb.pmb_name mb.pmb_expr in
+    collect_module_funcs env mb.pmb_name.Location.txt mb.pmb_expr
   | Pstr_open od -> collect_open env od.popen_lid.Location.txt
+  | _ -> env
+
+(* `module Store = { let count = s => Signal.get(s) }` in this file makes
+   `Store.count(s)` a read like any local helper. Walk the module body with the
+   surrounding environment (so it can use outer aliases), then qualify the
+   reactive names it introduced. Only same-file modules are reachable — a helper
+   imported from another file is what `View.probe` covers. *)
+and collect_module_funcs (env : env) (name : string) (me : module_expr) : env =
+  match me.pmod_desc with
+  | Pmod_structure s | Pmod_constraint ({ pmod_desc = Pmod_structure s; _ }, _) ->
+    let inner = List.fold_left update_env_si env s in
+    let added before after = List.filter (fun n -> not (List.mem n before)) after in
+    let names = added env.funcs inner.funcs @ added env.vals inner.vals in
+    { env with qfuncs = List.map (fun n -> name ^ "." ^ n) names @ env.qfuncs }
   | _ -> env
 
 and map_si (env : env) si =
@@ -1613,6 +1785,7 @@ let () =
   output_value oc name;
   (if magic = impl_magic then
      let structure = (Obj.magic payload : structure) in
+     source_file := Filename.basename name;
      fine_grain_helpers := structure_has_component structure;
      output_value oc (map_structure empty_env structure)
    else output_value oc payload);

--- a/src/View.res
+++ b/src/View.res
@@ -891,6 +891,113 @@ let rec child = (value: 'a): node => {
   }
 }
 
+/* ============================================================================
+ * Hidden signal reads (@xote.component)
+ * ============================================================================ */
+
+/* The ppx detects signal reads *syntactically*. A read it cannot see the
+   definition of — an imported helper (`Store.waitingCount(store)`), a read
+   pulled out of a data structure — is compiled as a plain value: the leaf is
+   evaluated once and never updates, and no error or warning is produced. Inside
+   an enclosing `tracked` block the same read silently widens that block's
+   dependencies, so one broadcast re-renders the whole region.
+
+   `probe` is what `@xote.component` emits around a leaf whose expression
+   contains a call it could not resolve. The first time that leaf is evaluated
+   it runs inside a throwaway computed, and what that computed subscribed to
+   settles the question:
+
+     - nothing subscribed: the leaf really is static. The computed is disposed
+       and the value returned, so `probe` is exactly the identity function.
+     - something subscribed: the read was hidden from the ppx. The value is read
+       back *through* the computed, so an enclosing tracked block subscribes
+       exactly as it would have without the probe (behaviour is unchanged), and
+       a one-time warning naming the source location tells the developer to
+       thunk it.
+
+   The warning is only emitted for a *scalar* result — the shape that silently
+   renders a stale number or class name. A reactive result (a signal, a thunk, a
+   `MaybeSignal`) is already handled by the runtime, and a node-shaped result is
+   built fresh by whatever renders it. */
+
+/* Does this computed subscribe to any signal? Reads `subs.firstDep` on the
+   `rescript-signals` computed. If the internal shape is not recognised, report
+   `false`: no warning and no behaviour change is the safe direction. */
+let hasDependencies: 'a => bool = %raw(`function (c) {
+  var subs = c == null ? null : c.subs
+  if (subs === null || typeof subs !== "object" || !("firstDep" in subs)) { return false }
+  return subs.firstDep != null
+}`)
+
+/* Probing costs one throwaway computed per unresolved leaf, so it is skipped in
+   production builds. `globalThis.__XOTE_DEV__` wins when set; otherwise
+   `process.env.NODE_ENV` (which bundlers inline) decides. When neither is
+   available the probe stays on: a silently stale UI is worse than an allocation. */
+let readDevFlag: unit => bool = %raw(`function () {
+  try {
+    if (typeof globalThis !== "undefined" && globalThis.__XOTE_DEV__ !== undefined) {
+      return !!globalThis.__XOTE_DEV__
+    }
+    if (typeof process !== "undefined" && process.env && process.env.NODE_ENV) {
+      return process.env.NODE_ENV !== "production"
+    }
+  } catch (_) {}
+  return true
+}`)
+
+let probeEnabled: ref<option<bool>> = ref(None)
+
+let isProbeEnabled = (): bool =>
+  switch probeEnabled.contents {
+  | Some(enabled) => enabled
+  | None => {
+      let enabled = readDevFlag()
+      probeEnabled := Some(enabled)
+      enabled
+    }
+  }
+
+let warnHiddenRead = (site: string): unit =>
+  Console.warn(
+    "[Xote] " ++
+    site ++
+    ": this value reads a signal through a call @xote.component cannot see " ++
+    "(a helper from another module, MaybeSignal.get, a read stored in a data structure), " ++
+    "so it compiled to a one-shot value that will never update — and inside a tracked " ++
+    "block it widens that block and re-renders it wholesale. Wrap it in a thunk " ++
+    "(`{() => ...}`) or inline the Signal.get. " ++
+    "See https://github.com/brnrdog/xote/blob/main/ppx/README.md#hidden-reads",
+  )
+
+/* Each site is probed once. The answer is a property of the source expression,
+   not of this render, so re-probing would only repeat the same finding — and
+   the leaked-read branch has to keep its computed alive to stay subscribed.
+   Every later evaluation of a probed leaf is therefore a plain call, and the
+   report is emitted once however often the component renders. */
+let probedSites: Dict.t<bool> = Dict.make()
+
+let probe = (site: string, compute: unit => 'a): 'a =>
+  if !isProbeEnabled() || probedSites->Dict.get(site)->Option.isSome {
+    compute()
+  } else {
+    probedSites->Dict.set(site, true)
+    let signal = Computed.make(compute)
+    if hasDependencies(signal) {
+      switch Signal.peek(signal)->Core.Type.Classify.classify {
+      | String(_) | Number(_) | Bool(_) => warnHiddenRead(site)
+      | _ => ()
+      }
+      /* Read back through the computed so an enclosing tracked block captures
+         the same dependencies it would have captured without the probe. The
+         computed is deliberately not disposed: it is what carries them. */
+      Signal.get(signal)
+    } else {
+      let value = Signal.peek(signal)
+      Computed.dispose(signal)
+      value
+    }
+  }
+
 module Text = {
   type props<'value, 'children> = {
     value?: 'value,

--- a/tests/Probe_test.res
+++ b/tests/Probe_test.res
@@ -1,0 +1,93 @@
+open! Zekr
+
+/* `View.probe` is what `@xote.component` emits around a leaf whose expression
+   contains a call the ppx cannot resolve. It has to be invisible when the leaf
+   really is static, and report the leaf — once — when the call turns out to
+   read a signal behind the ppx's back. */
+
+let mountTo = (node, container) => {
+  View.mount(node, container)
+  container
+}
+
+let captureWarnings: unit => unit = %raw(`function () {
+  globalThis.__probeWarnings = []
+  globalThis.__probeRealWarn = console.warn
+  console.warn = function (message) { globalThis.__probeWarnings.push(String(message)) }
+}`)
+
+let releaseWarnings: unit => array<string> = %raw(`function () {
+  console.warn = globalThis.__probeRealWarn
+  return globalThis.__probeWarnings
+}`)
+
+let mentions = (messages: array<string>, site: string) =>
+  messages->Array.some(message => message->String.includes(site))
+
+let suite = Zekr.suite(
+  "Probe",
+  [
+    test("returns the value untouched when nothing is read", () => {
+      captureWarnings()
+      let value = View.probe("Quiet.res:1:1", () => "static")
+      let warnings = releaseWarnings()
+      combineResults([assertEqual(value, "static"), assertEqual(Array.length(warnings), 0)])
+    }),
+    test("reports a scalar leaf that reads a signal through an opaque call", () => {
+      let count = Signal.make(4)
+      /* stands in for an imported helper: the ppx sees only the call */
+      let hidden = () => Signal.get(count)
+      captureWarnings()
+      let value = View.probe("Hidden.res:12:9", () => hidden())
+      let warnings = releaseWarnings()
+      combineResults([
+        assertEqual(value, 4),
+        assertTrue(mentions(warnings, "Hidden.res:12:9")),
+        assertTrue(mentions(warnings, "() => ...")),
+      ])
+    }),
+    test("reports each site once, however often it is evaluated", () => {
+      let count = Signal.make(1)
+      let hidden = () => Signal.get(count)
+      captureWarnings()
+      let _ = View.probe("Repeat.res:3:3", () => hidden())
+      let _ = View.probe("Repeat.res:3:3", () => hidden())
+      let _ = View.probe("Repeat.res:3:3", () => hidden())
+      let warnings = releaseWarnings()
+      assertEqual(
+        warnings->Array.filter(w => w->String.includes("Repeat.res:3:3"))->Array.length,
+        1,
+      )
+    }),
+    test("stays silent for a deliberate untracked peek", () => {
+      let count = Signal.make(7)
+      let peeked = () => Signal.peek(count)
+      captureWarnings()
+      let value = View.probe("Peek.res:5:5", () => peeked())
+      let warnings = releaseWarnings()
+      combineResults([assertEqual(value, 7), assertEqual(Array.length(warnings), 0)])
+    }),
+    test("stays silent for a value that is reactive on its own", () => {
+      let count = Signal.make(2)
+      captureWarnings()
+      let value = View.probe("Reactive.res:7:7", () => Computed.make(() => Signal.get(count) * 2))
+      let warnings = releaseWarnings()
+      combineResults([assertEqual(Signal.get(value), 4), assertEqual(Array.length(warnings), 0)])
+    }),
+    test("an enclosing tracked block still subscribes through the probe", () => {
+      let {container} = Dom.render("")
+      let label = Signal.make("a")
+      let hidden = () => Signal.get(label)
+      captureWarnings()
+      let _ = mountTo(
+        View.tracked(() => View.text(View.probe("Tracked.res:9:9", () => hidden()))),
+        container,
+      )
+      let r1 = Dom.Assert.toHaveTextContent(container, "a")
+      Signal.set(label, "b")
+      let r2 = Dom.Assert.toHaveTextContent(container, "b")
+      let warnings = releaseWarnings()
+      combineResults([r1, r2, assertTrue(mentions(warnings, "Tracked.res:9:9"))])
+    }),
+  ],
+)

--- a/tests/Tests.res
+++ b/tests/Tests.res
@@ -9,6 +9,7 @@ Zekr.runSuites([
   KeyedList_test.suite,
   Route_test.suite,
   PublicApi_test.suite,
+  Probe_test.suite,
   SSR_test.suite,
   SSRState_test.suite,
   Hydration_test.suite,


### PR DESCRIPTION
…'t see

`@xote.component` decides what to make reactive by reading the source, so a read it cannot follow compiled to a one-shot value with no error. Worse than a frozen leaf: inside a `tracked` block the hidden read was captured by *that* scope instead, quietly widening it, so one screen could look correct only because it was re-rendering wholesale while the screen next to it broke.

Two gaps are now closed outright:

- `MaybeSignal.get` / `Prop.get` are tracked reads like `Signal.get`, including through aliases, `open`, and qualified paths. Only `get` — `peek` stays the untracked read.
- a reactive helper reached through a module declared in the same file (`module Store = { let count = s => Signal.get(s) }` … `Store.count(s)`) is followed, alongside the local helpers already covered.

What remains — a call into another module — cannot be resolved by a syntactic, single-file rewriter, but its *presence* can be seen: an expression built only from constants, identifiers, field accesses, lambdas, operators and Xote's own constructors provably calls nothing. Leaves outside that set are emitted wrapped in `View.probe`, which settles it at runtime. The first evaluation runs inside a throwaway computed; if it subscribed to nothing the computed is disposed and the value returned unchanged, and if it did, the value is read back through the computed — so an enclosing tracked block keeps exactly the dependencies it had — and the site is reported once, with its source location and the fix.

The check is on what the evaluation really read, so there are no false positives: a deliberate `Signal.peek`, a `Computed`, and a call that reads nothing are all silent. Each site is probed once, and probing is skipped in production builds. In the docs site — 8 annotated files — this emits 10 probes and no warnings.

Untracked `if`/`switch` children are probed on their condition, scrutinee and `when` guards too: a read hidden there freezes the whole branch, not one value.

Docs at every level say the rule out loud, and `ppx/example/src/Store.res` is a second file so the e2e suite exercises a genuinely cross-module read.