### PR TITLE
fix(ppx): recognize namespaced value components and decompose JSX in container props

### DIFF
--- a/ppx/example/src/Demo.res
+++ b/ppx/example/src/Demo.res
@@ -486,3 +486,37 @@ module HelperHost = {
   @xote.component
   let make = () => <div id="helper-host"> {helperButton("Press")} </div>
 }
+
+/* Case 26: a fully-qualified value component — <Xote.View.Text>. A consumer
+   that does not `-open Xote` writes the namespaced path; the value-component
+   matcher must recognise it (not treat it as a user component, which would
+   coerce its child into a node and render "[object Object]"). */
+module QualifiedValue = {
+  @xote.component
+  let make = () =>
+    <div id="qualified-value">
+      <Xote.View.Text> {`n=${Signal.get(name)}`} </Xote.View.Text>
+      <Xote.View.Int value={Signal.get(count)} />
+    </div>
+}
+
+/* Case 27: JSX nested inside an array passed as a user-component prop. The prop
+   value is not itself JSX, but it *contains* JSX — its reactive leaves must
+   stay fine-grained and its bare children coerced (previously the array was
+   left untouched: the class was a one-shot read and a bare child was a compile
+   error). */
+module PropItemsHost = {
+  @xote.component
+  let make = (~items: array<View.node>) =>
+    <div id="prop-items-host"> {View.fragment(items)} </div>
+}
+
+module PropItemsUse = {
+  @xote.component
+  let make = () =>
+    <PropItemsHost
+      items=[
+        <li id="prop-item" class={Signal.get(theme)}> {Signal.get(name)} </li>,
+      ]
+    />
+}

--- a/ppx/example/verify.mjs
+++ b/ppx/example/verify.mjs
@@ -466,5 +466,35 @@ check('array literal inside View.fragment', ns.querySelector('#ns-arr').textCont
 check('pipe + map callback decomposed', ns.querySelectorAll('.ns-map').length === 2);
 check('local helper items rendered', ns.textContent.includes('one') && ns.textContent.includes('two'));
 
+// --- Regression: fully-qualified value component --------------------------
+// <Xote.View.Text>/<Xote.View.Int> must be treated as *value* components even
+// under the namespace, so their children/value are thunked, not coerced into a
+// node (which rendered "[object Object]").
+console.log('fully-qualified value components (<Xote.View.Text>/<Xote.View.Int>):');
+Signal.set(Demo.name, 'Ada');
+Signal.set(Demo.count, 0);
+const qv = mount(() => Demo.QualifiedValue.make({}));
+check('qualified text renders "n=Ada"', qv.textContent === 'n=Ada0');
+check('qualified int renders "0"', qv.textContent.includes('0'));
+Signal.set(Demo.name, 'Bo');
+Signal.set(Demo.count, 41);
+check('qualified text updates to "n=Bo"', document.querySelector('#qualified-value').textContent === 'n=Bo41');
+check('qualified int updates to "41"', document.querySelector('#qualified-value').textContent.includes('41'));
+
+// --- Regression: JSX nested in an array passed as a user-component prop -----
+console.log('JSX nested in an array prop (reactive leaves + bare child):');
+Signal.set(Demo.theme, 'light');
+Signal.set(Demo.name, 'Ada');
+const pitem = mount(() => Demo.PropItemsUse.make({}));
+const pitemLi = pitem.querySelector('#prop-item');
+pitemLi.__marker = 'PI';
+check('array-prop li renders bare child "Ada"', pitemLi.textContent === 'Ada');
+check('array-prop li class is "light"', pitemLi.className === 'light');
+Signal.set(Demo.name, 'Cy');
+Signal.set(Demo.theme, 'dark');
+check('array-prop bare child updates to "Cy"', document.querySelector('#prop-item').textContent === 'Cy');
+check('array-prop class updates to "dark"', document.querySelector('#prop-item').className === 'dark');
+check('array-prop li kept identity', document.querySelector('#prop-item').__marker === 'PI');
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/ppx/ppx.ml
+++ b/ppx/ppx.ml
@@ -1175,11 +1175,19 @@ let is_element (f : expression) : bool =
     String.length s > 0 && s.[0] >= 'a' && s.[0] <= 'z'
   | _ -> false
 
-(* View.Text / View.Int / View.Float / View.Bool: children are *values*. *)
+(* View.Text / View.Int / View.Float / View.Bool: children are *values*. Also
+   match the namespaced form (Xote.View.Text) — a consumer that does not
+   `-open Xote` writes the full path, and the matcher must not mistake it for a
+   user component (whose children would be coerced to nodes). *)
 let is_value_component (f : expression) : bool =
+  let is_view = function
+    | Longident.Lident "View" -> true
+    | Longident.Ldot (_, "View") -> true
+    | _ -> false
+  in
   match f.pexp_desc with
-  | Pexp_ident { txt = Longident.Ldot (Longident.Lident "View", ("Text" | "Int" | "Float" | "Bool")); _ } ->
-    true
+  | Pexp_ident { txt = Longident.Ldot (m, ("Text" | "Int" | "Float" | "Bool")); _ } ->
+    is_view m
   | _ -> false
 
 (* ---- render callbacks ----------------------------------------------------
@@ -1379,7 +1387,12 @@ and component_arg (env : env) ((lbl, v) : arg_label * expression) : arg_label * 
   if is_children_label lbl then (lbl, map_children (fine_node env) v)
   else if jsx_parts v <> None || is_jsx_fragment v then (lbl, fine_node env v)
   else if is_render_callback v then (lbl, fine_callback env v)
-  else (lbl, v)
+  (* A prop value that is not itself JSX can still *contain* JSX — an array,
+     tuple, record or application of markup (`items=[<li/>]`). Walk it like
+     node-position children so its reactive leaves stay fine-grained and its
+     bare children are coerced. Scalar props (a signal read, a plain value) are
+     rebuilt unchanged, so the deliberate one-shot-read semantics hold. *)
+  else (lbl, decompose_node_shaped env v)
 
 (* Decompose the body of a render callback, walking past its parameters (and
    the uncurried `Function$` wrapper) to the node-position body. *)


### PR DESCRIPTION
## Problem

Two reactivity bugs in the `@xote.component` PPX (both reproduced on `v7.1.0-beta.8`):

1. **Fully-qualified value components are broken.** `is_value_component` only matched
   `View.Text/Int/Float/Bool`; a consumer without `-open Xote` writing
   `<Xote.View.Text>` was treated as a user component, so its child was coerced into a
   node and rendered `"[object Object]"` instead of reactive text.
   `<Xote.View.Int value={Signal.get(x)} />` was similarly a one-shot read.

2. **JSX nested in a container passed as a user-component prop was not decomposed.**
   `component_arg` only descended into direct JSX, fragments, and render callbacks.
   JSX inside an array/tuple/record/application prop (`items=[<li/>]`) was left
   untouched: a reactive `class={Signal.get(theme)}` became a silent one-shot read, and
   a bare `{Signal.get(name)}` child was a compile error (`This has type: string`).

## Fix

- `is_value_component` now matches any path ending in `View` (consistent with how
  `Signal.get` is already matched), so namespaced value primitives get their
  children/value thunked.
- `component_arg` now walks non-JSX prop values through `decompose_node_shaped`,
  decomposing any JSX they contain. Scalar one-shot props are rebuilt unchanged,
  preserving the documented one-shot semantics.

## Tests

Added regression cases to `ppx/example/src/Demo.res` (cases 26–27) and 9 assertions to
`ppx/example/verify.mjs`. Full suite: **136 passed, 0 failed** (127 existing + 9 new).