### PR TITLE
ci: add the rc release-candidate channel

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,8 +6,10 @@ Releases are automated with [semantic-release](https://semantic-release.gitbook.
 | --- | --- | --- | --- |
 | Stable | `main` | `latest` | `npm install xote` |
 | Beta | `beta` | `beta` | `npm install xote@beta` |
+| Release candidate | `rc` | `rc` | `npm install xote@rc` |
 
 - **Stable:** run the workflow on `main` → publishes the next version (e.g. `6.5.0`) under `latest`.
 - **Beta (testing):** run the workflow on `beta` → publishes a pre-release (e.g. `6.5.0-beta.1`) under the `beta` dist-tag. This never moves `latest`, so only `npm install xote@beta` picks it up.
+- **Release candidate (shipping soon):** run the workflow on `rc` → publishes a pre-release (e.g. `6.5.0-rc.1`) under the `rc` dist-tag. Same mechanics as beta and equally invisible to `latest`; the difference is intent — `rc` carries what is expected to ship, so it is branched from `main` and kept close to it.
 
-When a beta is ready to ship, merge `beta` into `main` and run the workflow on `main` to cut the stable release.
+When a pre-release is ready to ship, merge its branch into `main` and run the workflow on `main` to cut the stable release. A typical path is `beta` → `rc` → `main`, but neither pre-release channel is a required stop.

--- a/package.json
+++ b/package.json
@@ -120,6 +120,10 @@
       {
         "name": "beta",
         "prerelease": true
+      },
+      {
+        "name": "rc",
+        "prerelease": true
       }
     ],
     "plugins": [


### PR DESCRIPTION
An `rc` prerelease branch alongside `beta`, with the same mechanics: versions like 6.5.0-rc.1 published under the `rc` dist-tag, never moving `latest`. The Release workflow needs no change — it is workflow_dispatch and acts on whichever branch it runs from.